### PR TITLE
feat(web): Multica-style agent timeline UI

### DIFF
--- a/internal/daemon/logging.go
+++ b/internal/daemon/logging.go
@@ -14,6 +14,7 @@ import (
 var noisyPollPaths = []string{
 	"/events",
 	"/transcript",
+	"/timeline",
 }
 
 // isNoisyPoll reports whether a successful GET is a UI poll endpoint whose

--- a/internal/daemon/logging_test.go
+++ b/internal/daemon/logging_test.go
@@ -136,13 +136,13 @@ func TestRequestLogSuppressesNoisyPolls(t *testing.T) {
 	}`)
 	captured.Reset()
 
-	for _, suffix := range []string{"", "/events", "/transcript"} {
+	for _, suffix := range []string{"", "/events", "/transcript", "/timeline"} {
 		req := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID+"/tasks/"+taskID+suffix, nil)
 		server.ServeHTTP(httptest.NewRecorder(), req)
 	}
 
 	output := captured.String()
-	if strings.Contains(output, "/events") || strings.Contains(output, "/transcript") {
+	if strings.Contains(output, "/events") || strings.Contains(output, "/transcript") || strings.Contains(output, "/timeline") {
 		t.Fatalf("poll endpoints should not be logged, got:\n%s", output)
 	}
 	if strings.Contains(output, "/tasks/"+taskID+" ") {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -291,6 +291,7 @@ func (server *Server) routes() {
 	server.mux.HandleFunc("GET /api/projects/{id}/tasks/{task_id}", server.handleGetTask)
 	server.mux.HandleFunc("GET /api/projects/{id}/tasks/{task_id}/events", server.handleTaskEvents)
 	server.mux.HandleFunc("GET /api/projects/{id}/tasks/{task_id}/transcript", server.handleTaskTranscript)
+	server.mux.HandleFunc("GET /api/projects/{id}/tasks/{task_id}/timeline", server.handleTaskTimeline)
 	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/stop", server.handleStopTask)
 	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/resume", server.handleResumeTask)
 	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/steer", server.handleSteerTask)

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -20,6 +20,7 @@ import (
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeprofile"
 	"pentest/internal/task"
+	"pentest/internal/timeline"
 	"pentest/internal/transcript"
 )
 
@@ -430,6 +431,30 @@ func (server *Server) handleTaskEvents(response http.ResponseWriter, request *ht
 		Events []task.Event `json:"events"`
 	}{
 		Events: events,
+	})
+}
+
+func (server *Server) handleTaskTimeline(response http.ResponseWriter, request *http.Request) {
+	found, ok := server.requireProjectTask(response, request)
+	if !ok {
+		return
+	}
+
+	events, err := server.tasks.Events(found.ID)
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, "list task events")
+		return
+	}
+	items := timeline.Build(events)
+	if items == nil {
+		items = []timeline.Item{}
+	}
+	writeJSON(response, http.StatusOK, struct {
+		TaskID string          `json:"task_id"`
+		Items  []timeline.Item `json:"items"`
+	}{
+		TaskID: found.ID,
+		Items:  items,
 	})
 }
 

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -1,0 +1,388 @@
+// Package timeline projects retained task events into a multica-style agent
+// transcript timeline: thinking, tool calls, tool results, agent text, and errors.
+package timeline
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"pentest/internal/task"
+	"pentest/internal/transcript"
+)
+
+// Item is one chronologically ordered timeline entry.
+type Item struct {
+	Seq       int            `json:"seq"`
+	Type      string         `json:"type"`
+	Tool      string         `json:"tool,omitempty"`
+	Content   string         `json:"content,omitempty"`
+	Input     map[string]any `json:"input,omitempty"`
+	Output    string         `json:"output,omitempty"`
+	CreatedAt time.Time      `json:"created_at"`
+}
+
+// Build projects task events into coalesced timeline items.
+func Build(events []task.Event) []Item {
+	items := make([]Item, 0, len(events))
+	nextSeq := 1
+	for _, event := range events {
+		if event.Kind == task.EventKindLifecycle {
+			continue
+		}
+		if event.Kind != task.EventKindRuntimeOutput {
+			continue
+		}
+		text := stringValue(event.Payload, "text")
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		if isIgnorableTimelineLine(text) {
+			continue
+		}
+		parsed := itemsForRuntimeLine(text, event)
+		for _, item := range parsed {
+			item.Seq = nextSeq
+			nextSeq++
+			items = append(items, item)
+		}
+	}
+	return coalesceItems(items)
+}
+
+func itemsForRuntimeLine(text string, event task.Event) []Item {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(trimmed, "{") {
+		return []Item{{
+			Type:      "text",
+			Content:   trimmed,
+			CreatedAt: event.CreatedAt,
+		}}
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &record); err != nil {
+		return []Item{{
+			Type:      "text",
+			Content:   trimmed,
+			CreatedAt: event.CreatedAt,
+		}}
+	}
+
+	if items := parseRecord(record, event.CreatedAt); len(items) > 0 {
+		return items
+	}
+
+	return []Item{{
+		Type:      "text",
+		Content:   trimmed,
+		CreatedAt: event.CreatedAt,
+	}}
+}
+
+func parseRecord(record map[string]any, createdAt time.Time) []Item {
+	if item, ok := mapValue(record, "item"); ok {
+		if items := parseRecord(item, createdAt); len(items) > 0 {
+			return items
+		}
+	}
+	if delta, ok := mapValue(record, "delta"); ok {
+		if text := firstText(delta, "text", "content"); text != "" {
+			return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
+		}
+	}
+
+	recordType := stringValue(record, "type")
+	switch recordType {
+	case "system":
+		return nil
+	case "assistant", "user", "message", "assistant_message", "agent_message", "response.output_text", "output_text", "message_delta", "content_block_delta":
+		return parseMessageRecord(record, createdAt)
+	case "tool_call", "function_call", "tool_use":
+		return []Item{toolUseItem(record, createdAt)}
+	case "tool_result", "function_call_output":
+		return []Item{toolResultItem(record, createdAt)}
+	case "result":
+		if isTruthy(record["is_error"]) {
+			content := firstText(record, "error", "message", "content")
+			if content == "" {
+				content = stringValue(record, "subtype")
+			}
+			return []Item{{Type: "error", Content: content, CreatedAt: createdAt}}
+		}
+		return nil
+	case "error":
+		return []Item{{Type: "error", Content: firstText(record, "error", "message", "content", "text"), CreatedAt: createdAt}}
+	default:
+		if recordType == "" && stringValue(record, "role") != "" {
+			text := firstText(record, "text", "content", "message", "output")
+			if text == "" {
+				return nil
+			}
+			return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
+		}
+		return nil
+	}
+}
+
+func parseMessageRecord(record map[string]any, createdAt time.Time) []Item {
+	if message, ok := mapValue(record, "message"); ok {
+		if mr := stringValue(message, "role"); mr == "toolResult" || mr == "tool" {
+			if item := toolResultItem(message, createdAt); item.Output != "" || item.Tool != "" {
+				return []Item{item}
+			}
+		}
+		if content, ok := sliceValue(message, "content"); ok {
+			return parseContentBlocks(content, createdAt)
+		}
+		if text := firstText(message, "text", "content", "message"); text != "" {
+			return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
+		}
+	}
+	if content, ok := sliceValue(record, "content"); ok {
+		return parseContentBlocks(content, createdAt)
+	}
+	if text := firstText(record, "text", "content", "message"); text != "" {
+		return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
+	}
+	return nil
+}
+
+func parseContentBlocks(content []any, createdAt time.Time) []Item {
+	items := make([]Item, 0, len(content))
+	for _, block := range content {
+		switch value := block.(type) {
+		case string:
+			if value != "" {
+				items = append(items, Item{Type: "text", Content: value, CreatedAt: createdAt})
+			}
+		case map[string]any:
+			blockType := strings.ToLower(stringValue(value, "type"))
+			switch blockType {
+			case "thinking":
+				if text := thinkingText(value); text != "" {
+					items = append(items, Item{Type: "thinking", Content: text, CreatedAt: createdAt})
+				}
+			case "text":
+				if text := firstText(value, "text", "content"); text != "" {
+					items = append(items, Item{Type: "text", Content: text, CreatedAt: createdAt})
+				}
+			case "tool_use", "tool_call", "toolcall", "function_call":
+				items = append(items, toolUseItem(value, createdAt))
+			case "tool_result", "toolresult", "function_call_output":
+				items = append(items, toolResultItem(value, createdAt))
+			default:
+				if text := firstText(value, "text", "content", "message", "output"); text != "" {
+					items = append(items, Item{Type: "text", Content: text, CreatedAt: createdAt})
+				}
+			}
+		}
+	}
+	return items
+}
+
+func toolUseItem(record map[string]any, createdAt time.Time) Item {
+	input := map[string]any{}
+	for _, key := range []string{"input", "arguments", "parameters"} {
+		if value, ok := record[key]; ok {
+			if typed, ok := value.(map[string]any); ok {
+				for k, v := range typed {
+					input[k] = v
+				}
+			}
+		}
+	}
+	return Item{
+		Type:      "tool_use",
+		Tool:      toolName(record),
+		Input:     nilIfEmpty(input),
+		CreatedAt: createdAt,
+	}
+}
+
+func toolResultItem(record map[string]any, createdAt time.Time) Item {
+	return Item{
+		Type:      "tool_result",
+		Tool:      firstText(record, "tool_name", "toolName", "name"),
+		Output:    firstText(record, "output", "content", "result", "text"),
+		CreatedAt: createdAt,
+	}
+}
+
+func thinkingText(record map[string]any) string {
+	if text := firstText(record, "thinking", "text", "content"); text != "" {
+		return text
+	}
+	return ""
+}
+
+func isIgnorableTimelineLine(text string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" || !strings.HasPrefix(text, "{") {
+		return false
+	}
+	var record map[string]any
+	if err := json.Unmarshal([]byte(text), &record); err != nil {
+		return false
+	}
+	if transcript.IsIgnorableRuntimeLine(text) && !isThinkingOnlyAssistantRecord(record) {
+		return true
+	}
+	recordType := stringValue(record, "type")
+	switch recordType {
+	case "ping", "keepalive":
+		return true
+	case "result":
+		return !isTruthy(record["is_error"])
+	}
+	return false
+}
+
+func isThinkingOnlyAssistantRecord(record map[string]any) bool {
+	if stringValue(record, "type") != "assistant" {
+		return false
+	}
+	message, ok := mapValue(record, "message")
+	if !ok {
+		return false
+	}
+	content, ok := sliceValue(message, "content")
+	if !ok || len(content) == 0 {
+		return false
+	}
+	for _, block := range content {
+		blockMap, ok := block.(map[string]any)
+		if !ok {
+			return false
+		}
+		blockType := strings.ToLower(stringValue(blockMap, "type"))
+		if blockType != "thinking" {
+			return false
+		}
+	}
+	return true
+}
+
+func coalesceItems(items []Item) []Item {
+	if len(items) == 0 {
+		return items
+	}
+	out := make([]Item, 0, len(items))
+	for _, item := range items {
+		if len(out) == 0 {
+			out = append(out, item)
+			continue
+		}
+		prev := out[len(out)-1]
+		if canMergeStreamingText(prev, item) {
+			out[len(out)-1] = Item{
+				Seq:       prev.Seq,
+				Type:      prev.Type,
+				Tool:      prev.Tool,
+				Content:   prev.Content + item.Content,
+				Input:     prev.Input,
+				Output:    prev.Output,
+				CreatedAt: item.CreatedAt,
+			}
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func canMergeStreamingText(prev, next Item) bool {
+	return (prev.Type == "thinking" || prev.Type == "text") && prev.Type == next.Type
+}
+
+func toolName(record map[string]any) string {
+	if name := firstText(record, "name", "tool_name"); name != "" {
+		return name
+	}
+	if function, ok := mapValue(record, "function"); ok {
+		return firstText(function, "name")
+	}
+	return ""
+}
+
+func stringValue(record map[string]any, key string) string {
+	value, ok := record[key]
+	if !ok {
+		return ""
+	}
+	text, _ := value.(string)
+	return text
+}
+
+func firstText(record map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := record[key]
+		if !ok {
+			continue
+		}
+		if text := valueToText(value); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func valueToText(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := valueToText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	case map[string]any:
+		if text := firstText(typed, "text", "content", "message", "output"); text != "" {
+			return text
+		}
+		return ""
+	case nil:
+		return ""
+	default:
+		return ""
+	}
+}
+
+func mapValue(record map[string]any, key string) (map[string]any, bool) {
+	value, ok := record[key]
+	if !ok {
+		return nil, false
+	}
+	typed, ok := value.(map[string]any)
+	return typed, ok
+}
+
+func sliceValue(record map[string]any, key string) ([]any, bool) {
+	value, ok := record[key]
+	if !ok {
+		return nil, false
+	}
+	typed, ok := value.([]any)
+	return typed, ok
+}
+
+func nilIfEmpty(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func isTruthy(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return typed == "true" || typed == "1"
+	default:
+		return false
+	}
+}

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -1,0 +1,100 @@
+package timeline_test
+
+import (
+	"testing"
+	"time"
+
+	"pentest/internal/task"
+	"pentest/internal/timeline"
+)
+
+func TestBuildParsesThinkingToolUseTextAndResult(t *testing.T) {
+	createdAt := time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC)
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindLifecycle, Payload: task.EventPayload{"phase": "started", "adapter": "claude_code"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"system","subtype":"init","session_id":"abc"}`}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan recon"}]}}`}, CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "ev-4", Seq: 4, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"curl example.com"}}]}}`}, CreatedAt: createdAt.Add(3 * time.Second)},
+		{ID: "ev-5", Seq: 5, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"200 OK"}]}}`}, CreatedAt: createdAt.Add(4 * time.Second)},
+		{ID: "ev-6", Seq: 6, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"text","text":"Done inspecting."}]}}`}, CreatedAt: createdAt.Add(5 * time.Second)},
+	}
+
+	got := timeline.Build(events)
+
+	requireItem(t, got, 0, "thinking", "", "plan recon")
+	requireItem(t, got, 1, "tool_use", "Bash", "")
+	if got[1].Input["command"] != "curl example.com" {
+		t.Fatalf("unexpected tool input: %#v", got[1].Input)
+	}
+	requireItem(t, got, 2, "tool_result", "", "200 OK")
+	requireItem(t, got, 3, "text", "", "Done inspecting.")
+}
+
+func TestBuildCoalescesAdjacentThinkingFragments(t *testing.T) {
+	createdAt := time.Now().UTC()
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"part one"}]}}`}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":" part two"}]}}`}, CreatedAt: createdAt.Add(time.Second)},
+	}
+
+	got := timeline.Build(events)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 coalesced thinking item, got %d: %#v", len(got), got)
+	}
+	if got[0].Type != "thinking" || got[0].Content != "part one part two" {
+		t.Fatalf("unexpected coalesced thinking: %#v", got[0])
+	}
+}
+
+func TestBuildDropsTaskProgressAndThinkingTokens(t *testing.T) {
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"system","subtype":"thinking_tokens","estimated_tokens":13}`}},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"system","subtype":"task_progress","description":"Exploit"}`}},
+		{ID: "ev-3", Seq: 3, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"text","text":"Visible."}]}}`}},
+	}
+
+	got := timeline.Build(events)
+
+	if len(got) != 1 || got[0].Type != "text" || got[0].Content != "Visible." {
+		t.Fatalf("expected only visible assistant text, got %#v", got)
+	}
+}
+
+func TestBuildParsesOpenAIToolCallFormat(t *testing.T) {
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"tool_call","id":"call-1","name":"curl","arguments":{"url":"http://127.0.0.1:3000"}}`}},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"tool_result","tool_call_id":"call-1","output":"OK"}`}},
+	}
+
+	got := timeline.Build(events)
+
+	requireItem(t, got, 0, "tool_use", "curl", "")
+	requireItem(t, got, 1, "tool_result", "", "OK")
+}
+
+func requireItem(t *testing.T, items []timeline.Item, index int, typ, tool, content string) {
+	t.Helper()
+	if index >= len(items) {
+		t.Fatalf("expected item at index %d, got %d items", index, len(items))
+	}
+	item := items[index]
+	if item.Type != typ {
+		t.Fatalf("items[%d].Type = %q, want %q", index, item.Type, typ)
+	}
+	if tool != "" && item.Tool != tool {
+		t.Fatalf("items[%d].Tool = %q, want %q", index, item.Tool, tool)
+	}
+	if content != "" {
+		switch typ {
+		case "tool_result":
+			if item.Output != content {
+				t.Fatalf("items[%d].Output = %q, want %q", index, item.Output, content)
+			}
+		default:
+			if item.Content != content {
+				t.Fatalf("items[%d].Content = %q, want %q", index, item.Content, content)
+			}
+		}
+	}
+}

--- a/web/src/components/task-transcript/AgentTranscriptView.tsx
+++ b/web/src/components/task-transcript/AgentTranscriptView.tsx
@@ -1,0 +1,520 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertCircle,
+  ArrowDownNarrowWide,
+  ArrowUpNarrowWide,
+  Bot,
+  Brain,
+  Check,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  Copy,
+  Filter,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Task } from "@/lib/api";
+import type { TimelineItem, TranscriptSortDirection } from "./types";
+import {
+  buildFilterOptions,
+  colorClasses,
+  formatDuration,
+  formatElapsedMs,
+  getEventColor,
+  getEventLabel,
+  getEventSummary,
+  itemFilterKey,
+} from "./timeline-utils";
+
+interface AgentTranscriptViewProps {
+  task: Task;
+  items: TimelineItem[];
+  profileName?: string;
+  isLive?: boolean;
+}
+
+export function AgentTranscriptView({ task, items, profileName, isLive = false }: AgentTranscriptViewProps) {
+  const [selectedSeq, setSelectedSeq] = useState<number | null>(null);
+  const [elapsed, setElapsed] = useState("");
+  const [copied, setCopied] = useState(false);
+  const [selectedTools, setSelectedTools] = useState<Set<string>>(new Set());
+  const [sortDirection, setSortDirection] = useState<TranscriptSortDirection>("chronological");
+  const [filterOpen, setFilterOpen] = useState(false);
+  const eventRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const filterRef = useRef<HTMLDivElement>(null);
+
+  const filterOptions = useMemo(() => buildFilterOptions(items), [items]);
+
+  const filteredItems = useMemo(() => {
+    if (selectedTools.size === 0) return items;
+    return items.filter((item) => selectedTools.has(itemFilterKey(item)));
+  }, [items, selectedTools]);
+
+  const displayItems = useMemo(
+    () => (sortDirection === "newest_first" ? [...filteredItems].reverse() : filteredItems),
+    [filteredItems, sortDirection],
+  );
+
+  useEffect(() => {
+    if (!isLive) return;
+    const startRef = task.created_at;
+    const update = () => setElapsed(formatElapsedMs(Date.now() - new Date(startRef).getTime()));
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  }, [isLive, task.created_at]);
+
+  useEffect(() => {
+    if (!filterOpen) return;
+    function handleClick(event: MouseEvent) {
+      if (filterRef.current && !filterRef.current.contains(event.target as Node)) {
+        setFilterOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [filterOpen]);
+
+  const handleSortDirectionChange = useCallback(
+    (dir: TranscriptSortDirection) => {
+      if (dir === sortDirection) return;
+      setSortDirection(dir);
+      scrollContainerRef.current?.scrollTo({ top: 0 });
+    },
+    [sortDirection],
+  );
+
+  const handleSegmentClick = useCallback((seq: number) => {
+    setSelectedSeq(seq);
+    eventRefs.current.get(seq)?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
+
+  const handleCopyAll = useCallback(() => {
+    const text = displayItems
+      .map((item) => `[${getEventLabel(item)}] ${getEventSummary(item)}`)
+      .join("\n");
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [displayItems]);
+
+  const toggleTool = useCallback((tool: string) => {
+    setSelectedTools((prev) => {
+      const next = new Set(prev);
+      if (next.has(tool)) next.delete(tool);
+      else next.add(tool);
+      return next;
+    });
+  }, []);
+
+  const clearFilters = useCallback(() => setSelectedTools(new Set()), []);
+
+  const duration =
+    task.updated_at && !isLive && task.status !== "running"
+      ? formatDuration(task.created_at, task.updated_at)
+      : isLive
+        ? elapsed
+        : null;
+
+  const toolCount = items.filter((item) => item.type === "tool_use").length;
+
+  const statusBadge = isLive ? (
+    <span className="inline-flex items-center gap-1 rounded-full bg-info/15 px-2 py-0.5 text-xs font-medium text-info">
+      <Loader2 className="h-3 w-3 animate-spin" />
+      Running
+    </span>
+  ) : task.status === "completed" ? (
+    <span className="inline-flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+      <CheckCircle2 className="h-3 w-3" />
+      Completed
+    </span>
+  ) : task.status === "failed" ? (
+    <span className="inline-flex items-center gap-1 rounded-full bg-destructive/15 px-2 py-0.5 text-xs font-medium text-destructive">
+      <XCircle className="h-3 w-3" />
+      Failed
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground capitalize">
+      {task.status}
+    </span>
+  );
+
+  return (
+    <div className="flex min-h-[32rem] flex-col overflow-hidden rounded-xl border border-border bg-card">
+      <div className="shrink-0 space-y-2 border-b px-4 py-3">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-info/10 text-info">
+              <Bot className="h-3.5 w-3.5" />
+            </div>
+            <span className="text-sm font-medium">{profileName ?? "Agent"}</span>
+          </div>
+          {statusBadge}
+          <div className="ml-auto flex items-center gap-1">
+            {items.length > 1 && (
+              <SortDirectionToggle value={sortDirection} onChange={handleSortDirectionChange} />
+            )}
+            {filterOptions.length > 0 && (
+              <div className="relative" ref={filterRef}>
+                <button
+                  type="button"
+                  onClick={() => setFilterOpen((open) => !open)}
+                  className={cn(
+                    "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+                    selectedTools.size > 0
+                      ? "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                  )}
+                >
+                  <Filter className="h-3 w-3" />
+                  Filter
+                  {selectedTools.size > 0 && (
+                    <span className="ml-0.5 rounded-full bg-blue-500/20 px-1.5 py-0 text-[10px] font-medium">
+                      {selectedTools.size}
+                    </span>
+                  )}
+                </button>
+                {filterOpen && (
+                  <div className="absolute right-0 z-20 mt-1 min-w-[10rem] rounded-md border bg-popover p-1 text-xs shadow-md">
+                    {filterOptions.map(([value, label]) => (
+                      <label key={value} className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 hover:bg-accent">
+                        <input
+                          type="checkbox"
+                          checked={selectedTools.has(value)}
+                          onChange={() => toggleTool(value)}
+                          className="rounded border-input"
+                        />
+                        {label}
+                      </label>
+                    ))}
+                    {selectedTools.size > 0 && (
+                      <button
+                        type="button"
+                        onClick={clearFilters}
+                        className="mt-1 w-full rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-accent"
+                      >
+                        Clear filters
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={handleCopyAll}
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+              {copied ? "Copied" : selectedTools.size > 0 ? "Copy filtered" : "Copy all"}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <MetadataChip>runner: {task.runner}</MetadataChip>
+          {profileName && <MetadataChip>{profileName}</MetadataChip>}
+          {duration && (
+            <MetadataChip icon={<Clock className="h-3 w-3" />}>
+              {duration}
+            </MetadataChip>
+          )}
+          {toolCount > 0 && <MetadataChip>{toolCount} tool calls</MetadataChip>}
+          <MetadataChip>
+            {selectedTools.size > 0
+              ? `${filteredItems.length} / ${items.length} events`
+              : `${items.length} events`}
+          </MetadataChip>
+          {task.created_at && (
+            <MetadataChip>
+              {new Date(task.created_at).toLocaleString(undefined, {
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </MetadataChip>
+          )}
+        </div>
+      </div>
+
+      {displayItems.length > 0 && (
+        <div className="shrink-0 border-b px-4 py-2.5">
+          <TimelineBar items={displayItems} selectedSeq={selectedSeq} onSegmentClick={handleSegmentClick} />
+        </div>
+      )}
+
+      <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
+        {displayItems.length === 0 ? (
+          <div className="flex h-full min-h-[12rem] items-center justify-center text-sm text-muted-foreground">
+            {isLive ? (
+              <div className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Waiting for events…
+              </div>
+            ) : (
+              "No timeline data"
+            )}
+          </div>
+        ) : (
+          <div className="divide-y">
+            {displayItems.map((item) => (
+              <TranscriptEventRow
+                key={item.seq}
+                ref={(el) => {
+                  if (el) eventRefs.current.set(item.seq, el);
+                  else eventRefs.current.delete(item.seq);
+                }}
+                item={item}
+                isSelected={selectedSeq === item.seq}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SortDirectionToggle({
+  value,
+  onChange,
+}: {
+  value: TranscriptSortDirection;
+  onChange: (dir: TranscriptSortDirection) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Sort direction"
+      className="inline-flex items-center rounded border bg-muted/40 p-0.5 text-xs"
+    >
+      <button
+        type="button"
+        aria-pressed={value === "chronological"}
+        title="Chronological"
+        onClick={() => onChange("chronological")}
+        className={cn(
+          "flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors",
+          value === "chronological"
+            ? "bg-background text-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <ArrowDownNarrowWide className="h-3 w-3" />
+        <span className="hidden sm:inline">Oldest</span>
+      </button>
+      <button
+        type="button"
+        aria-pressed={value === "newest_first"}
+        title="Newest first"
+        onClick={() => onChange("newest_first")}
+        className={cn(
+          "flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors",
+          value === "newest_first"
+            ? "bg-background text-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <ArrowUpNarrowWide className="h-3 w-3" />
+        <span className="hidden sm:inline">Newest</span>
+      </button>
+    </div>
+  );
+}
+
+function MetadataChip({ icon, children }: { icon?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground">
+      {icon}
+      {children}
+    </span>
+  );
+}
+
+function TimelineBar({
+  items,
+  selectedSeq,
+  onSegmentClick,
+}: {
+  items: TimelineItem[];
+  selectedSeq: number | null;
+  onSegmentClick: (seq: number) => void;
+}) {
+  const segments: { startIdx: number; endIdx: number; color: ReturnType<typeof getEventColor>; count: number }[] = [];
+  let currentColor: ReturnType<typeof getEventColor> | null = null;
+  let currentStart = 0;
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!;
+    const color = getEventColor(item);
+    if (color !== currentColor) {
+      if (currentColor !== null) {
+        segments.push({ startIdx: currentStart, endIdx: i - 1, color: currentColor, count: i - currentStart });
+      }
+      currentColor = color;
+      currentStart = i;
+    }
+  }
+  if (currentColor !== null) {
+    segments.push({ startIdx: currentStart, endIdx: items.length - 1, color: currentColor, count: items.length - currentStart });
+  }
+
+  return (
+    <div className="flex h-5 gap-0.5 overflow-hidden rounded" role="navigation" aria-label="Timeline">
+      {segments.map((seg) => {
+        const isSelected =
+          selectedSeq !== null && items.slice(seg.startIdx, seg.endIdx + 1).some((item) => item.seq === selectedSeq);
+        const color = colorClasses[seg.color];
+        const widthPercent = (seg.count / items.length) * 100;
+
+        return (
+          <button
+            type="button"
+            key={seg.startIdx}
+            className={cn(
+              "group relative h-full min-w-[4px] transition-all duration-150 hover:opacity-80",
+              isSelected ? color.bgActive : color.bg,
+            )}
+            style={{ width: `${Math.max(widthPercent, 0.5)}%` }}
+            onClick={() => onSegmentClick(items[seg.startIdx]!.seq)}
+            title={`${getEventLabel(items[seg.startIdx]!)}${seg.count > 1 ? ` (+${seg.count - 1} more)` : ""}`}
+          >
+            <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 hidden -translate-x-1/2 group-hover:block">
+              <div className="whitespace-nowrap rounded border bg-popover px-2 py-1 text-[10px] text-popover-foreground shadow-md">
+                {getEventLabel(items[seg.startIdx]!)}
+                {seg.count > 1 && <span className="ml-1 text-muted-foreground">+{seg.count - 1}</span>}
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function TranscriptEventRow({
+  ref,
+  item,
+  isSelected,
+}: {
+  ref?: React.Ref<HTMLDivElement>;
+  item: TimelineItem;
+  isSelected: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const color = getEventColor(item);
+  const label = getEventLabel(item);
+  const summary = getEventSummary(item);
+  const date = useMemo(() => (item.created_at ? new Date(item.created_at) : null), [item.created_at]);
+
+  const hasDetail =
+    (item.type === "tool_use" && item.input && Object.keys(item.input).length > 0) ||
+    (item.type === "tool_result" && item.output && item.output.length > 0) ||
+    (item.type === "thinking" && item.content && item.content.length > 0) ||
+    (item.type === "text" && item.content && item.content.length > 0) ||
+    (item.type === "error" && item.content && item.content.length > 0);
+
+  return (
+    <div ref={ref} className={cn("group transition-colors", isSelected && "bg-accent/50")}>
+      <div className="flex items-start gap-2 px-4 py-2">
+        <span
+          className={cn(
+            "mt-0.5 inline-flex min-w-[60px] shrink-0 items-center justify-center rounded px-1.5 py-0.5 text-[11px] font-medium",
+            colorClasses[color].label,
+          )}
+        >
+          {item.type === "thinking" && <Brain className="mr-1 h-3 w-3 shrink-0" />}
+          {item.type === "error" && <AlertCircle className="mr-1 h-3 w-3 shrink-0" />}
+          {label}
+        </span>
+
+        <button
+          type="button"
+          disabled={!hasDetail}
+          onClick={() => hasDetail && setExpanded((open) => !open)}
+          className={cn(
+            "min-w-0 flex-1 py-0.5 text-left text-xs transition-colors",
+            hasDetail ? "cursor-pointer hover:text-foreground" : "cursor-default",
+            item.type === "error" ? "text-destructive" : "text-muted-foreground",
+          )}
+        >
+          <div className="flex items-start gap-1.5">
+            {hasDetail && (
+              <ChevronRight
+                className={cn(
+                  "mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/50 transition-transform",
+                  expanded && "rotate-90",
+                )}
+              />
+            )}
+            <span className="truncate">{summary || "(empty)"}</span>
+          </div>
+        </button>
+
+        <span className="mt-1 shrink-0 text-[10px] tabular-nums text-muted-foreground/50">#{item.seq}</span>
+
+        {date && (
+          <span
+            className="mt-1 shrink-0 text-[10px] tabular-nums text-muted-foreground/50"
+            title={date.toLocaleString()}
+          >
+            {date.toLocaleTimeString(undefined, {
+              hour: "2-digit",
+              minute: "2-digit",
+              second: "2-digit",
+            })}
+          </span>
+        )}
+      </div>
+
+      {hasDetail && expanded && (
+        <div className="px-4 pb-3">
+          <div className="ml-[72px] rounded border bg-muted/40">
+            <EventDetailContent item={item} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EventDetailContent({ item }: { item: TimelineItem }) {
+  switch (item.type) {
+    case "tool_use":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all p-3 text-[11px] text-muted-foreground">
+          {item.input ? JSON.stringify(item.input, null, 2) : ""}
+        </pre>
+      );
+    case "tool_result":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all p-3 text-[11px] text-muted-foreground">
+          {item.output
+            ? item.output.length > 4000
+              ? item.output.slice(0, 4000) + "\n... (truncated)"
+              : item.output
+            : ""}
+        </pre>
+      );
+    case "thinking":
+    case "text":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-words p-3 text-[11px] text-muted-foreground">
+          {item.content ?? ""}
+        </pre>
+      );
+    case "error":
+      return (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-words p-3 text-[11px] text-destructive">
+          {item.content ?? ""}
+        </pre>
+      );
+    default:
+      return null;
+  }
+}

--- a/web/src/components/task-transcript/timeline-utils.test.ts
+++ b/web/src/components/task-transcript/timeline-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { getEventColor, getEventLabel, getEventSummary, itemFilterKey } from "./timeline-utils";
+import type { TimelineItem } from "./types";
+
+describe("timeline-utils", () => {
+  it("maps item types to multica colors", () => {
+    expect(getEventColor({ seq: 1, type: "thinking" })).toBe("thinking");
+    expect(getEventColor({ seq: 2, type: "tool_use", tool: "Bash" })).toBe("tool");
+    expect(getEventColor({ seq: 3, type: "text", content: "hi" })).toBe("agent");
+  });
+
+  it("summarizes bash commands from tool input", () => {
+    const item: TimelineItem = {
+      seq: 1,
+      type: "tool_use",
+      tool: "Bash",
+      input: { command: "curl https://example.com" },
+    };
+    expect(getEventLabel(item)).toBe("Bash");
+    expect(getEventSummary(item)).toBe("curl https://example.com");
+  });
+
+  it("builds stable filter keys for tool rows", () => {
+    const item: TimelineItem = { seq: 1, type: "tool_use", tool: "Bash" };
+    expect(itemFilterKey(item)).toBe("tool:Bash");
+  });
+});

--- a/web/src/components/task-transcript/timeline-utils.ts
+++ b/web/src/components/task-transcript/timeline-utils.ts
@@ -1,0 +1,125 @@
+import type { EventColor, TimelineItem } from "./types";
+
+export function getEventColor(item: TimelineItem): EventColor {
+  switch (item.type) {
+    case "text":
+      return "agent";
+    case "thinking":
+      return "thinking";
+    case "tool_use":
+      return "tool";
+    case "tool_result":
+      return "result";
+    case "error":
+      return "error";
+    default:
+      return "result";
+  }
+}
+
+export const colorClasses: Record<EventColor, { bg: string; bgActive: string; label: string }> = {
+  agent: { bg: "bg-emerald-400/60", bgActive: "bg-emerald-500", label: "bg-emerald-500/20 text-emerald-700 dark:text-emerald-300" },
+  thinking: { bg: "bg-violet-400/60", bgActive: "bg-violet-500", label: "bg-violet-500/20 text-violet-700 dark:text-violet-300" },
+  tool: { bg: "bg-blue-400/60", bgActive: "bg-blue-500", label: "bg-blue-500/20 text-blue-700 dark:text-blue-300" },
+  result: { bg: "bg-slate-300/60 dark:bg-slate-600/60", bgActive: "bg-slate-400 dark:bg-slate-500", label: "bg-muted text-muted-foreground" },
+  error: { bg: "bg-red-400/60", bgActive: "bg-red-500", label: "bg-red-500/20 text-red-700 dark:text-red-300" },
+};
+
+export function getEventLabel(item: TimelineItem): string {
+  switch (item.type) {
+    case "text":
+      return "Agent";
+    case "thinking":
+      return "Thinking";
+    case "tool_use":
+      return item.tool ?? "Tool";
+    case "tool_result":
+      return item.tool ? item.tool : "Result";
+    case "error":
+      return "Error";
+    default:
+      return "Event";
+  }
+}
+
+export function getEventSummary(item: TimelineItem): string {
+  switch (item.type) {
+    case "text":
+      return item.content?.split("\n").find((line) => line.trim().length > 0) ?? "";
+    case "thinking":
+      return item.content?.slice(0, 200) ?? "";
+    case "tool_use": {
+      if (!item.input) return "";
+      const inp = item.input as Record<string, string>;
+      if (inp.query) return inp.query;
+      if (inp.file_path) return shortenPath(inp.file_path);
+      if (inp.path) return shortenPath(inp.path);
+      if (inp.pattern) return inp.pattern;
+      if (inp.description) return String(inp.description);
+      if (inp.command) {
+        const cmd = String(inp.command);
+        return cmd.length > 120 ? cmd.slice(0, 120) + "..." : cmd;
+      }
+      if (inp.prompt) {
+        const prompt = String(inp.prompt);
+        return prompt.length > 120 ? prompt.slice(0, 120) + "..." : prompt;
+      }
+      if (inp.skill) return String(inp.skill);
+      for (const value of Object.values(inp)) {
+        if (typeof value === "string" && value.length > 0 && value.length < 120) return value;
+      }
+      return "";
+    }
+    case "tool_result":
+      return item.output?.slice(0, 200) ?? "";
+    case "error":
+      return item.content ?? "";
+    default:
+      return "";
+  }
+}
+
+export function shortenPath(path: string): string {
+  const parts = path.split("/");
+  if (parts.length <= 3) return path;
+  return ".../" + parts.slice(-2).join("/");
+}
+
+export function itemFilterKey(item: TimelineItem): string {
+  return item.tool && (item.type === "tool_use" || item.type === "tool_result")
+    ? `tool:${item.tool}`
+    : item.type;
+}
+
+export function buildFilterOptions(items: TimelineItem[]): [string, string][] {
+  const options = new Map<string, string>();
+  for (const item of items) {
+    if (item.tool && (item.type === "tool_use" || item.type === "tool_result")) {
+      const key = `tool:${item.tool}`;
+      if (!options.has(key)) options.set(key, key);
+    } else {
+      const value = item.type;
+      if (!options.has(value)) {
+        options.set(value, getEventLabel(item));
+      }
+    }
+  }
+  return Array.from(options.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+}
+
+export function formatDuration(start: string, end: string): string {
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}m ${secs}s`;
+}
+
+export function formatElapsedMs(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}m ${secs}s`;
+}

--- a/web/src/components/task-transcript/types.ts
+++ b/web/src/components/task-transcript/types.ts
@@ -1,0 +1,15 @@
+export type TimelineItemType = "tool_use" | "tool_result" | "thinking" | "text" | "error";
+
+export interface TimelineItem {
+  seq: number;
+  type: TimelineItemType;
+  tool?: string;
+  content?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  created_at?: string;
+}
+
+export type TranscriptSortDirection = "chronological" | "newest_first";
+
+export type EventColor = "agent" | "thinking" | "tool" | "result" | "error";

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -346,6 +346,21 @@ export interface TaskTranscript {
   entries: TaskTranscriptEntry[];
 }
 
+export interface TaskTimelineItem {
+  seq: number;
+  type: "tool_use" | "tool_result" | "thinking" | "text" | "error";
+  tool?: string;
+  content?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  created_at?: string;
+}
+
+export interface TaskTimeline {
+  task_id: string;
+  items: TaskTimelineItem[];
+}
+
 export interface PreflightCheck {
   name: string;
   status: "pass" | "fail";

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useState, useRef, type RefObject } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Square, Send, Terminal, Activity, GitBranch, MessageSquare, Play, FileText, Shield, ChevronRight, Wrench, User, Bot, ArrowDown, ArrowUp } from "lucide-react";
-import { apiGet, apiPost, type Task, type TaskEvent, type TaskTranscript, type TaskTranscriptEntry } from "@/lib/api";
+import { apiGet, apiPost, type Task, type TaskTimeline, type TaskTimelineItem, type TaskTranscript, type TaskTranscriptEntry } from "@/lib/api";
 import { Button, Card, Input, Badge, Select } from "@/components/ui";
 import { BackLink, PageContainer } from "@/components/shared";
-import { collapsedTranscriptTitle, shouldShowInTimeline, summarizeTaskEvent } from "./taskDetailView";
+import { AgentTranscriptView } from "@/components/task-transcript/AgentTranscriptView";
+import { collapsedTranscriptTitle } from "./taskDetailView";
 
 const ACTIVE = new Set(["running", "paused"]);
 
 export function TaskDetailPage() {
   const { projectId, taskId } = useParams<{ projectId: string; taskId: string }>();
   const [task, setTask] = useState<Task | null>(null);
-  const [events, setEvents] = useState<TaskEvent[]>([]);
+  const [timeline, setTimeline] = useState<TaskTimelineItem[]>([]);
   const [transcript, setTranscript] = useState<TaskTranscriptEntry[]>([]);
   const [activeView, setActiveView] = useState<"conversation" | "timeline">("conversation");
   const [autoFollow, setAutoFollow] = useState(true);
@@ -28,13 +29,13 @@ export function TaskDetailPage() {
   async function loadAll() {
     if (!projectId || !taskId) return;
     try {
-      const [t, ev, tr] = await Promise.all([
+      const [t, tl, tr] = await Promise.all([
         apiGet<Task>(`${base}`),
-        apiGet<{ events: TaskEvent[] }>(`${base}/events`),
+        apiGet<TaskTimeline>(`${base}/timeline`),
         apiGet<TaskTranscript>(`${base}/transcript`),
       ]);
       setTask(t);
-      setEvents(ev.events ?? []);
+      setTimeline(tl.items ?? []);
       setTranscript(tr.entries ?? []);
       setError(null);
     } catch (e) {
@@ -90,7 +91,7 @@ export function TaskDetailPage() {
     if (autoFollowRef.current) {
       timelineEnd.current?.scrollIntoView({ behavior: "smooth" });
     }
-  }, [events, transcript]);
+  }, [timeline, transcript]);
 
   function scrollToLatest() {
     const container = findScrollContainer(pageRef.current);
@@ -214,7 +215,15 @@ export function TaskDetailPage() {
       {activeView === "conversation" ? (
         <TranscriptList entries={transcript} endRef={timelineEnd} />
       ) : (
-        <TimelineList events={events} endRef={timelineEnd} />
+        <div>
+          <AgentTranscriptView
+            task={task}
+            items={timeline}
+            profileName={profiles.find((p) => p.id === task.runtime_profile_id)?.name}
+            isLive={ACTIVE.has(task.status)}
+          />
+          <div ref={timelineEnd} />
+        </div>
       )}
 
       <FloatingScrollControls autoFollow={autoFollow} onTop={scrollToTop} onBottom={scrollToLatest} />
@@ -284,21 +293,6 @@ function TranscriptList({ entries, endRef }: { entries: TaskTranscriptEntry[]; e
       ))}
       {entries.length === 0 && <p className="text-sm text-muted-foreground">No transcript yet.</p>}
       <div ref={endRef} />
-    </div>
-  );
-}
-
-function TimelineList({ events, endRef }: { events: TaskEvent[]; endRef: RefObject<HTMLDivElement | null> }) {
-  const timelineEvents = events.filter(shouldShowInTimeline);
-  return (
-    <div className="rounded-lg border border-border bg-muted/20 p-2 font-mono text-xs">
-      <div className="space-y-1">
-        {timelineEvents.map((ev) => (
-          <EventRow key={ev.id} ev={ev} />
-        ))}
-        {timelineEvents.length === 0 && <p className="px-2 py-3 text-sm text-muted-foreground">No events yet.</p>}
-        <div ref={endRef} />
-      </div>
     </div>
   );
 }
@@ -376,35 +370,4 @@ function collapsedBody(entry: TaskTranscriptEntry) {
   return parts.join("\n\n") || "(empty)";
 }
 
-function firstLine(value: string) {
-  return value.split(/\r?\n/, 1)[0];
-}
 
-function EventRow({ ev }: { ev: TaskEvent }) {
-  const icon =
-    ev.kind === "lifecycle" ? <Activity className="h-3 w-3" /> :
-    ev.kind === "steering" ? <GitBranch className="h-3 w-3" /> :
-    ev.kind === "conversation" ? <MessageSquare className="h-3 w-3" /> :
-    <Terminal className="h-3 w-3" />;
-  const summary = summarizeTaskEvent(ev);
-  const raw = typeof ev.payload.text === "string" ? ev.payload.text : "";
-  const showDetails = ev.kind === "runtime_output" && raw.trim().startsWith("{");
-  return (
-    <details className="group rounded border border-transparent px-2 py-1 hover:border-border hover:bg-background/60 open:border-border open:bg-background/80">
-      <summary className="flex cursor-pointer list-none items-start gap-2 [&::-webkit-details-marker]:hidden">
-        <span className="mt-0.5 shrink-0 text-muted-foreground">{icon}</span>
-        <span className="min-w-0 flex-1">
-          <span className="text-muted-foreground">#{ev.seq} {ev.kind}</span>
-          {ev.created_at && <span className="text-muted-foreground"> · {new Date(ev.created_at).toLocaleTimeString()}</span>}
-          <span className="ml-2 text-foreground">{summary}</span>
-        </span>
-        {showDetails && <ChevronRight className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />}
-      </summary>
-      {showDetails && (
-        <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words border-t border-border/60 px-2 py-2 text-[11px] leading-5 text-muted-foreground">
-          {raw}
-        </pre>
-      )}
-    </details>
-  );
-}


### PR DESCRIPTION
## Summary

Replaces the monospace Timeline tab with a Multica-style agent transcript view: colored pills (Thinking / Bash / Agent / Result / Error), segmented progress bar, metadata chips, filter/sort/copy controls, and expandable event rows.

## Changes

- **Go** `internal/timeline`: builds coalesced timeline items from `runtime_output` events (thinking, tool_use, tool_result, text, error); filters `thinking_tokens`, `task_*`, `init` noise
- **API** `GET /api/projects/{id}/tasks/{task_id}/timeline`
- **Web** `AgentTranscriptView` component ported from Multica's `AgentTranscriptDialog` layout and color mapping
- Conversation tab unchanged; Timeline tab now uses the new view

## Test plan

- [x] `go test ./internal/timeline/...`
- [x] `npm test` (187 tests)
- [x] `npm run build`
- [ ] Restart `make dev`, open a task, switch to Timeline — verify colored bar + pills match Multica