### PR TITLE
refactor: shared runtimeoutput parse core for transcript/timeline

### DIFF
--- a/internal/runtimeoutput/coalesce.go
+++ b/internal/runtimeoutput/coalesce.go
@@ -1,0 +1,37 @@
+package runtimeoutput
+
+// CoalesceStreaming merges adjacent thinking or text turns split by flush timing.
+func CoalesceStreaming(turns []Turn) []Turn {
+	if len(turns) == 0 {
+		return turns
+	}
+	out := make([]Turn, 0, len(turns))
+	for _, turn := range turns {
+		if len(out) == 0 {
+			out = append(out, turn)
+			continue
+		}
+		prev := out[len(out)-1]
+		if canMergeStreamingText(prev, turn) {
+			out[len(out)-1] = Turn{
+				Kind:         prev.Kind,
+				Role:         prev.Role,
+				Text:         prev.Text + turn.Text,
+				Tool:         prev.Tool,
+				Input:        prev.Input,
+				Output:       prev.Output,
+				ToolCallID:   prev.ToolCallID,
+				Details:      prev.Details,
+				ContentIndex: prev.ContentIndex,
+				CreatedAt:    turn.CreatedAt,
+			}
+			continue
+		}
+		out = append(out, turn)
+	}
+	return out
+}
+
+func canMergeStreamingText(prev, next Turn) bool {
+	return (prev.Kind == KindThinking || prev.Kind == KindText) && prev.Kind == next.Kind
+}

--- a/internal/runtimeoutput/ignore.go
+++ b/internal/runtimeoutput/ignore.go
@@ -1,0 +1,106 @@
+package runtimeoutput
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ShouldIgnoreForStorage reports whether a raw runtime line should not be stored
+// or shown in the task conversation transcript.
+func ShouldIgnoreForStorage(text string) bool {
+	record, ok := parseJSONRecord(text)
+	if !ok {
+		return false
+	}
+	return isIgnorableStorageRecord(record)
+}
+
+// IsThinkingOnlyAssistantLine reports assistant records that contain only thinking blocks.
+func IsThinkingOnlyAssistantLine(text string) bool {
+	record, ok := parseJSONRecord(text)
+	if !ok {
+		return false
+	}
+	return isThinkingOnlyAssistantRecord(record)
+}
+
+// ShouldIgnoreForTimeline reports whether a stored runtime line should be omitted
+// from the agent timeline projection. Thinking-only assistant lines are kept.
+func ShouldIgnoreForTimeline(text string) bool {
+	record, ok := parseJSONRecord(text)
+	if !ok {
+		return false
+	}
+	if isIgnorableStorageRecord(record) && !isThinkingOnlyAssistantRecord(record) {
+		return true
+	}
+	switch stringValue(record, "type") {
+	case "ping", "keepalive":
+		return true
+	case "result":
+		return !isTruthy(record["is_error"])
+	}
+	return false
+}
+
+func isIgnorableStorageRecord(record map[string]any) bool {
+	return isIgnorableSystemRecord(record) || isIgnorableRecordType(record) || isThinkingOnlyAssistantRecord(record)
+}
+
+func isIgnorableRecordType(record map[string]any) bool {
+	switch stringValue(record, "type") {
+	case "ping", "keepalive", "result":
+		return true
+	default:
+		return false
+	}
+}
+
+func isIgnorableSystemRecord(record map[string]any) bool {
+	if stringValue(record, "type") != "system" {
+		return false
+	}
+	subtype := stringValue(record, "subtype")
+	switch subtype {
+	case "thinking_tokens", "init":
+		return true
+	}
+	return strings.HasPrefix(subtype, "task_")
+}
+
+func isThinkingOnlyAssistantRecord(record map[string]any) bool {
+	if stringValue(record, "type") != "assistant" {
+		return false
+	}
+	message, ok := mapValue(record, "message")
+	if !ok {
+		return false
+	}
+	content, ok := sliceValue(message, "content")
+	if !ok || len(content) == 0 {
+		return false
+	}
+	for _, block := range content {
+		blockMap, ok := block.(map[string]any)
+		if !ok {
+			return false
+		}
+		blockType := strings.ToLower(stringValue(blockMap, "type"))
+		if blockType != "thinking" {
+			return false
+		}
+	}
+	return true
+}
+
+func parseJSONRecord(text string) (map[string]any, bool) {
+	text = strings.TrimSpace(text)
+	if text == "" || !strings.HasPrefix(text, "{") {
+		return nil, false
+	}
+	var record map[string]any
+	if err := json.Unmarshal([]byte(text), &record); err != nil {
+		return nil, false
+	}
+	return record, true
+}

