### PR TITLE
test: runtimeoutput parity + ingest decouple

### DIFF
--- a/internal/runtime/output_reader.go
+++ b/internal/runtime/output_reader.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"pentest/internal/adapters"
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/task"
-	"pentest/internal/transcript"
 )
 
 // maxRuntimeOutputLineBytes matches multica's codex stdout scanner cap so a
@@ -69,7 +69,7 @@ func ScanOutput(reader io.Reader, stream string, maxLineBytes int, emit func(tas
 	for {
 		line, truncated, err := ReadBoundedLine(br, maxLineBytes)
 		if line != "" {
-			if !transcript.IsIgnorableRuntimeLine(line) {
+			if !runtimeoutput.ShouldIgnoreForStorage(line) {
 				payload := task.EventPayload{
 					"stream": stream,
 					"text":   line,

--- a/internal/runtime/output_reader_test.go
+++ b/internal/runtime/output_reader_test.go
@@ -60,6 +60,22 @@ func TestScanOutputEmitsTruncatedLineAndKeepsReading(t *testing.T) {
 	}
 }
 
+func TestScanOutputDropsIgnorableProviderNoise(t *testing.T) {
+	payload := `{"type":"system","subtype":"thinking_tokens","estimated_tokens":13}` + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Visible."}]}}` + "\n"
+	var emitted []task.EventPayload
+	runtime.ScanOutput(bytes.NewReader([]byte(payload)), "stdout", 1024, func(_ task.EventKind, payload task.EventPayload) {
+		emitted = append(emitted, payload)
+	})
+
+	if len(emitted) != 1 {
+		t.Fatalf("expected 1 stored line, got %d: %#v", len(emitted), emitted)
+	}
+	if text, _ := emitted[0]["text"].(string); !strings.Contains(text, "Visible.") {
+		t.Fatalf("expected visible assistant text, got %#v", emitted[0])
+	}
+}
+
 func TestReadBoundedLineReturnsEOFWithoutErrorForEmptyStream(t *testing.T) {
 	line, truncated, err := runtime.ReadBoundedLine(bufio.NewReader(strings.NewReader("")), 1024)
 	if err != io.EOF || truncated || line != "" {

--- a/internal/runtime/pi_session_tail.go
+++ b/internal/runtime/pi_session_tail.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/task"
-	"pentest/internal/transcript"
 )
 
 // piSessionTailAdapter wraps a runtime Adapter and, in parallel with the
@@ -89,7 +89,7 @@ func tailPiSession(ctx context.Context, sessionDir string, emit func(task.EventK
 			line, err := reader.ReadString('\n')
 			if len(line) > 0 {
 				offset += int64(len(line))
-				if trimmed := strings.TrimRight(line, "\n"); trimmed != "" && !transcript.IsIgnorableRuntimeLine(trimmed) {
+				if trimmed := strings.TrimRight(line, "\n"); trimmed != "" && !runtimeoutput.ShouldIgnoreForStorage(trimmed) {
 					emit(task.EventKindRuntimeOutput, task.EventPayload{
 						"stream": "pi_session",
 						"text":   trimmed,

--- a/internal/runtimeoutput/parity_test.go
+++ b/internal/runtimeoutput/parity_test.go
@@ -1,0 +1,116 @@
+package runtimeoutput_test
+
+import (
+	"testing"
+	"time"
+
+	"pentest/internal/task"
+	"pentest/internal/timeline"
+	"pentest/internal/transcript"
+)
+
+type semanticStep struct {
+	kind   string
+	text   string
+	tool   string
+	output string
+}
+
+func transcriptSteps(entries []transcript.Entry) []semanticStep {
+	out := make([]semanticStep, 0, len(entries))
+	for _, entry := range entries {
+		switch entry.Kind {
+		case transcript.KindMessage:
+			if entry.Role == transcript.RoleAssistant && entry.Text != "" {
+				out = append(out, semanticStep{kind: "text", text: entry.Text})
+			}
+		case transcript.KindToolCall:
+			out = append(out, semanticStep{kind: "tool_use", tool: entry.ToolName})
+		case transcript.KindToolResult:
+			out = append(out, semanticStep{kind: "tool_result", tool: entry.ToolName, output: entry.Text})
+		}
+	}
+	return out
+}
+
+func timelineSteps(items []timeline.Item) []semanticStep {
+	out := make([]semanticStep, 0, len(items))
+	for _, item := range items {
+		switch item.Type {
+		case "thinking":
+			continue
+		case "text":
+			out = append(out, semanticStep{kind: "text", text: item.Content})
+		case "tool_use":
+			out = append(out, semanticStep{kind: "tool_use", tool: item.Tool})
+		case "tool_result":
+			out = append(out, semanticStep{kind: "tool_result", tool: item.Tool, output: item.Output})
+		case "error":
+			out = append(out, semanticStep{kind: "error", text: item.Content})
+		}
+	}
+	return out
+}
+
+func assertSemanticParity(t *testing.T, gotTranscript, gotTimeline []semanticStep) {
+	t.Helper()
+	if len(gotTranscript) != len(gotTimeline) {
+		t.Fatalf("step count mismatch: transcript=%#v timeline=%#v", gotTranscript, gotTimeline)
+	}
+	for i := range gotTranscript {
+		if gotTranscript[i] != gotTimeline[i] {
+			t.Fatalf("step[%d] mismatch: transcript=%#v timeline=%#v", i, gotTranscript[i], gotTimeline[i])
+		}
+	}
+}
+
+func TestTranscriptTimelineParityClaudeAssistantFlow(t *testing.T) {
+	createdAt := time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC)
+	subject := task.Task{ID: "task-1", Goal: "Recon", CreatedAt: createdAt}
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindLifecycle, Payload: task.EventPayload{"phase": "started", "adapter": "claude_code"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"system","subtype":"init","session_id":"abc"}`}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan recon"}]}}`}, CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "ev-4", Seq: 4, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"curl example.com"}}]}}`}, CreatedAt: createdAt.Add(3 * time.Second)},
+		{ID: "ev-5", Seq: 5, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"200 OK"}]}}`}, CreatedAt: createdAt.Add(4 * time.Second)},
+		{ID: "ev-6", Seq: 6, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"text","text":"Done inspecting."}]}}`}, CreatedAt: createdAt.Add(5 * time.Second)},
+	}
+
+	transcriptEntries := transcript.Build(subject, events)
+	timelineItems := timeline.Build(events)
+
+	assertSemanticParity(t, transcriptSteps(transcriptEntries), timelineSteps(timelineItems))
+}
+
+func TestTranscriptTimelineParityOpenAIToolFlow(t *testing.T) {
+	createdAt := time.Now().UTC()
+	subject := task.Task{ID: "task-1", Goal: "Do work", CreatedAt: createdAt}
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindLifecycle, Payload: task.EventPayload{"phase": "started", "adapter": "pi"}},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"tool_call","id":"call-1","name":"curl","arguments":{"url":"http://127.0.0.1:3000"}}`}},
+		{ID: "ev-3", Seq: 3, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"tool_result","tool_call_id":"call-1","output":"OK"}`}},
+	}
+
+	transcriptEntries := transcript.Build(subject, events)
+	timelineItems := timeline.Build(events)
+
+	assertSemanticParity(t, transcriptSteps(transcriptEntries), timelineSteps(timelineItems))
+}
+
+func TestTranscriptTimelineParityDropsSharedNoise(t *testing.T) {
+	events := []task.Event{
+		{ID: "ev-0", Seq: 0, Kind: task.EventKindLifecycle, Payload: task.EventPayload{"phase": "started", "adapter": "claude_code"}},
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"system","subtype":"thinking_tokens","estimated_tokens":13}`}},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"system","subtype":"task_progress","description":"Exploit"}`}},
+		{ID: "ev-3", Seq: 3, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"text","text":"Visible."}]}}`}},
+	}
+
+	subject := task.Task{ID: "task-1", Goal: "Do work", CreatedAt: time.Now().UTC()}
+	transcriptEntries := transcript.Build(subject, events)
+	timelineItems := timeline.Build(events)
+
+	assertSemanticParity(t, transcriptSteps(transcriptEntries), timelineSteps(timelineItems))
+	if len(timelineSteps(timelineItems)) != 1 || timelineSteps(timelineItems)[0].text != "Visible." {
+		t.Fatalf("expected one visible text step, got %#v", timelineSteps(timelineItems))
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #19:

- **Parity tests** — same stored runtime events produce matching non-thinking steps in `transcript.Build` and `timeline.Build` (Claude flow, OpenAI tools, shared noise drop)
- **Ingest decouple** — `output_reader` and `pi_session_tail` call `runtimeoutput.ShouldIgnoreForStorage` directly instead of `transcript.IsIgnorableRuntimeLine`
- **Ingest test** — `ScanOutput` drops `thinking_tokens` noise before emit

## Test plan

- [x] `go test ./internal/runtimeoutput/... ./internal/runtime/...`