### PR TITLE
feat(runtime): Tier 1 runtime handoff improvements

### DIFF
--- a/internal/adapters/adapters.go
+++ b/internal/adapters/adapters.go
@@ -283,10 +283,15 @@ func redactMatch(match string) string {
 // When live steering is unavailable, adapters restart the runtime with a prompt
 // that carries the goal, prior task summary (if any), the fact index, and any
 // pending steering directive. This is the mechanical handoff path.
+// MaxResumeFindings limits how many findings are injected into a resume prompt.
+const MaxResumeFindings = 10
+
 type ResumeRequest struct {
 	Goal              string
 	TaskSummary       string
 	FactIndex         []string
+	FindingIndex      []string
+	ProgressFacts     []string
 	SteeringDirective string
 }
 
@@ -314,6 +319,26 @@ func BuildResumePrompt(req ResumeRequest) string {
 		for _, fact := range req.FactIndex {
 			b.WriteString("- ")
 			b.WriteString(fact)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if len(req.FindingIndex) > 0 {
+		b.WriteString("Current findings:\n")
+		for _, finding := range req.FindingIndex {
+			b.WriteString("- ")
+			b.WriteString(finding)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if len(req.ProgressFacts) > 0 {
+		b.WriteString("Progress state:\n")
+		for _, progress := range req.ProgressFacts {
+			b.WriteString("- ")
+			b.WriteString(progress)
 			b.WriteString("\n")
 		}
 		b.WriteString("\n")

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -345,3 +345,31 @@ func TestBuildResumePromptWorksWithoutTaskSummary(t *testing.T) {
 		t.Fatalf("expected mechanical handoff marker when no summary, got %q", prompt)
 	}
 }
+
+func TestBuildResumePromptIncludesFindingsAndProgressFacts(t *testing.T) {
+	prompt := adapters.BuildResumePrompt(adapters.ResumeRequest{
+		Goal: "solve challenges",
+		FactIndex: []string{
+			"recon:api — mapped REST endpoints",
+		},
+		FindingIndex: []string{
+			"sqli-login: SQL injection in login (unconfirmed)",
+		},
+		ProgressFacts: []string{
+			"progress:juice-shop:\n{\"solved\":53,\"total\":112}",
+		},
+	})
+
+	if !strings.Contains(prompt, "Current findings:") {
+		t.Fatalf("expected findings section, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "sqli-login") {
+		t.Fatalf("expected finding in resume prompt, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "Progress state:") {
+		t.Fatalf("expected progress section, got %q", prompt)
+	}
+	if !strings.Contains(prompt, `"solved":53`) {
+		t.Fatalf("expected progress body in resume prompt, got %q", prompt)
+	}
+}

--- a/internal/daemon/mcp_test.go
+++ b/internal/daemon/mcp_test.go
@@ -81,6 +81,7 @@ func TestMCPEndpointInitializesAndListsTools(t *testing.T) {
 		"generate_report",
 		"request_approval",
 		"request_scope_expansion",
+		"submit_task_summary",
 	} {
 		if !bytes.Contains([]byte(body), []byte(tool)) {
 			t.Fatalf("tools/list missing %q in %s", tool, body)

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -110,7 +110,7 @@ func (server *Server) handleCreateTask(response http.ResponseWriter, request *ht
 
 	server.recordLoopbackRewriteEvent(created)
 
-	server.launchTaskInBackground(created, adapter)
+	server.launchTaskInBackground(created, adapter, created.Goal)
 
 	if _, err := server.approvals.RecordAudit(approval.AuditEntry{
 		ProjectID: projectID,
@@ -137,12 +137,12 @@ func (server *Server) handleCreateTask(response http.ResponseWriter, request *ht
 	writeJSON(response, http.StatusCreated, launched)
 }
 
-func (server *Server) launchTaskInBackground(created task.Task, adapter runtime.Adapter) {
+func (server *Server) launchTaskInBackground(created task.Task, adapter runtime.Adapter, goal string) {
 	server.logTask(created, "launched", "")
 	go func() {
 		err := server.harness.Launch(context.Background(), runtime.LaunchRequest{
 			TaskID:  created.ID,
-			Goal:    created.Goal,
+			Goal:    goal,
 			Adapter: adapter,
 		})
 		switch {
@@ -518,8 +518,31 @@ func (server *Server) handleResumeTask(response http.ResponseWriter, request *ht
 		return
 	}
 	factLines := make([]string, 0, len(factIndex))
+	progressFacts := make([]string, 0)
 	for _, entry := range factIndex {
 		factLines = append(factLines, entry.FactKey+": "+entry.Summary)
+		if !strings.HasPrefix(entry.FactKey, "progress:") {
+			continue
+		}
+		fact, err := server.facts.GetFact(projectID, entry.FactKey)
+		if err != nil || strings.TrimSpace(fact.Body) == "" {
+			continue
+		}
+		progressFacts = append(progressFacts, entry.FactKey+":\n"+fact.Body)
+	}
+
+	findings, err := server.facts.ListFindings(projectID)
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, "load findings")
+		return
+	}
+	findingLines := make([]string, 0, len(findings))
+	start := 0
+	if len(findings) > adapters.MaxResumeFindings {
+		start = len(findings) - adapters.MaxResumeFindings
+	}
+	for _, finding := range findings[start:] {
+		findingLines = append(findingLines, finding.FindingKey+": "+finding.Title+" ("+string(finding.Status)+")")
 	}
 
 	taskSummary := ""
@@ -552,6 +575,8 @@ func (server *Server) handleResumeTask(response http.ResponseWriter, request *ht
 		Goal:              found.Goal,
 		TaskSummary:       taskSummary,
 		FactIndex:         factLines,
+		FindingIndex:      findingLines,
+		ProgressFacts:     progressFacts,
 		SteeringDirective: steeringDirective,
 	})
 
@@ -565,7 +590,7 @@ func (server *Server) handleResumeTask(response http.ResponseWriter, request *ht
 		return
 	}
 
-	server.launchTaskInBackground(found, adapter)
+	server.launchTaskInBackground(found, adapter, resumeGoal)
 
 	if _, err := server.approvals.RecordAudit(approval.AuditEntry{
 		ProjectID: projectID,

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -795,6 +795,60 @@ func TestCreateTaskOmitsRewriteEventWhenGoalHasNoLoopback(t *testing.T) {
 	}
 }
 
+func TestResumeTaskEnrichesPromptWithFindingsAndProgressFacts(t *testing.T) {
+	server := newDaemon(t)
+	projectID := createProject(t, server, `{"name":"Acme","scope":{"domains":["example.com"]}}`)
+	profileID := createRuntimeProfile(t, server, `{"name":"Fake","provider":"fake"}`)
+	taskID := createTask(t, server, projectID, `{
+		"goal":"enumerate example.com",
+		"runtime_profile_id":`+quoteJSON(profileID)+`,
+		"runner":"sandbox"
+	}`)
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
+
+	upsertFact(t, server, projectID, "progress:juice-shop", `{
+		"summary":"53 of 112 challenges solved",
+		"body":"{\"solved\":53,\"total\":112}"
+	}`)
+	upsertFinding(t, server, projectID, "sqli-login", `{
+		"title":"SQL injection in login",
+		"status":"unconfirmed"
+	}`)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume", nil)
+	server.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("expected resume status 202, got %d with body %s", resp.Code, resp.Body.String())
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var sawEnrichedGoal bool
+	for time.Now().Before(deadline) {
+		events := getTaskEvents(t, server, projectID, taskID)
+		for _, event := range events {
+			if event["kind"] != "runtime_output" {
+				continue
+			}
+			payload := event["payload"].(map[string]any)
+			goal, _ := payload["goal"].(string)
+			if strings.Contains(goal, "sqli-login") &&
+				strings.Contains(goal, "Current findings:") &&
+				strings.Contains(goal, `"solved":53`) {
+				sawEnrichedGoal = true
+				break
+			}
+		}
+		if sawEnrichedGoal {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !sawEnrichedGoal {
+		t.Fatalf("expected resumed runtime to receive enriched handoff prompt")
+	}
+}
+
 func putTaskSummary(t *testing.T, server interface {
 	ServeHTTP(http.ResponseWriter, *http.Request)
 }, projectID, taskID, body string) {

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -241,6 +242,36 @@ func New(deps Deps) *sdkmcp.Server {
 	})
 
 	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "submit_task_summary",
+		Description: "Submit a task summary before ending a continuation so the next resume carries compact handoff context.",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, args submitTaskSummaryArgs) (*sdkmcp.CallToolResult, any, error) {
+		_ = ctx
+		_ = req
+		if deps.Tasks == nil {
+			return toolError(fmt.Errorf("task service unavailable"))
+		}
+		if _, err := deps.Projects.Get(args.ProjectID); err != nil {
+			return toolError(err)
+		}
+		found, err := deps.Tasks.Get(args.TaskID)
+		if err != nil {
+			return toolError(err)
+		}
+		if found.ProjectID != args.ProjectID {
+			return toolError(fmt.Errorf("task not found"))
+		}
+		submittedBy := strings.TrimSpace(args.SubmittedBy)
+		if submittedBy == "" {
+			submittedBy = "runtime"
+		}
+		version, err := deps.Tasks.PutSummary(args.TaskID, args.Summary, submittedBy)
+		if err != nil {
+			return toolError(err)
+		}
+		return toolJSON(version)
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
 		Name:        "request_scope_expansion",
 		Description: "Request approval to expand project scope with a newly discovered asset or permission.",
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, args requestApprovalArgs) (*sdkmcp.CallToolResult, any, error) {
@@ -327,6 +358,13 @@ type attachEvidenceArgs struct {
 type generateReportArgs struct {
 	ProjectID string `json:"project_id" jsonschema:"project id"`
 	TaskID    string `json:"task_id,omitempty" jsonschema:"task id for runner and scope context"`
+}
+
+type submitTaskSummaryArgs struct {
+	ProjectID   string `json:"project_id" jsonschema:"project id"`
+	TaskID      string `json:"task_id" jsonschema:"task id"`
+	Summary     string `json:"summary" jsonschema:"compact handoff summary for the next continuation"`
+	SubmittedBy string `json:"submitted_by,omitempty" jsonschema:"runtime identifier"`
 }
 
 type requestApprovalArgs struct {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -223,3 +223,45 @@ func TestMCPApprovalRequestsPersistPendingRecords(t *testing.T) {
 		t.Fatalf("expected scope expansion kind, got %#v", got)
 	}
 }
+
+func TestMCPSubmitTaskSummaryWritesEquivalentState(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	projects := project.NewService(db)
+	tasks := task.NewService(db, projects)
+	proj, err := projects.Create("Acme", "", project.Scope{}, project.Defaults{})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	launched, err := tasks.Create(task.CreateRequest{
+		ProjectID: proj.ID,
+		Goal:      "enumerate example.com",
+		Runner:    task.RunnerSandbox,
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	session := connectMCP(t, mcpserver.Deps{Projects: projects, Tasks: tasks})
+	body := callTool(t, session, "submit_task_summary", map[string]any{
+		"project_id":   proj.ID,
+		"task_id":      launched.ID,
+		"summary":      "Mapped APIs and solved 10 easy challenges.",
+		"submitted_by": "claude_code",
+	})
+	if !strings.Contains(body, `"version":1`) {
+		t.Fatalf("expected versioned summary response, got %s", body)
+	}
+
+	versions, err := tasks.SummaryVersions(launched.ID)
+	if err != nil {
+		t.Fatalf("list summary versions: %v", err)
+	}
+	if len(versions) != 1 || versions[0].Summary != "Mapped APIs and solved 10 easy challenges." {
+		t.Fatalf("unexpected stored summary: %#v", versions)
+	}
+}

--- a/internal/runner/mcp.go
+++ b/internal/runner/mcp.go
@@ -155,6 +155,13 @@ func writeRuntimeSmokeInstructions(workdir string, ctx TaskContext) error {
 		fmt.Fprintf(&b, "- mcp_url: `%s`\n", ctx.MCPURL)
 	}
 	b.WriteString("\nRead `.pentest/context.json` or env vars `PENTEST_PROJECT_ID`, `PENTEST_TASK_ID`, `PENTEST_MCP_URL` if needed.\n")
+	b.WriteString("\n## Required workflow\n\n")
+	b.WriteString("Use trusted MCP on every blackboard write. Do not rely on chat alone.\n\n")
+	b.WriteString("1. After each recon phase, upsert durable facts with `upsert_project_fact` (API maps, endpoints, credentials found, progress snapshots under `progress:*` keys).\n")
+	b.WriteString("2. When you confirm or strongly suspect a vulnerability, record it with `record_vulnerability` (start `unconfirmed`, move to `confirmed` once proof is solid).\n")
+	b.WriteString("3. Attach proof with `attach_evidence` when you have HTTP captures, screenshots, or command output worth keeping.\n")
+	b.WriteString("4. Before ending a continuation, call `submit_task_summary` with what you accomplished, what remains, and the next focus.\n")
+	b.WriteString("5. For black-box web targets, discover APIs with `curl`/httpx first (including frontend bundles); use `agent-browser` when you need DOM, cookies, or interactive flows.\n")
 	b.WriteString("\n## Authorized scope\n\n")
 	b.WriteString("Read `.pentest/scope.json` for the task scope snapshot captured at launch. ")
 	b.WriteString("Stay within listed domains, URLs, IPs, ports, exclusions, and testing limits. ")

--- a/internal/runner/projection_mcp_test.go
+++ b/internal/runner/projection_mcp_test.go
@@ -301,6 +301,14 @@ func TestAGENTSMDDocumentsLoopbackRewriteInSandbox(t *testing.T) {
 	if !strings.Contains(string(agents), "`.claude/skills/`") {
 		t.Fatalf("expected sandbox AGENTS.md to document claude skills path, got:\n%s", agents)
 	}
+	if !strings.Contains(string(agents), "## Required workflow") {
+		t.Fatalf("expected AGENTS.md to document required workflow, got:\n%s", agents)
+	}
+	if !strings.Contains(string(agents), "upsert_project_fact") ||
+		!strings.Contains(string(agents), "record_vulnerability") ||
+		!strings.Contains(string(agents), "submit_task_summary") {
+		t.Fatalf("expected AGENTS.md to document MCP workflow tools, got:\n%s", agents)
+	}
 }
 
 func TestAGENTSMDOmitsLoopbackRewriteForHostRunner(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements Tier 1 improvements to boost runtime problem-solving effectiveness and resume quality:

1. **AGENTS.md workflow contract** — projected task instructions now mandate trusted MCP writes (`upsert_project_fact`, `record_vulnerability`, `attach_evidence`, `submit_task_summary`) and curl-first black-box web recon.
2. **`submit_task_summary` MCP tool** — runtimes can submit a handoff summary before ending a continuation (equivalent to HTTP `PUT .../summary`).
3. **Rich mechanical handoff** — resume prompts now include findings index and full bodies for `progress:*` facts.
4. **Resume bugfix** — harness now receives the built resume prompt instead of the original task goal (findings/progress were previously dropped).

## Test plan

- [x] `go test ./internal/adapters/... ./internal/mcpserver/... ./internal/runner/... ./internal/daemon/...`
- [x] New tests: AGENTS workflow, MCP submit_task_summary, BuildResumePrompt findings/progress, resume integration