--- a/internal/runtimeoutput/parse.go
+++ b/internal/runtimeoutput/parse.go
@@ -1,0 +1,300 @@
+package runtimeoutput
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// ParseLine normalizes one runtime stdout/stderr line into turns. The bool is
+// true when the line is treated as plain-text fallback rather than structured JSON.
+func ParseLine(text string, createdAt time.Time, opts ParseOptions) ([]Turn, bool) {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(trimmed, "{") {
+		return []Turn{{Kind: KindText, Text: trimmed, ContentIndex: -1, CreatedAt: createdAt}}, true
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &record); err != nil {
+		return []Turn{{Kind: KindText, Text: trimmed, ContentIndex: -1, CreatedAt: createdAt}}, true
+	}
+
+	turns := ParseRecord(record, opts, createdAt)
+	if len(turns) == 0 {
+		return []Turn{{Kind: KindText, Text: trimmed, ContentIndex: -1, CreatedAt: createdAt}}, true
+	}
+	return turns, false
+}
+
+// ParseRecord projects one provider JSON object into normalized turns.
+func ParseRecord(record map[string]any, opts ParseOptions, createdAt time.Time) []Turn {
+	if item, ok := mapValue(record, "item"); ok {
+		if turns := ParseRecord(item, opts, createdAt); len(turns) > 0 {
+			return turns
+		}
+	}
+	if delta, ok := mapValue(record, "delta"); ok {
+		if text := firstText(delta, "text", "content"); text != "" {
+			return []Turn{{Kind: KindText, Role: roleAssistant, Text: text, ContentIndex: -1, CreatedAt: createdAt}}
+		}
+	}
+
+	recordType := stringValue(record, "type")
+	switch recordType {
+	case "system":
+		if isIgnorableSystemRecord(record) {
+			return nil
+		}
+		return parseMessageRecord(record, opts, roleFromType(recordType), createdAt)
+	case "assistant", "user", "message", "assistant_message", "agent_message", "response.output_text", "output_text", "message_delta", "content_block_delta":
+		return parseMessageRecord(record, opts, roleFromType(recordType), createdAt)
+	case "tool_call", "function_call", "tool_use":
+		return []Turn{toolUseTurn(record, createdAt)}
+	case "tool_result", "function_call_output":
+		return []Turn{toolResultTurn(record, createdAt)}
+	case "result":
+		if opts.IncludeErrors && isTruthy(record["is_error"]) {
+			content := firstText(record, "error", "message", "content")
+			if content == "" {
+				content = stringValue(record, "subtype")
+			}
+			return []Turn{{Kind: KindError, Text: content, ContentIndex: -1, CreatedAt: createdAt}}
+		}
+		return nil
+	case "error":
+		if !opts.IncludeErrors {
+			return nil
+		}
+		return []Turn{{Kind: KindError, Text: firstText(record, "error", "message", "content", "text"), ContentIndex: -1, CreatedAt: createdAt}}
+	default:
+		if recordType == "" && stringValue(record, "role") != "" {
+			text := firstText(record, "text", "content", "message", "output")
+			if text == "" {
+				return nil
+			}
+			return []Turn{{Kind: KindText, Role: stringValue(record, "role"), Text: text, ContentIndex: -1, CreatedAt: createdAt}}
+		}
+		return nil
+	}
+}
+
+func parseMessageRecord(record map[string]any, opts ParseOptions, role string, createdAt time.Time) []Turn {
+	if message, ok := mapValue(record, "message"); ok {
+		if mr := stringValue(message, "role"); mr == "toolResult" || mr == "tool" {
+			if turn := toolResultTurn(message, createdAt); turn.Output != "" || turn.ToolCallID != "" || turn.Tool != "" {
+				return []Turn{turn}
+			}
+		}
+		if content, ok := sliceValue(message, "content"); ok {
+			return parseContentBlocks(content, opts, role, createdAt)
+		}
+		if text := firstText(message, "text", "content", "message"); text != "" {
+			return []Turn{{Kind: KindText, Role: role, Text: text, ContentIndex: -1, CreatedAt: createdAt}}
+		}
+	}
+	if content, ok := sliceValue(record, "content"); ok {
+		return parseContentBlocks(content, opts, role, createdAt)
+	}
+	if text := firstText(record, "text", "content", "message"); text != "" {
+		return []Turn{{Kind: KindText, Role: role, Text: text, ContentIndex: -1, CreatedAt: createdAt}}
+	}
+	return nil
+}
+
+func parseContentBlocks(content []any, opts ParseOptions, role string, createdAt time.Time) []Turn {
+	turns := make([]Turn, 0, len(content))
+	for index, block := range content {
+		switch value := block.(type) {
+		case string:
+			if value != "" {
+				turns = append(turns, Turn{Kind: KindText, Role: role, Text: value, ContentIndex: index, CreatedAt: createdAt})
+			}
+		case map[string]any:
+			blockType := strings.ToLower(stringValue(value, "type"))
+			switch blockType {
+			case "thinking":
+				if !opts.IncludeThinking {
+					continue
+				}
+				if text := thinkingText(value); text != "" {
+					turns = append(turns, Turn{Kind: KindThinking, Role: role, Text: text, ContentIndex: index, CreatedAt: createdAt})
+				}
+			case "text":
+				if text := firstText(value, "text", "content"); text != "" {
+					turns = append(turns, Turn{Kind: KindText, Role: role, Text: text, ContentIndex: index, CreatedAt: createdAt})
+				}
+			case "tool_use", "tool_call", "toolcall", "function_call":
+				turn := toolUseTurn(value, createdAt)
+				turn.ContentIndex = index
+				turns = append(turns, turn)
+			case "tool_result", "toolresult", "function_call_output":
+				turn := toolResultTurn(value, createdAt)
+				turn.ContentIndex = index
+				turns = append(turns, turn)
+			default:
+				if text := firstText(value, "text", "content", "message", "output"); text != "" {
+					turns = append(turns, Turn{Kind: KindText, Role: role, Text: text, ContentIndex: index, CreatedAt: createdAt})
+				}
+			}
+		}
+	}
+	return turns
+}
+
+func toolUseTurn(record map[string]any, createdAt time.Time) Turn {
+	input := map[string]any{}
+	details := map[string]any{}
+	for _, key := range []string{"input", "arguments", "parameters"} {
+		if value, ok := record[key]; ok {
+			details[key] = value
+			if typed, ok := value.(map[string]any); ok {
+				for k, v := range typed {
+					input[k] = v
+				}
+			}
+		}
+	}
+	return Turn{
+		Kind:         KindToolUse,
+		Role:         roleAssistant,
+		Tool:         toolName(record),
+		ToolCallID:   firstText(record, "tool_call_id", "tool_use_id", "call_id", "id"),
+		Input:        nilIfEmpty(input),
+		Details:      nilIfEmpty(details),
+		ContentIndex: -1,
+		CreatedAt:    createdAt,
+	}
+}
+
+func toolResultTurn(record map[string]any, createdAt time.Time) Turn {
+	details := map[string]any{}
+	for _, key := range []string{"is_error", "isError", "error"} {
+		if value, ok := record[key]; ok {
+			details[key] = value
+		}
+	}
+	return Turn{
+		Kind:         KindToolResult,
+		Role:         roleTool,
+		Tool:         firstText(record, "tool_name", "toolName", "name"),
+		Output:       firstText(record, "output", "content", "result", "text"),
+		ToolCallID:   firstText(record, "tool_call_id", "tool_use_id", "call_id", "toolCallId", "id"),
+		Details:      nilIfEmpty(details),
+		ContentIndex: -1,
+		CreatedAt:    createdAt,
+	}
+}
+
+func thinkingText(record map[string]any) string {
+	return firstText(record, "thinking", "text", "content")
+}
+
+const (
+	roleAssistant = "assistant"
+	roleUser      = "user"
+	roleSystem    = "system"
+	roleTool      = "tool"
+)
+
+func roleFromType(recordType string) string {
+	switch recordType {
+	case "user":
+		return roleUser
+	case "system":
+		return roleSystem
+	default:
+		return roleAssistant
+	}
+}
+
+func toolName(record map[string]any) string {
+	if name := firstText(record, "name", "tool_name"); name != "" {
+		return name
+	}
+	if function, ok := mapValue(record, "function"); ok {
+		return firstText(function, "name")
+	}
+	return ""
+}
+
+func stringValue(record map[string]any, key string) string {
+	value, ok := record[key]
+	if !ok {
+		return ""
+	}
+	text, _ := value.(string)
+	return text
+}
+
+func firstText(record map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := record[key]
+		if !ok {
+			continue
+		}
+		if text := valueToText(value); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func valueToText(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := valueToText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	case map[string]any:
+		if text := firstText(typed, "text", "content", "message", "output"); text != "" {
+			return text
+		}
+		return ""
+	case nil:
+		return ""
+	default:
+		return ""
+	}
+}
+
+func mapValue(record map[string]any, key string) (map[string]any, bool) {
+	value, ok := record[key]
+	if !ok {
+		return nil, false
+	}
+	typed, ok := value.(map[string]any)
+	return typed, ok
+}
+
+func sliceValue(record map[string]any, key string) ([]any, bool) {
+	value, ok := record[key]
+	if !ok {
+		return nil, false
+	}
+	typed, ok := value.([]any)
+	return typed, ok
+}
+
+func nilIfEmpty(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func isTruthy(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return typed == "true" || typed == "1"
+	default:
+		return false
+	}
+}

--- a/internal/runtimeoutput/parse_test.go
+++ b/internal/runtimeoutput/parse_test.go
@@ -1,0 +1,96 @@
+package runtimeoutput_test
+
+import (
+	"testing"
+	"time"
+
+	"pentest/internal/runtimeoutput"
+)
+
+func TestShouldIgnoreForStorageDropsThinkingTokensAndTaskProgress(t *testing.T) {
+	cases := []struct {
+		line   string
+		ignore bool
+	}{
+		{`{"type":"system","subtype":"thinking_tokens","estimated_tokens":13}`, true},
+		{`{"type":"system","subtype":"task_progress","description":"Exploit"}`, true},
+		{`{"type":"assistant","message":{"content":[{"type":"text","text":"Visible."}]}}`, false},
+		{`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan"}]}}`, true},
+	}
+	for _, tc := range cases {
+		if got := runtimeoutput.ShouldIgnoreForStorage(tc.line); got != tc.ignore {
+			t.Fatalf("ShouldIgnoreForStorage(%q) = %v, want %v", tc.line, got, tc.ignore)
+		}
+	}
+}
+
+func TestShouldIgnoreForTimelineAllowsThinkingOnlyAssistant(t *testing.T) {
+	line := `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan recon"}]}}`
+	if !runtimeoutput.ShouldIgnoreForStorage(line) {
+		t.Fatal("storage should ignore thinking-only assistant")
+	}
+	if runtimeoutput.ShouldIgnoreForTimeline(line) {
+		t.Fatal("timeline projection should keep thinking-only assistant")
+	}
+}
+
+func TestParseRecordClaudeAssistantBlocks(t *testing.T) {
+	record := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{"type": "text", "text": "I will inspect the app."},
+				map[string]any{"type": "tool_use", "id": "toolu_1", "name": "curl", "input": map[string]any{"url": "http://127.0.0.1:3000"}},
+			},
+		},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	if len(turns) != 2 {
+		t.Fatalf("expected 2 turns, got %d: %#v", len(turns), turns)
+	}
+	if turns[0].Kind != runtimeoutput.KindText || turns[0].Text != "I will inspect the app." {
+		t.Fatalf("unexpected text turn: %#v", turns[0])
+	}
+	if turns[1].Kind != runtimeoutput.KindToolUse || turns[1].Tool != "curl" {
+		t.Fatalf("unexpected tool turn: %#v", turns[1])
+	}
+}
+
+func TestParseRecordOmitsThinkingWhenDisabled(t *testing.T) {
+	record := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{"type": "thinking", "thinking": "hidden"},
+				map[string]any{"type": "text", "text": "visible"},
+			},
+		},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{}, time.Time{})
+	if len(turns) != 1 || turns[0].Text != "visible" {
+		t.Fatalf("expected only visible text, got %#v", turns)
+	}
+}
+
+func TestParseLinePlainTextFallback(t *testing.T) {
+	at := time.Now().UTC()
+	turns, fallback := runtimeoutput.ParseLine("plain runtime line", at, runtimeoutput.ParseOptions{IncludeThinking: true})
+	if !fallback || len(turns) != 1 || turns[0].Kind != runtimeoutput.KindText || turns[0].Text != "plain runtime line" {
+		t.Fatalf("unexpected plain fallback: %#v fallback=%v", turns, fallback)
+	}
+}
+
+func TestCoalesceMergesAdjacentThinking(t *testing.T) {
+	turns := []runtimeoutput.Turn{
+		{Kind: runtimeoutput.KindThinking, Text: "part one"},
+		{Kind: runtimeoutput.KindThinking, Text: " part two"},
+		{Kind: runtimeoutput.KindToolUse, Tool: "Bash"},
+	}
+	got := runtimeoutput.CoalesceStreaming(turns)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 coalesced turns, got %d: %#v", len(got), got)
+	}
+	if got[0].Text != "part one part two" {
+		t.Fatalf("unexpected merged thinking: %#v", got[0])
+	}
+}

--- a/internal/runtimeoutput/turn.go
+++ b/internal/runtimeoutput/turn.go
@@ -1,0 +1,34 @@
+package runtimeoutput
+
+import "time"
+
+// Kind classifies one normalized runtime output turn.
+type Kind string
+
+const (
+	KindThinking   Kind = "thinking"
+	KindText       Kind = "text"
+	KindToolUse    Kind = "tool_use"
+	KindToolResult Kind = "tool_result"
+	KindError      Kind = "error"
+)
+
+// Turn is one normalized fragment from a provider stdout/stderr JSON line.
+type Turn struct {
+	Kind         Kind
+	Role         string
+	Text         string
+	Tool         string
+	Input        map[string]any
+	Output       string
+	ToolCallID   string
+	Details      map[string]any
+	ContentIndex int // block index within provider content; -1 omits the numeric suffix
+	CreatedAt    time.Time
+}
+
+// ParseOptions controls which fragments are emitted from a provider record.
+type ParseOptions struct {
+	IncludeThinking bool
+	IncludeErrors   bool
+}

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -3,12 +3,11 @@
 package timeline
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
 
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/task"
-	"pentest/internal/transcript"
 )
 
 // Item is one chronologically ordered timeline entry.
@@ -22,10 +21,14 @@ type Item struct {
 	CreatedAt time.Time      `json:"created_at"`
 }
 
+var timelineParseOpts = runtimeoutput.ParseOptions{
+	IncludeThinking: true,
+	IncludeErrors:   true,
+}
+
 // Build projects task events into coalesced timeline items.
 func Build(events []task.Event) []Item {
-	items := make([]Item, 0, len(events))
-	nextSeq := 1
+	turns := make([]runtimeoutput.Turn, 0, len(events))
 	for _, event := range events {
 		if event.Kind == task.EventKindLifecycle {
 			continue
@@ -37,272 +40,45 @@ func Build(events []task.Event) []Item {
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
-		if isIgnorableTimelineLine(text) {
+		if runtimeoutput.ShouldIgnoreForTimeline(text) {
 			continue
 		}
-		parsed := itemsForRuntimeLine(text, event)
-		for _, item := range parsed {
-			item.Seq = nextSeq
-			nextSeq++
-			items = append(items, item)
-		}
+		lineTurns, _ := runtimeoutput.ParseLine(text, event.CreatedAt, timelineParseOpts)
+		turns = append(turns, lineTurns...)
 	}
-	return coalesceItems(items)
+	return turnsToItems(runtimeoutput.CoalesceStreaming(turns))
 }
 
-func itemsForRuntimeLine(text string, event task.Event) []Item {
-	trimmed := strings.TrimSpace(text)
-	if !strings.HasPrefix(trimmed, "{") {
-		return []Item{{
-			Type:      "text",
-			Content:   trimmed,
-			CreatedAt: event.CreatedAt,
-		}}
-	}
-
-	var record map[string]any
-	if err := json.Unmarshal([]byte(trimmed), &record); err != nil {
-		return []Item{{
-			Type:      "text",
-			Content:   trimmed,
-			CreatedAt: event.CreatedAt,
-		}}
-	}
-
-	if items := parseRecord(record, event.CreatedAt); len(items) > 0 {
-		return items
-	}
-
-	return []Item{{
-		Type:      "text",
-		Content:   trimmed,
-		CreatedAt: event.CreatedAt,
-	}}
-}
-
-func parseRecord(record map[string]any, createdAt time.Time) []Item {
-	if item, ok := mapValue(record, "item"); ok {
-		if items := parseRecord(item, createdAt); len(items) > 0 {
-			return items
+func turnsToItems(turns []runtimeoutput.Turn) []Item {
+	items := make([]Item, 0, len(turns))
+	nextSeq := 1
+	for _, turn := range turns {
+		item, ok := turnToItem(turn)
+		if !ok {
+			continue
 		}
-	}
-	if delta, ok := mapValue(record, "delta"); ok {
-		if text := firstText(delta, "text", "content"); text != "" {
-			return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
-		}
-	}
-
-	recordType := stringValue(record, "type")
-	switch recordType {
-	case "system":
-		return nil
-	case "assistant", "user", "message", "assistant_message", "agent_message", "response.output_text", "output_text", "message_delta", "content_block_delta":
-		return parseMessageRecord(record, createdAt)
-	case "tool_call", "function_call", "tool_use":
-		return []Item{toolUseItem(record, createdAt)}
-	case "tool_result", "function_call_output":
-		return []Item{toolResultItem(record, createdAt)}
-	case "result":
-		if isTruthy(record["is_error"]) {
-			content := firstText(record, "error", "message", "content")
-			if content == "" {
-				content = stringValue(record, "subtype")
-			}
-			return []Item{{Type: "error", Content: content, CreatedAt: createdAt}}
-		}
-		return nil
-	case "error":
-		return []Item{{Type: "error", Content: firstText(record, "error", "message", "content", "text"), CreatedAt: createdAt}}
-	default:
-		if recordType == "" && stringValue(record, "role") != "" {
-			text := firstText(record, "text", "content", "message", "output")
-			if text == "" {
-				return nil
-			}
-			return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
-		}
-		return nil
-	}
-}
-
-func parseMessageRecord(record map[string]any, createdAt time.Time) []Item {
-	if message, ok := mapValue(record, "message"); ok {
-		if mr := stringValue(message, "role"); mr == "toolResult" || mr == "tool" {
-			if item := toolResultItem(message, createdAt); item.Output != "" || item.Tool != "" {
-				return []Item{item}
-			}
-		}
-		if content, ok := sliceValue(message, "content"); ok {
-			return parseContentBlocks(content, createdAt)
-		}
-		if text := firstText(message, "text", "content", "message"); text != "" {
-			return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
-		}
-	}
-	if content, ok := sliceValue(record, "content"); ok {
-		return parseContentBlocks(content, createdAt)
-	}
-	if text := firstText(record, "text", "content", "message"); text != "" {
-		return []Item{{Type: "text", Content: text, CreatedAt: createdAt}}
-	}
-	return nil
-}
-
-func parseContentBlocks(content []any, createdAt time.Time) []Item {
-	items := make([]Item, 0, len(content))
-	for _, block := range content {
-		switch value := block.(type) {
-		case string:
-			if value != "" {
-				items = append(items, Item{Type: "text", Content: value, CreatedAt: createdAt})
-			}
-		case map[string]any:
-			blockType := strings.ToLower(stringValue(value, "type"))
-			switch blockType {
-			case "thinking":
-				if text := thinkingText(value); text != "" {
-					items = append(items, Item{Type: "thinking", Content: text, CreatedAt: createdAt})
-				}
-			case "text":
-				if text := firstText(value, "text", "content"); text != "" {
-					items = append(items, Item{Type: "text", Content: text, CreatedAt: createdAt})
-				}
-			case "tool_use", "tool_call", "toolcall", "function_call":
-				items = append(items, toolUseItem(value, createdAt))
-			case "tool_result", "toolresult", "function_call_output":
-				items = append(items, toolResultItem(value, createdAt))
-			default:
-				if text := firstText(value, "text", "content", "message", "output"); text != "" {
-					items = append(items, Item{Type: "text", Content: text, CreatedAt: createdAt})
-				}
-			}
-		}
+		item.Seq = nextSeq
+		nextSeq++
+		items = append(items, item)
 	}
 	return items
 }
 
-func toolUseItem(record map[string]any, createdAt time.Time) Item {
-	input := map[string]any{}
-	for _, key := range []string{"input", "arguments", "parameters"} {
-		if value, ok := record[key]; ok {
-			if typed, ok := value.(map[string]any); ok {
-				for k, v := range typed {
-					input[k] = v
-				}
-			}
-		}
+func turnToItem(turn runtimeoutput.Turn) (Item, bool) {
+	switch turn.Kind {
+	case runtimeoutput.KindThinking:
+		return Item{Type: "thinking", Content: turn.Text, CreatedAt: turn.CreatedAt}, true
+	case runtimeoutput.KindText:
+		return Item{Type: "text", Content: turn.Text, CreatedAt: turn.CreatedAt}, true
+	case runtimeoutput.KindToolUse:
+		return Item{Type: "tool_use", Tool: turn.Tool, Input: turn.Input, CreatedAt: turn.CreatedAt}, true
+	case runtimeoutput.KindToolResult:
+		return Item{Type: "tool_result", Tool: turn.Tool, Output: turn.Output, CreatedAt: turn.CreatedAt}, true
+	case runtimeoutput.KindError:
+		return Item{Type: "error", Content: turn.Text, CreatedAt: turn.CreatedAt}, true
+	default:
+		return Item{}, false
 	}
-	return Item{
-		Type:      "tool_use",
-		Tool:      toolName(record),
-		Input:     nilIfEmpty(input),
-		CreatedAt: createdAt,
-	}
-}
-
-func toolResultItem(record map[string]any, createdAt time.Time) Item {
-	return Item{
-		Type:      "tool_result",
-		Tool:      firstText(record, "tool_name", "toolName", "name"),
-		Output:    firstText(record, "output", "content", "result", "text"),
-		CreatedAt: createdAt,
-	}
-}
-
-func thinkingText(record map[string]any) string {
-	if text := firstText(record, "thinking", "text", "content"); text != "" {
-		return text
-	}
-	return ""
-}
-
-func isIgnorableTimelineLine(text string) bool {
-	text = strings.TrimSpace(text)
-	if text == "" || !strings.HasPrefix(text, "{") {
-		return false
-	}
-	var record map[string]any
-	if err := json.Unmarshal([]byte(text), &record); err != nil {
-		return false
-	}
-	if transcript.IsIgnorableRuntimeLine(text) && !isThinkingOnlyAssistantRecord(record) {
-		return true
-	}
-	recordType := stringValue(record, "type")
-	switch recordType {
-	case "ping", "keepalive":
-		return true
-	case "result":
-		return !isTruthy(record["is_error"])
-	}
-	return false
-}
-
-func isThinkingOnlyAssistantRecord(record map[string]any) bool {
-	if stringValue(record, "type") != "assistant" {
-		return false
-	}
-	message, ok := mapValue(record, "message")
-	if !ok {
-		return false
-	}
-	content, ok := sliceValue(message, "content")
-	if !ok || len(content) == 0 {
-		return false
-	}
-	for _, block := range content {
-		blockMap, ok := block.(map[string]any)
-		if !ok {
-			return false
-		}
-		blockType := strings.ToLower(stringValue(blockMap, "type"))
-		if blockType != "thinking" {
-			return false
-		}
-	}
-	return true
-}
-
-func coalesceItems(items []Item) []Item {
-	if len(items) == 0 {
-		return items
-	}
-	out := make([]Item, 0, len(items))
-	for _, item := range items {
-		if len(out) == 0 {
-			out = append(out, item)
-			continue
-		}
-		prev := out[len(out)-1]
-		if canMergeStreamingText(prev, item) {
-			out[len(out)-1] = Item{
-				Seq:       prev.Seq,
-				Type:      prev.Type,
-				Tool:      prev.Tool,
-				Content:   prev.Content + item.Content,
-				Input:     prev.Input,
-				Output:    prev.Output,
-				CreatedAt: item.CreatedAt,
-			}
-			continue
-		}
-		out = append(out, item)
-	}
-	return out
-}
-
-func canMergeStreamingText(prev, next Item) bool {
-	return (prev.Type == "thinking" || prev.Type == "text") && prev.Type == next.Type
-}
-
-func toolName(record map[string]any) string {
-	if name := firstText(record, "name", "tool_name"); name != "" {
-		return name
-	}
-	if function, ok := mapValue(record, "function"); ok {
-		return firstText(function, "name")
-	}
-	return ""
 }
 
 func stringValue(record map[string]any, key string) string {
@@ -312,77 +88,4 @@ func stringValue(record map[string]any, key string) string {
 	}
 	text, _ := value.(string)
 	return text
-}
-
-func firstText(record map[string]any, keys ...string) string {
-	for _, key := range keys {
-		value, ok := record[key]
-		if !ok {
-			continue
-		}
-		if text := valueToText(value); text != "" {
-			return text
-		}
-	}
-	return ""
-}
-
-func valueToText(value any) string {
-	switch typed := value.(type) {
-	case string:
-		return typed
-	case []any:
-		parts := make([]string, 0, len(typed))
-		for _, item := range typed {
-			if text := valueToText(item); text != "" {
-				parts = append(parts, text)
-			}
-		}
-		return strings.Join(parts, "\n")
-	case map[string]any:
-		if text := firstText(typed, "text", "content", "message", "output"); text != "" {
-			return text
-		}
-		return ""
-	case nil:
-		return ""
-	default:
-		return ""
-	}
-}
-
-func mapValue(record map[string]any, key string) (map[string]any, bool) {
-	value, ok := record[key]
-	if !ok {
-		return nil, false
-	}
-	typed, ok := value.(map[string]any)
-	return typed, ok
-}
-
-func sliceValue(record map[string]any, key string) ([]any, bool) {
-	value, ok := record[key]
-	if !ok {
-		return nil, false
-	}
-	typed, ok := value.([]any)
-	return typed, ok
-}
-
-func nilIfEmpty(values map[string]any) map[string]any {
-	if len(values) == 0 {
-		return nil
-	}
-	return values
-}
-
-func isTruthy(value any) bool {
-	switch typed := value.(type) {
-	case bool:
-		return typed
-	case string:
-		return typed == "true" || typed == "1"
-	default:
-		return false
-	}
 }

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/runtimeplugin"
 	"pentest/internal/task"
 )
@@ -226,97 +227,43 @@ func ParserForAdapter(adapter string, registry *runtimeplugin.Registry) string {
 // derived entries inherit. It is exported so runtime tails can reuse the same
 // parsing as the post-hoc transcript builder.
 func ParseRecord(record map[string]any, base Entry) []Entry {
-	if item, ok := mapValue(record, "item"); ok {
-		if entries := ParseRecord(item, base); len(entries) > 0 {
-			return entries
-		}
-	}
-	if delta, ok := mapValue(record, "delta"); ok {
-		if text := firstText(delta, "text", "content"); text != "" {
-			return []Entry{messageEntry(base, indexedID(base.ID, "-message", ""), RoleAssistant, text)}
-		}
-	}
-
-	recordType := stringValue(record, "type")
-	switch recordType {
-	case "system":
-		if isIgnorableSystemRecord(record) {
-			return nil
-		}
-		return parseMessageRecord(record, base, roleFromType(recordType))
-	case "assistant", "user", "message", "assistant_message", "agent_message", "response.output_text", "output_text", "message_delta", "content_block_delta":
-		return parseMessageRecord(record, base, roleFromType(recordType))
-	case "tool_call", "function_call", "tool_use":
-		return []Entry{toolCallEntry(record, base, indexedID(base.ID, "-tool-call", ""))}
-	case "tool_result", "function_call_output":
-		return []Entry{toolResultEntry(record, base, indexedID(base.ID, "-tool-result", ""))}
-	default:
-		if recordType == "" && stringValue(record, "role") != "" {
-			text := firstText(record, "text", "content", "message", "output")
-			if text == "" {
-				return nil
-			}
-			role := stringValue(record, "role")
-			return []Entry{messageEntry(base, indexedID(base.ID, "-message", ""), role, text)}
-		}
-		return nil
-	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{}, base.CreatedAt)
+	return turnsToEntries(turns, base)
 }
 
-func parseMessageRecord(record map[string]any, base Entry, role string) []Entry {
-	if message, ok := mapValue(record, "message"); ok {
-		// pi uses toolResult as a role on the message itself; surface it as a
-		// tool result entry so it renders like other provider tool results.
-		if mr := stringValue(message, "role"); mr == "toolResult" || mr == "tool" {
-			if res := toolResultEntry(message, base, indexedID(base.ID, "-tool-result", "")); res.Text != "" || res.ToolCallID != "" {
-				return []Entry{res}
-			}
-		}
-		if content, ok := sliceValue(message, "content"); ok {
-			return parseContentBlocks(content, base, role)
-		}
-		if text := firstText(message, "text", "content", "message"); text != "" {
-			return []Entry{messageEntry(base, base.ID+"-message", role, text)}
-		}
-	}
-	if content, ok := sliceValue(record, "content"); ok {
-		return parseContentBlocks(content, base, role)
-	}
-	if text := firstText(record, "text", "content", "message"); text != "" {
-		return []Entry{messageEntry(base, base.ID+"-message", role, text)}
-	}
-	return nil
-}
-
-func parseContentBlocks(content []any, base Entry, role string) []Entry {
-	entries := make([]Entry, 0, len(content))
-	for index, block := range content {
-		switch value := block.(type) {
-		case string:
-			if value != "" {
-				entries = append(entries, messageEntry(base, fmt.Sprintf("%s-message-%d", base.ID, index), role, value))
-			}
-		case map[string]any:
-			blockType := stringValue(value, "type")
-			switch strings.ToLower(blockType) {
-			case "thinking":
-				continue
-			case "text":
-				if text := firstText(value, "text", "content"); text != "" {
-					entries = append(entries, messageEntry(base, fmt.Sprintf("%s-message-%d", base.ID, index), role, text))
-				}
-			case "tool_use", "tool_call", "toolcall", "function_call":
-				entries = append(entries, toolCallEntry(value, base, fmt.Sprintf("%s-tool-call-%d", base.ID, index)))
-			case "tool_result", "toolresult", "function_call_output":
-				entries = append(entries, toolResultEntry(value, base, fmt.Sprintf("%s-tool-result-%d", base.ID, index)))
-			default:
-				if text := firstText(value, "text", "content", "message", "output"); text != "" {
-					entries = append(entries, messageEntry(base, fmt.Sprintf("%s-message-%d", base.ID, index), role, text))
-				}
-			}
+func turnsToEntries(turns []runtimeoutput.Turn, base Entry) []Entry {
+	entries := make([]Entry, 0, len(turns))
+	for _, turn := range turns {
+		switch turn.Kind {
+		case runtimeoutput.KindText:
+			entries = append(entries, messageEntry(base, entryID(base.ID, "-message", turn.ContentIndex), mapRuntimeRole(turn.Role), turn.Text))
+		case runtimeoutput.KindToolUse:
+			entries = append(entries, toolCallEntryFromTurn(turn, base, entryID(base.ID, "-tool-call", turn.ContentIndex)))
+		case runtimeoutput.KindToolResult:
+			entries = append(entries, toolResultEntryFromTurn(turn, base, entryID(base.ID, "-tool-result", turn.ContentIndex)))
 		}
 	}
 	return entries
+}
+
+func entryID(baseID, suffix string, index int) string {
+	if index < 0 {
+		return baseID + suffix
+	}
+	return fmt.Sprintf("%s%s-%d", baseID, suffix, index)
+}
+
+func mapRuntimeRole(role string) string {
+	switch role {
+	case "user":
+		return RoleUser
+	case "system":
+		return RoleSystem
+	case "tool":
+		return RoleTool
+	default:
+		return RoleAssistant
+	}
 }
 
 func messageEntry(base Entry, id, role, text string) Entry {
@@ -331,124 +278,45 @@ func messageEntry(base Entry, id, role, text string) Entry {
 	}
 }
 
-func toolCallEntry(record map[string]any, base Entry, id string) Entry {
-	details := map[string]any{}
-	for _, key := range []string{"arguments", "input", "parameters"} {
-		if value, ok := record[key]; ok {
-			details[key] = value
-		}
-	}
+func toolCallEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry {
 	return Entry{
 		ID:           id,
 		Seq:          base.Seq,
 		Continuation: base.Continuation,
 		Kind:         KindToolCall,
 		Role:         RoleAssistant,
-		ToolCallID:   firstText(record, "tool_call_id", "tool_use_id", "call_id", "id"),
-		ToolName:     toolName(record),
-		Details:      nilIfEmpty(details),
+		ToolCallID:   turn.ToolCallID,
+		ToolName:     turn.Tool,
+		Details:      turn.Details,
 		Status:       StatusCollapsed,
 		CreatedAt:    base.CreatedAt,
 	}
 }
 
-func toolResultEntry(record map[string]any, base Entry, id string) Entry {
-	details := map[string]any{}
-	for _, key := range []string{"is_error", "isError", "error"} {
-		if value, ok := record[key]; ok {
-			details[key] = value
-		}
-	}
+func toolResultEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry {
 	return Entry{
 		ID:           id,
 		Seq:          base.Seq,
 		Continuation: base.Continuation,
 		Kind:         KindToolResult,
 		Role:         RoleTool,
-		Text:         firstText(record, "output", "content", "result", "text"),
-		ToolCallID:   firstText(record, "tool_call_id", "tool_use_id", "call_id", "toolCallId", "id"),
-		ToolName:     firstText(record, "tool_name", "toolName", "name"),
-		Details:      nilIfEmpty(details),
+		Text:         turn.Output,
+		ToolCallID:   turn.ToolCallID,
+		ToolName:     turn.Tool,
+		Details:      turn.Details,
 		Status:       StatusCollapsed,
 		CreatedAt:    base.CreatedAt,
 	}
 }
 
 // IsIgnorableRuntimeLine reports whether a raw runtime stdout/stderr line is
-// provider metadata that should not be stored or shown in the task timeline.
+// provider metadata that should not be stored or shown in the task conversation transcript.
 func IsIgnorableRuntimeLine(text string) bool {
-	text = strings.TrimSpace(text)
-	if text == "" || !strings.HasPrefix(text, "{") {
-		return false
-	}
-	var record map[string]any
-	if err := json.Unmarshal([]byte(text), &record); err != nil {
-		return false
-	}
-	return isIgnorableRuntimeRecord(record)
+	return runtimeoutput.ShouldIgnoreForStorage(text)
 }
 
 func isIgnorableUnparsedRuntimeLine(text string) bool {
-	text = strings.TrimSpace(text)
-	if text == "" || !strings.HasPrefix(text, "{") {
-		return false
-	}
-	var record map[string]any
-	if err := json.Unmarshal([]byte(text), &record); err != nil {
-		return false
-	}
-	return isThinkingOnlyAssistantRecord(record)
-}
-
-func isIgnorableRuntimeRecord(record map[string]any) bool {
-	return isIgnorableSystemRecord(record) || isIgnorableRecordType(record) || isThinkingOnlyAssistantRecord(record)
-}
-
-func isIgnorableRecordType(record map[string]any) bool {
-	switch stringValue(record, "type") {
-	case "ping", "keepalive", "result":
-		return true
-	default:
-		return false
-	}
-}
-
-func isIgnorableSystemRecord(record map[string]any) bool {
-	if stringValue(record, "type") != "system" {
-		return false
-	}
-	subtype := stringValue(record, "subtype")
-	switch subtype {
-	case "thinking_tokens", "init":
-		return true
-	}
-	// Claude Code workflow telemetry: task_started, task_failed, task_progress, …
-	return strings.HasPrefix(subtype, "task_")
-}
-
-func isThinkingOnlyAssistantRecord(record map[string]any) bool {
-	if stringValue(record, "type") != "assistant" {
-		return false
-	}
-	message, ok := mapValue(record, "message")
-	if !ok {
-		return false
-	}
-	content, ok := sliceValue(message, "content")
-	if !ok || len(content) == 0 {
-		return false
-	}
-	for _, block := range content {
-		blockMap, ok := block.(map[string]any)
-		if !ok {
-			return false
-		}
-		blockType := strings.ToLower(stringValue(blockMap, "type"))
-		if blockType != "thinking" {
-			return false
-		}
-	}
-	return true
+	return runtimeoutput.IsThinkingOnlyAssistantLine(text)
 }
 
 func runtimeFallback(event task.Event, continuation int, text, stream string) Entry {
@@ -463,27 +331,6 @@ func runtimeFallback(event task.Event, continuation int, text, stream string) En
 		Status:       StatusCollapsed,
 		CreatedAt:    event.CreatedAt,
 	}
-}
-
-func roleFromType(recordType string) string {
-	switch recordType {
-	case "user":
-		return RoleUser
-	case "system":
-		return RoleSystem
-	default:
-		return RoleAssistant
-	}
-}
-
-func toolName(record map[string]any) string {
-	if name := firstText(record, "name", "tool_name"); name != "" {
-		return name
-	}
-	if function, ok := mapValue(record, "function"); ok {
-		return firstText(function, "name")
-	}
-	return ""
 }
 
 func firstText(record map[string]any, keys ...string) string {
@@ -578,9 +425,4 @@ func nilIfEmpty(values map[string]any) map[string]any {
 	return values
 }
 
-func indexedID(base, suffix, index string) string {
-	if index == "" {
-		return base + suffix
-	}
-	return base + suffix + "-" + index
-}
+


### PR DESCRIPTION
## Summary

Extracts duplicated runtime stdout/stderr parsing from `internal/transcript` and `internal/timeline` into a new `internal/runtimeoutput` package.

- **Ignore rules**: `ShouldIgnoreForStorage` (transcript) vs `ShouldIgnoreForTimeline` (keeps thinking-only assistant lines)
- **Parse core**: `ParseLine` / `ParseRecord` emit normalized `Turn` values with `ParseOptions` for thinking/errors
- **Streaming**: `CoalesceStreaming` merges adjacent thinking/text fragments
- **Consumers**: transcript maps `Turn` → `Entry`; timeline maps `Turn` → `Item`

## Test plan

- [x] `go test ./internal/runtimeoutput/...`
- [x] `go test ./internal/transcript/... ./internal/timeline/... ./internal/runtime/...`