### PR TITLE
Complete interrupt steer native resume lifecycle

### DIFF
--- a/internal/adapters/adapters.go
+++ b/internal/adapters/adapters.go
@@ -35,6 +35,13 @@ type LaunchArgsRequest struct {
 	Sandbox bool
 }
 
+type NativeResumeArgsRequest struct {
+	Provider        runtimeprofile.Provider
+	Profile         runtimeprofile.Profile
+	NativeSessionID string
+	ResumedMessage  string
+}
+
 // BuildLaunchArgs constructs the command-line arguments a real runtime would
 // receive, derived from the structured profile fields and task goal. It never
 // embeds resolved secret values — credential references are resolved by the
@@ -55,6 +62,38 @@ func BuildLaunchArgs(req LaunchArgsRequest) ([]string, error) {
 	}
 
 	return runtimeplugin.RenderLaunch(plugin.Launch, launchRenderContext(req, binary))
+}
+
+func BuildNativeResumeArgs(req NativeResumeArgsRequest) ([]string, error) {
+	registry := runtimeplugin.MustBuiltinRegistry()
+	plugin, ok := registry.Get(string(req.Provider))
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider %q", req.Provider)
+	}
+	if !plugin.NativeResume.Supported {
+		return nil, fmt.Errorf("native resume unsupported for provider %q", req.Provider)
+	}
+	if strings.TrimSpace(req.NativeSessionID) == "" {
+		return nil, fmt.Errorf("native resume requires a native session id")
+	}
+	binary := strings.TrimSpace(req.Profile.Fields.BinaryPath)
+	if binary == "" {
+		binary = strings.TrimSpace(plugin.Binary.Default)
+	}
+	if binary == "" {
+		return nil, fmt.Errorf("no binary path configured for provider %q", req.Provider)
+	}
+	return runtimeplugin.RenderLaunch(runtimeplugin.LaunchTemplate{Args: plugin.NativeResume.Args}, runtimeplugin.RenderContext{
+		Scalars: map[string]string{
+			"binary":          binary,
+			"model":           strings.TrimSpace(req.Profile.Fields.Model),
+			"native_session":  strings.TrimSpace(req.NativeSessionID),
+			"resumed_message": req.ResumedMessage,
+		},
+		Lists: map[string][]string{
+			"custom_args": append([]string{}, req.Profile.Fields.CustomArgs...),
+		},
+	})
 }
 
 func hasCLIOption(args []string, option string) bool {

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -1,6 +1,7 @@
 package adapters_test
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -103,6 +104,39 @@ func TestBuildCodexLaunchArgsDoesNotDuplicateExplicitSkipGitRepoCheck(t *testing
 
 	if strings.Count(strings.Join(args, " "), "--skip-git-repo-check") != 1 {
 		t.Fatalf("expected one --skip-git-repo-check, got %#v", args)
+	}
+}
+
+func TestBuildNativeResumeArgsUsesRuntimePluginContract(t *testing.T) {
+	args, err := adapters.BuildNativeResumeArgs(adapters.NativeResumeArgsRequest{
+		Provider: runtimeprofile.ProviderCodex,
+		Profile: runtimeprofile.Profile{
+			Provider: runtimeprofile.ProviderCodex,
+			Fields: runtimeprofile.Fields{
+				BinaryPath: "/usr/local/bin/codex",
+				Model:      "gpt-5",
+			},
+		},
+		NativeSessionID: "sess-123",
+		ResumedMessage:  "focus admin",
+	})
+	if err != nil {
+		t.Fatalf("build native resume args: %v", err)
+	}
+	want := []string{"/usr/local/bin/codex", "--model", "gpt-5", "resume", "sess-123", "focus admin"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("unexpected native resume args:\nwant %#v\ngot  %#v", want, args)
+	}
+}
+
+func TestBuildNativeResumeArgsRejectsUnsupportedRuntime(t *testing.T) {
+	_, err := adapters.BuildNativeResumeArgs(adapters.NativeResumeArgsRequest{
+		Provider:        runtimeprofile.ProviderClaudeCode,
+		Profile:         runtimeprofile.Profile{Provider: runtimeprofile.ProviderClaudeCode},
+		NativeSessionID: "sess-123",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("expected unsupported native resume error, got %v", err)
 	}
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"pentest/internal/approval"
@@ -78,6 +79,8 @@ type Server struct {
 	containerCLI      string
 	listenAddr        string
 	tempSkillsRoot    string
+	controlMu         sync.Mutex
+	activeControls    map[string]bool
 }
 
 func NewServer(config Config) (*Server, error) {
@@ -149,15 +152,16 @@ func NewServer(config Config) (*Server, error) {
 		preflight: preflight.NewService(profiles, creds, skills).
 			WithModelProviders(modelProviders, runtimePlugins).
 			WithRuntimeExtensions(runtimeExtensions),
-		tasks:             tasks,
-		harness:           runtime.NewHarness(tasks),
-		facts:             blackboard.NewService(db),
-		approvals:         approval.NewService(db),
-		runtimeRoot:       runtimeRoot,
-		sandboxImage:      config.SandboxImage,
-		containerCLI:      config.ContainerCLI,
-		listenAddr:        listenAddr,
-		tempSkillsRoot:    tempSkillsRoot,
+		tasks:          tasks,
+		harness:        runtime.NewHarness(tasks),
+		facts:          blackboard.NewService(db),
+		approvals:      approval.NewService(db),
+		runtimeRoot:    runtimeRoot,
+		sandboxImage:   config.SandboxImage,
+		containerCLI:   config.ContainerCLI,
+		listenAddr:     listenAddr,
+		tempSkillsRoot: tempSkillsRoot,
+		activeControls: map[string]bool{},
 	}
 	if server.logger == nil {
 		server.logger = log.Default()
@@ -294,6 +298,8 @@ func (server *Server) routes() {
 	server.mux.HandleFunc("GET /api/projects/{id}/tasks/{task_id}/timeline", server.handleTaskTimeline)
 	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/stop", server.handleStopTask)
 	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/resume", server.handleResumeTask)
+	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/resume/handoff", server.handleResumeHandoffTask)
+	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/steer/queue", server.handleQueueSteerTask)
 	server.mux.HandleFunc("POST /api/projects/{id}/tasks/{task_id}/steer", server.handleSteerTask)
 	server.mux.HandleFunc("GET /api/projects/{id}/tasks/{task_id}/continuation", server.handleTaskContinuation)
 	server.mux.HandleFunc("PUT /api/projects/{id}/tasks/{task_id}/summary", server.handlePutTaskSummary)

--- a/internal/daemon/task_adapter_error_test.go
+++ b/internal/daemon/task_adapter_error_test.go
@@ -40,7 +40,7 @@ func TestResumeTaskSurfacesAdapterPrepareError(t *testing.T) {
 	proj := createAdapterErrorTestProject(t, server)
 	created := createAdapterErrorTestTask(t, server, proj.ID, profile.ID)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+proj.ID+"/tasks/"+created.ID+"/resume", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+proj.ID+"/tasks/"+created.ID+"/resume/handoff", nil)
 	resp := httptest.NewRecorder()
 	server.ServeHTTP(resp, req)
 

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -24,6 +25,11 @@ import (
 	"pentest/internal/task"
 	"pentest/internal/timeline"
 	"pentest/internal/transcript"
+)
+
+var (
+	errNativeResumeUnavailable  = errors.New("native resume unavailable")
+	errNativeSessionUnavailable = errors.New("native session unavailable")
 )
 
 func (server *Server) handleCreateTask(response http.ResponseWriter, request *http.Request) {
@@ -303,8 +309,16 @@ func (server *Server) buildTaskLaunchPlan(created task.Task, goal string, launch
 	if err != nil {
 		return taskLaunchPlan{}, err
 	}
-	if nativeResumeSessionID != "" && profile.Provider == runtimeprofile.ProviderCodex {
-		providerCommand = buildCodexResumeCommand(providerCommand[0], strings.TrimSpace(launchProfile.Fields.Model), nativeResumeSessionID, goal)
+	if nativeResumeSessionID != "" {
+		providerCommand, err = adapters.BuildNativeResumeArgs(adapters.NativeResumeArgsRequest{
+			Provider:        profile.Provider,
+			Profile:         launchProfile,
+			NativeSessionID: nativeResumeSessionID,
+			ResumedMessage:  goal,
+		})
+		if err != nil {
+			return taskLaunchPlan{}, err
+		}
 	}
 
 	runtimeCommand := append([]string{}, providerCommand...)
@@ -386,13 +400,22 @@ func (server *Server) buildTaskLaunchPlan(created task.Task, goal string, launch
 		"args":    commandArgs,
 	})
 
-	adapter := runtime.NewCommandAdapter(runtime.CommandAdapterConfig{
-		Name:    string(profile.Provider),
-		Program: commandProgram,
-		Args:    commandArgs,
-		Workdir: workdir,
-		Env:     processEnv,
-	})
+	var adapter runtime.Adapter
+	if sandbox {
+		adapter = runtime.NewDockerSandboxAdapter(runtime.DockerSandboxConfig{
+			Name:         string(profile.Provider),
+			ContainerCLI: commandProgram,
+			CreateArgs:   commandArgs,
+		})
+	} else {
+		adapter = runtime.NewCommandAdapter(runtime.CommandAdapterConfig{
+			Name:    string(profile.Provider),
+			Program: commandProgram,
+			Args:    commandArgs,
+			Workdir: workdir,
+			Env:     processEnv,
+		})
+	}
 
 	// Pi writes its real-time progress to a session jsonl file instead of
 	// stdout, so a sandboxed Pi task's timeline is empty until it exits. Wrap
@@ -436,18 +459,6 @@ func (server *Server) buildTaskLaunchPlan(created task.Task, goal string, launch
 		Metadata:         metadata,
 		StopConfirmation: stopConfirmation,
 	}, nil
-}
-
-func buildCodexResumeCommand(binary string, model string, sessionID string, goal string) []string {
-	command := []string{binary}
-	if strings.TrimSpace(model) != "" {
-		command = append(command, "--model", strings.TrimSpace(model))
-	}
-	command = append(command, "resume", sessionID)
-	if strings.TrimSpace(goal) != "" {
-		command = append(command, goal)
-	}
-	return command
 }
 
 func sandboxNetworkMode(runControls task.RunControls) runner.SandboxNetworkMode {
@@ -540,9 +551,44 @@ func (server *Server) decorateTask(found task.Task) (task.Task, error) {
 	if err != nil {
 		return task.Task{}, err
 	}
+	controls, err := server.runtimeControlsForTask(found, latest)
+	if err != nil {
+		return task.Task{}, err
+	}
+	found.RuntimeControls = controls
 	found.ActiveContinuation = active
 	found.LatestContinuation = latest
 	return found, nil
+}
+
+func (server *Server) runtimeControlsForTask(found task.Task, latest *task.TaskContinuation) (task.RuntimeControls, error) {
+	profile, err := server.resolveTaskRuntimeProfile(found)
+	if err != nil {
+		return task.RuntimeControls{}, err
+	}
+	plugin, ok := server.runtimePlugins.Get(string(profile.Provider))
+	nativeResumeSupported := ok && plugin.NativeResume.Supported
+	active := found.Status == task.StatusRunning || found.Status == task.StatusPaused
+	sessionCaptured := latest != nil && strings.TrimSpace(latest.NativeSessionID) != ""
+
+	controls := task.RuntimeControls{
+		HandoffResumeAvailable:  !active,
+		QueueSteerAvailable:     true,
+		NativeSessionCaptured:   sessionCaptured,
+		SameRuntimeProviderOnly: true,
+		RuntimeProvider:         string(profile.Provider),
+	}
+	if nativeResumeSupported {
+		controls.NativeResumeAvailable = !active && sessionCaptured
+		controls.InterruptSteerAvailable = active
+	} else {
+		controls.NativeResumeReason = fmt.Sprintf("native resume unsupported for provider %s", profile.Provider)
+		controls.InterruptSteerReason = controls.NativeResumeReason
+	}
+	if nativeResumeSupported && !sessionCaptured {
+		controls.NativeResumeReason = "native session unavailable"
+	}
+	return controls, nil
 }
 
 func (server *Server) handleTaskEvents(response http.ResponseWriter, request *http.Request) {
@@ -635,13 +681,41 @@ func (server *Server) handleStopTask(response http.ResponseWriter, request *http
 		return
 	}
 
-	server.harness.Stop(taskID)
+	if found.Status == task.StatusRunning || found.Status == task.StatusPaused {
+		if ok := server.harness.StopAndWait(taskID, 10*time.Second); !ok {
+			writeError(response, http.StatusConflict, "runtime did not stop in time")
+			return
+		}
+		stopped, err := server.taskDetail(taskID)
+		if err != nil {
+			writeTaskError(response, err)
+			return
+		}
+		writeJSON(response, http.StatusOK, stopped)
+		return
+	}
 	stopped, err := server.tasks.UpdateStatus(taskID, task.StatusStopped)
 	if err != nil {
 		writeTaskError(response, err)
 		return
 	}
 	writeJSON(response, http.StatusOK, stopped)
+}
+
+func (server *Server) acquireTaskControl(taskID string) bool {
+	server.controlMu.Lock()
+	defer server.controlMu.Unlock()
+	if server.activeControls[taskID] {
+		return false
+	}
+	server.activeControls[taskID] = true
+	return true
+}
+
+func (server *Server) releaseTaskControl(taskID string) {
+	server.controlMu.Lock()
+	defer server.controlMu.Unlock()
+	delete(server.activeControls, taskID)
 }
 
 func (server *Server) handleResumeTask(response http.ResponseWriter, request *http.Request) {
@@ -668,7 +742,12 @@ func (server *Server) handleResumeTask(response http.ResponseWriter, request *ht
 		writeError(response, http.StatusConflict, "task is already running")
 		return
 	}
-	found, resumeGoal, plan, err := server.prepareResumeContinuation(found)
+	if !server.acquireTaskControl(taskID) {
+		writeError(response, http.StatusConflict, "task control operation already active")
+		return
+	}
+	defer server.releaseTaskControl(taskID)
+	found, resumeGoal, plan, err := server.prepareNativeResumeContinuation(found, "")
 	if err != nil {
 		server.writeResumePreparationError(response, err)
 		return
@@ -687,7 +766,7 @@ func (server *Server) handleResumeTask(response http.ResponseWriter, request *ht
 		ProjectID: projectID,
 		TaskID:    found.ID,
 		Kind:      "task_resumed",
-		Summary:   "task resumed with mechanical handoff",
+		Summary:   "task resumed with native session",
 		Payload: map[string]any{
 			"task_id": found.ID,
 			"runner":  found.Runner,
@@ -705,7 +784,86 @@ func (server *Server) handleResumeTask(response http.ResponseWriter, request *ht
 	writeJSON(response, http.StatusAccepted, updated)
 }
 
-func (server *Server) prepareResumeContinuation(found task.Task) (task.Task, string, taskLaunchPlan, error) {
+func (server *Server) handleResumeHandoffTask(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	taskID := request.PathValue("task_id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	if taskID == "" {
+		writeError(response, http.StatusNotFound, "task not found")
+		return
+	}
+	found, err := server.tasks.Get(taskID)
+	if err != nil {
+		writeTaskError(response, err)
+		return
+	}
+	if found.ProjectID != projectID {
+		writeError(response, http.StatusNotFound, "task not found")
+		return
+	}
+	if server.harness.IsActive(taskID) || found.Status == task.StatusRunning {
+		writeError(response, http.StatusConflict, "task is already running")
+		return
+	}
+	if !server.acquireTaskControl(taskID) {
+		writeError(response, http.StatusConflict, "task control operation already active")
+		return
+	}
+	defer server.releaseTaskControl(taskID)
+	found, resumeGoal, plan, err := server.prepareHandoffResumeContinuation(found)
+	if err != nil {
+		server.writeResumePreparationError(response, err)
+		return
+	}
+	if _, err := server.tasks.RecordRuntimeConfig(found.ID, found.RuntimeProfileID, plan.RuntimeConfig); err != nil {
+		writeError(response, http.StatusInternalServerError, "record task runtime configuration")
+		return
+	}
+	if err := server.launchTaskInBackground(found, plan, resumeGoal); err != nil {
+		writeError(response, http.StatusInternalServerError, "create task continuation")
+		return
+	}
+	if _, err := server.approvals.RecordAudit(approval.AuditEntry{
+		ProjectID: projectID,
+		TaskID:    found.ID,
+		Kind:      "task_resumed",
+		Summary:   "task resumed with mechanical handoff",
+		Payload: map[string]any{
+			"task_id": found.ID,
+			"runner":  found.Runner,
+		},
+	}); err != nil {
+		writeError(response, http.StatusInternalServerError, "record task audit")
+		return
+	}
+	updated, err := server.taskDetail(found.ID)
+	if err != nil {
+		writeTaskError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusAccepted, updated)
+}
+
+func (server *Server) prepareNativeResumeContinuation(found task.Task, resumedMessage string) (task.Task, string, taskLaunchPlan, error) {
+	effectiveProfile, err := server.resolveTaskRuntimeProfile(found)
+	if err != nil {
+		return task.Task{}, "", taskLaunchPlan{}, err
+	}
+	found.RuntimeProfileID = effectiveProfile.ID
+	nativeResumeSessionID, err := server.discoverNativeResumeSession(found)
+	if err != nil {
+		return task.Task{}, "", taskLaunchPlan{}, err
+	}
+	plan, err := server.buildTaskLaunchPlan(found, resumedMessage, "", nativeResumeSessionID)
+	if err != nil {
+		return task.Task{}, "", taskLaunchPlan{}, err
+	}
+	return found, resumedMessage, plan, nil
+}
+
+func (server *Server) prepareHandoffResumeContinuation(found task.Task) (task.Task, string, taskLaunchPlan, error) {
 	effectiveProfile, err := server.resolveTaskRuntimeProfile(found)
 	if err != nil {
 		return task.Task{}, "", taskLaunchPlan{}, err
@@ -716,11 +874,7 @@ func (server *Server) prepareResumeContinuation(found task.Task) (task.Task, str
 	if err != nil {
 		return task.Task{}, "", taskLaunchPlan{}, err
 	}
-	nativeResumeSessionID, err := server.discoverNativeResumeSession(found)
-	if err != nil {
-		return task.Task{}, "", taskLaunchPlan{}, err
-	}
-	plan, err := server.buildTaskLaunchPlan(found, resumeGoal, "", nativeResumeSessionID)
+	plan, err := server.buildTaskLaunchPlan(found, resumeGoal, "", "")
 	if err != nil {
 		return task.Task{}, "", taskLaunchPlan{}, err
 	}
@@ -797,9 +951,76 @@ func (server *Server) writeResumePreparationError(response http.ResponseWriter, 
 	switch {
 	case errors.Is(err, runtimeprofile.ErrNotFound):
 		writeError(response, http.StatusBadRequest, "runtime profile not found")
+	case errors.Is(err, errNativeResumeUnavailable):
+		writeError(response, http.StatusBadRequest, err.Error())
+	case errors.Is(err, errNativeSessionUnavailable):
+		writeError(response, http.StatusConflict, err.Error())
 	default:
 		writeTaskAdapterError(response, err)
 	}
+}
+
+func (server *Server) handleQueueSteerTask(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	taskID := request.PathValue("task_id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	if taskID == "" {
+		writeError(response, http.StatusNotFound, "task not found")
+		return
+	}
+	found, err := server.tasks.Get(taskID)
+	if err != nil {
+		writeTaskError(response, err)
+		return
+	}
+	if found.ProjectID != projectID {
+		writeError(response, http.StatusNotFound, "task not found")
+		return
+	}
+	var input struct {
+		Directive        string         `json:"directive"`
+		RuntimeProfileID string         `json:"runtime_profile_id"`
+		SubmittedBy      string         `json:"submitted_by"`
+		Config           map[string]any `json:"config"`
+	}
+	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+		writeError(response, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(input.Directive) == "" {
+		writeError(response, http.StatusBadRequest, "steering directive is required")
+		return
+	}
+	payload := task.EventPayload{
+		"directive": input.Directive,
+		"phase":     "steering_requested",
+		"mode":      "queue",
+	}
+	if input.SubmittedBy != "" {
+		payload["submitted_by"] = input.SubmittedBy
+	}
+	if input.RuntimeProfileID != "" {
+		payload["runtime_profile_id"] = input.RuntimeProfileID
+	}
+	event, err := server.tasks.AppendEvent(taskID, task.EventKindSteering, payload)
+	if err != nil {
+		writeTaskError(response, err)
+		return
+	}
+	var configVersion *task.RuntimeConfigVersion
+	if input.RuntimeProfileID != "" {
+		recorded, ok := server.recordSteeredRuntimeConfig(response, found, event.ID, input.RuntimeProfileID, input.Config)
+		if !ok {
+			return
+		}
+		configVersion = &recorded
+	}
+	writeJSON(response, http.StatusOK, struct {
+		Event                task.Event                 `json:"event"`
+		RuntimeConfigVersion *task.RuntimeConfigVersion `json:"runtime_config_version,omitempty"`
+	}{Event: event, RuntimeConfigVersion: configVersion})
 }
 
 func (server *Server) handleSteerTask(response http.ResponseWriter, request *http.Request) {
@@ -838,8 +1059,18 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 		return
 	}
 
+	activeSteer := found.Status == task.StatusRunning || found.Status == task.StatusPaused
+	if activeSteer {
+		if !server.acquireTaskControl(taskID) {
+			writeError(response, http.StatusConflict, "task control operation already active")
+			return
+		}
+		defer server.releaseTaskControl(taskID)
+	}
+
 	payload := task.EventPayload{
 		"directive": input.Directive,
+		"phase":     "steering_requested",
 	}
 	if input.SubmittedBy != "" {
 		payload["submitted_by"] = input.SubmittedBy
@@ -856,46 +1087,21 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 
 	var configVersion *task.RuntimeConfigVersion
 	if input.RuntimeProfileID != "" {
-		currentProfile, err := server.resolveTaskRuntimeProfile(found)
-		if err != nil {
-			if errors.Is(err, runtimeprofile.ErrNotFound) {
-				writeError(response, http.StatusBadRequest, "runtime profile not found")
-				return
-			}
-			writeError(response, http.StatusInternalServerError, "load runtime profile")
-			return
-		}
-		requestedProfile, err := server.profiles.Get(input.RuntimeProfileID)
-		if err != nil {
-			if errors.Is(err, runtimeprofile.ErrNotFound) {
-				writeError(response, http.StatusBadRequest, "runtime profile not found")
-				return
-			}
-			writeError(response, http.StatusInternalServerError, "load runtime profile")
-			return
-		}
-		if requestedProfile.Provider != currentProfile.Provider {
-			writeError(response, http.StatusBadRequest, "steering runtime profile must keep the same runtime provider")
-			return
-		}
-
-		config := input.Config
-		if config == nil {
-			config = map[string]any{}
-		}
-		config["runtime_profile_id"] = input.RuntimeProfileID
-		config["runner"] = found.Runner
-		config["steering_event_id"] = event.ID
-		recorded, err := server.tasks.RecordRuntimeConfig(taskID, input.RuntimeProfileID, config)
-		if err != nil {
-			writeTaskError(response, err)
+		recorded, ok := server.recordSteeredRuntimeConfig(response, found, event.ID, input.RuntimeProfileID, input.Config)
+		if !ok {
 			return
 		}
 		configVersion = &recorded
 	}
 
-	if found.Status == task.StatusRunning || found.Status == task.StatusPaused {
+	if activeSteer {
+		_, _ = server.tasks.AppendEvent(taskID, task.EventKindLifecycle, task.EventPayload{
+			"phase": "interrupting",
+		})
 		if ok := server.harness.StopAndWait(taskID, 10*time.Second); !ok {
+			_, _ = server.tasks.AppendEvent(taskID, task.EventKindLifecycle, task.EventPayload{
+				"phase": "stop_failed",
+			})
 			writeError(response, http.StatusConflict, "runtime did not stop in time")
 			return
 		}
@@ -905,8 +1111,12 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 			writeTaskError(response, err)
 			return
 		}
-		resumedTask, resumeGoal, plan, err := server.prepareResumeContinuation(refreshed)
+		resumedTask, resumeGoal, plan, err := server.prepareNativeResumeContinuation(refreshed, input.Directive)
 		if err != nil {
+			_, _ = server.tasks.AppendEvent(taskID, task.EventKindLifecycle, task.EventPayload{
+				"phase": "resume_failed",
+				"error": err.Error(),
+			})
 			server.writeResumePreparationError(response, err)
 			return
 		}
@@ -914,10 +1124,18 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 			writeError(response, http.StatusInternalServerError, "record task runtime configuration")
 			return
 		}
+		_, _ = server.tasks.AppendEvent(taskID, task.EventKindLifecycle, task.EventPayload{
+			"phase": "resuming_native",
+		})
 		if err := server.launchTaskInBackground(resumedTask, plan, resumeGoal); err != nil {
 			writeError(response, http.StatusInternalServerError, "create task continuation")
 			return
 		}
+		_, _ = server.tasks.AppendEvent(taskID, task.EventKindSteering, task.EventPayload{
+			"phase":              "steering_applied",
+			"directive":          input.Directive,
+			"requested_event_id": event.ID,
+		})
 		detailed, err := server.taskDetail(taskID)
 		if err != nil {
 			writeTaskError(response, err)
@@ -944,6 +1162,44 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 	})
 }
 
+func (server *Server) recordSteeredRuntimeConfig(response http.ResponseWriter, found task.Task, steeringEventID string, runtimeProfileID string, config map[string]any) (task.RuntimeConfigVersion, bool) {
+	currentProfile, err := server.resolveTaskRuntimeProfile(found)
+	if err != nil {
+		if errors.Is(err, runtimeprofile.ErrNotFound) {
+			writeError(response, http.StatusBadRequest, "runtime profile not found")
+			return task.RuntimeConfigVersion{}, false
+		}
+		writeError(response, http.StatusInternalServerError, "load runtime profile")
+		return task.RuntimeConfigVersion{}, false
+	}
+	requestedProfile, err := server.profiles.Get(runtimeProfileID)
+	if err != nil {
+		if errors.Is(err, runtimeprofile.ErrNotFound) {
+			writeError(response, http.StatusBadRequest, "runtime profile not found")
+			return task.RuntimeConfigVersion{}, false
+		}
+		writeError(response, http.StatusInternalServerError, "load runtime profile")
+		return task.RuntimeConfigVersion{}, false
+	}
+	if requestedProfile.Provider != currentProfile.Provider {
+		writeError(response, http.StatusBadRequest, "steering runtime profile must keep the same runtime provider")
+		return task.RuntimeConfigVersion{}, false
+	}
+
+	if config == nil {
+		config = map[string]any{}
+	}
+	config["runtime_profile_id"] = runtimeProfileID
+	config["runner"] = found.Runner
+	config["steering_event_id"] = steeringEventID
+	recorded, err := server.tasks.RecordRuntimeConfig(found.ID, runtimeProfileID, config)
+	if err != nil {
+		writeTaskError(response, err)
+		return task.RuntimeConfigVersion{}, false
+	}
+	return recorded, true
+}
+
 func (server *Server) resolveTaskRuntimeProfile(found task.Task) (runtimeprofile.Profile, error) {
 	profileID := found.RuntimeProfileID
 	versions, err := server.tasks.RuntimeConfigVersions(found.ID)
@@ -964,8 +1220,16 @@ func (server *Server) discoverNativeResumeSession(found task.Task) (string, erro
 	if err != nil {
 		return "", err
 	}
-	if profile.Provider != runtimeprofile.ProviderCodex {
-		return "", nil
+	plugin, ok := server.runtimePlugins.Get(string(profile.Provider))
+	if !ok || !plugin.NativeResume.Supported {
+		return "", fmt.Errorf("%w for provider %s", errNativeResumeUnavailable, profile.Provider)
+	}
+	latest, err := server.tasks.LatestContinuation(found.ID)
+	if err != nil {
+		return "", err
+	}
+	if latest != nil && strings.TrimSpace(latest.NativeSessionID) != "" {
+		return latest.NativeSessionID, nil
 	}
 	layout, err := runner.PrepareTaskLayout(server.runtimeRoot, found.ID, profile.Provider)
 	if err != nil {
@@ -974,6 +1238,9 @@ func (server *Server) discoverNativeResumeSession(found task.Task) (string, erro
 	metadata, err := runtime.DiscoverCodexSession(layout.ProviderHome)
 	if err != nil {
 		return "", err
+	}
+	if strings.TrimSpace(metadata.NativeSessionID) == "" {
+		return "", errNativeSessionUnavailable
 	}
 	return metadata.NativeSessionID, nil
 }

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -116,6 +116,7 @@ func TestGetTaskIncludesLatestContinuation(t *testing.T) {
 		"runtime_profile_id":`+quoteJSON(profileID)+`,
 		"runner":"sandbox"
 	}`)
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID+"/tasks/"+taskID, nil)
@@ -125,7 +126,15 @@ func TestGetTaskIncludesLatestContinuation(t *testing.T) {
 	}
 
 	var found struct {
-		ID                 string `json:"id"`
+		ID              string `json:"id"`
+		RuntimeControls struct {
+			NativeResumeAvailable   bool   `json:"native_resume_available"`
+			NativeResumeReason      string `json:"native_resume_reason"`
+			HandoffResumeAvailable  bool   `json:"handoff_resume_available"`
+			QueueSteerAvailable     bool   `json:"queue_steer_available"`
+			SameRuntimeProviderOnly bool   `json:"same_runtime_provider_only"`
+			RuntimeProvider         string `json:"runtime_provider"`
+		} `json:"runtime_controls"`
 		LatestContinuation *struct {
 			Number           int    `json:"number"`
 			RuntimeProfileID string `json:"runtime_profile_id"`
@@ -146,6 +155,18 @@ func TestGetTaskIncludesLatestContinuation(t *testing.T) {
 	}
 	if found.LatestContinuation.RuntimeProvider != "fake" {
 		t.Fatalf("expected latest continuation provider fake, got %q", found.LatestContinuation.RuntimeProvider)
+	}
+	if found.RuntimeControls.NativeResumeAvailable {
+		t.Fatal("expected fake runtime native resume to be unavailable")
+	}
+	if !strings.Contains(found.RuntimeControls.NativeResumeReason, "unsupported") {
+		t.Fatalf("expected unsupported native resume reason, got %q", found.RuntimeControls.NativeResumeReason)
+	}
+	if !found.RuntimeControls.HandoffResumeAvailable || !found.RuntimeControls.QueueSteerAvailable {
+		t.Fatalf("expected handoff resume and queue steer available, got %#v", found.RuntimeControls)
+	}
+	if !found.RuntimeControls.SameRuntimeProviderOnly || found.RuntimeControls.RuntimeProvider != "fake" {
+		t.Fatalf("expected same-provider fake controls, got %#v", found.RuntimeControls)
 	}
 }
 
@@ -388,8 +409,17 @@ func TestLaunchTaskReturnsBeforeRuntimeProcessCompletes(t *testing.T) {
 }
 
 func TestLaunchTaskWrapsProviderCommandInSandboxRunner(t *testing.T) {
-	containerCLI := filepath.Join(t.TempDir(), "fake-docker")
-	if err := os.WriteFile(containerCLI, []byte("#!/bin/sh\necho sandbox-command:$*\n"), 0o700); err != nil {
+	dir := t.TempDir()
+	createLog := filepath.Join(dir, "create.log")
+	containerCLI := filepath.Join(dir, "fake-docker")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  create) echo \"$*\" > " + shellQuote(createLog) + "; echo ctr-1 ;;\n" +
+		"  start) echo sandbox-command:$(cat " + shellQuote(createLog) + ") ;;\n" +
+		"  rm) exit 0 ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(containerCLI, []byte(script), 0o700); err != nil {
 		t.Fatalf("write fake container cli: %v", err)
 	}
 	server, err := daemon.NewServer(daemon.Config{
@@ -419,7 +449,7 @@ func TestLaunchTaskWrapsProviderCommandInSandboxRunner(t *testing.T) {
 		"runner":"sandbox"
 	}`)
 
-	waitForEventText(t, server, projectID, taskID, "sandbox-command:run --rm -i")
+	waitForEventText(t, server, projectID, taskID, "sandbox-command:create -i")
 	events := getTaskEvents(t, server, projectID, taskID)
 	var sawSandboxCommand bool
 	for _, event := range events {
@@ -428,7 +458,7 @@ func TestLaunchTaskWrapsProviderCommandInSandboxRunner(t *testing.T) {
 		}
 		payload := event["payload"].(map[string]any)
 		text, _ := payload["text"].(string)
-		if strings.Contains(text, "sandbox-command:run --rm -i") &&
+		if strings.Contains(text, "sandbox-command:create -i") &&
 			strings.Contains(text, "pentest-kali:test codex exec --model gpt-test") &&
 			strings.Contains(text, "enumerate example.com") {
 			sawSandboxCommand = true
@@ -447,6 +477,7 @@ func TestSandboxResumeRebuildsContainerWithPersistentTaskMountAndRuntimeHome(t *
 	containerCLI := filepath.Join(dir, "fake-docker")
 	script := "#!/bin/sh\n" +
 		"echo \"$*\" >> " + shellQuote(logPath) + "\n" +
+		"if [ \"$1\" != \"create\" ]; then exit 0; fi\n" +
 		"cidfile=\"\"\n" +
 		"prev=\"\"\n" +
 		"for arg in \"$@\"; do\n" +
@@ -457,7 +488,7 @@ func TestSandboxResumeRebuildsContainerWithPersistentTaskMountAndRuntimeHome(t *
 		"count=$((count + 1))\n" +
 		"echo \"$count\" > " + shellQuote(countPath) + "\n" +
 		"if [ -n \"$cidfile\" ]; then echo \"ctr-$count\" > \"$cidfile\"; fi\n" +
-		"echo sandbox-command:$*\n"
+		"echo ctr-$count\n"
 	if err := os.WriteFile(containerCLI, []byte(script), 0o700); err != nil {
 		t.Fatalf("write fake container cli: %v", err)
 	}
@@ -482,7 +513,7 @@ func TestSandboxResumeRebuildsContainerWithPersistentTaskMountAndRuntimeHome(t *
 	waitForTaskStatus(t, server, projectID, taskID, "completed")
 
 	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume/handoff", nil)
 	server.ServeHTTP(resp, req)
 	if resp.Code != http.StatusAccepted {
 		t.Fatalf("expected resume status 202, got %d with body %s", resp.Code, resp.Body.String())
@@ -495,7 +526,7 @@ func TestSandboxResumeRebuildsContainerWithPersistentTaskMountAndRuntimeHome(t *
 	}
 	logText := string(rawLog)
 	taskMount := filepath.Join(runtimeRoot, taskID) + ":/task"
-	if got := strings.Count(logText, "run --rm -i --cidfile"); got != 2 {
+	if got := strings.Count(logText, "create -i --cidfile"); got != 2 {
 		t.Fatalf("expected two sandbox container launches, got %d in log:\n%s", got, logText)
 	}
 	if got := strings.Count(logText, taskMount); got != 2 {
@@ -503,7 +534,7 @@ func TestSandboxResumeRebuildsContainerWithPersistentTaskMountAndRuntimeHome(t *
 	}
 	var launchLines []string
 	for _, line := range strings.Split(strings.TrimSpace(logText), "\n") {
-		if strings.HasPrefix(line, "run --rm") {
+		if strings.HasPrefix(line, "create -i") {
 			launchLines = append(launchLines, line)
 		}
 	}
@@ -753,6 +784,7 @@ func TestTaskRoutesRejectUnknownProject(t *testing.T) {
 		{"task events", http.MethodGet, "/api/projects/" + bogus + "/tasks/anything/events", ""},
 		{"stop task", http.MethodPost, "/api/projects/" + bogus + "/tasks/anything/stop", ""},
 		{"steer task", http.MethodPost, "/api/projects/" + bogus + "/tasks/anything/steer", `{"directive":"focus"}`},
+		{"resume handoff task", http.MethodPost, "/api/projects/" + bogus + "/tasks/anything/resume/handoff", ""},
 		{"task continuation", http.MethodGet, "/api/projects/" + bogus + "/tasks/anything/continuation", ""},
 		{"put task summary", http.MethodPut, "/api/projects/" + bogus + "/tasks/anything/summary", `{"summary":"s"}`},
 		{"get task summary", http.MethodGet, "/api/projects/" + bogus + "/tasks/anything/summary", ""},
@@ -815,6 +847,20 @@ func waitForEventText(t *testing.T, server interface {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for event text %q", want)
+}
+
+func waitForDockerLogText(t *testing.T, logPath, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(logPath)
+		if err == nil && strings.Contains(string(raw), want) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	raw, _ := os.ReadFile(logPath)
+	t.Fatalf("timed out waiting for docker log text %q in\n%s", want, string(raw))
 }
 
 func hasTranscriptEntry(entries []map[string]any, kind, role, text string) bool {
@@ -985,7 +1031,7 @@ func TestResumeTaskEnrichesPromptWithFindingsAndProgressFacts(t *testing.T) {
 	}`)
 
 	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume/handoff", nil)
 	server.ServeHTTP(resp, req)
 	if resp.Code != http.StatusAccepted {
 		t.Fatalf("expected resume status 202, got %d with body %s", resp.Code, resp.Body.String())
@@ -1070,7 +1116,7 @@ func TestResumeTaskUsesSteeredRuntimeProfileWhenProviderMatches(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume/handoff", nil)
 	server.ServeHTTP(resp, req)
 	if resp.Code != http.StatusAccepted {
 		t.Fatalf("expected resume status 202, got %d with body %s", resp.Code, resp.Body.String())
@@ -1089,6 +1135,60 @@ func TestResumeTaskUsesSteeredRuntimeProfileWhenProviderMatches(t *testing.T) {
 	}
 	if resumed.LatestContinuation.RuntimeProfileID != profileB {
 		t.Fatalf("expected resumed continuation profile %q, got %q", profileB, resumed.LatestContinuation.RuntimeProfileID)
+	}
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
+}
+
+func TestQueueSteerRecordsSameProviderRuntimeProfileForNextContinuation(t *testing.T) {
+	server := newDaemon(t)
+	projectID := createProject(t, server, `{"name":"Acme","scope":{"domains":["example.com"]}}`)
+	profileA := createRuntimeProfile(t, server, `{"name":"Fake A","provider":"fake"}`)
+	profileB := createRuntimeProfile(t, server, `{"name":"Fake B","provider":"fake"}`)
+	taskID := createTask(t, server, projectID, `{
+		"goal":"enumerate example.com",
+		"runtime_profile_id":`+quoteJSON(profileA)+`,
+		"runner":"sandbox"
+	}`)
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
+
+	steerResp := httptest.NewRecorder()
+	steerReq := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/steer/queue", bytes.NewReader([]byte(`{
+		"directive":"use profile b next",
+		"runtime_profile_id":`+quoteJSON(profileB)+`
+	}`)))
+	steerReq.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(steerResp, steerReq)
+	if steerResp.Code != http.StatusOK {
+		t.Fatalf("expected queue steer status 200, got %d with body %s", steerResp.Code, steerResp.Body.String())
+	}
+	var queued struct {
+		RuntimeConfigVersion *struct {
+			RuntimeProfileID string `json:"runtime_profile_id"`
+		} `json:"runtime_config_version"`
+	}
+	if err := json.NewDecoder(steerResp.Body).Decode(&queued); err != nil {
+		t.Fatalf("decode queue steer: %v", err)
+	}
+	if queued.RuntimeConfigVersion == nil || queued.RuntimeConfigVersion.RuntimeProfileID != profileB {
+		t.Fatalf("expected queued runtime profile %q, got %#v", profileB, queued.RuntimeConfigVersion)
+	}
+
+	resumeResp := httptest.NewRecorder()
+	resumeReq := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume/handoff", nil)
+	server.ServeHTTP(resumeResp, resumeReq)
+	if resumeResp.Code != http.StatusAccepted {
+		t.Fatalf("expected resume status 202, got %d with body %s", resumeResp.Code, resumeResp.Body.String())
+	}
+	var resumed struct {
+		LatestContinuation *struct {
+			RuntimeProfileID string `json:"runtime_profile_id"`
+		} `json:"latest_continuation"`
+	}
+	if err := json.NewDecoder(resumeResp.Body).Decode(&resumed); err != nil {
+		t.Fatalf("decode resumed task: %v", err)
+	}
+	if resumed.LatestContinuation == nil || resumed.LatestContinuation.RuntimeProfileID != profileB {
+		t.Fatalf("expected resumed continuation profile %q, got %#v", profileB, resumed.LatestContinuation)
 	}
 	waitForTaskStatus(t, server, projectID, taskID, "completed")
 }
@@ -1140,6 +1240,44 @@ func TestResumeTaskUsesCodexNativeResumeWhenSessionExists(t *testing.T) {
 	waitForTaskStatus(t, server, projectID, taskID, "completed")
 }
 
+func TestResumeTaskFailsWhenNativeSessionIsMissing(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	server := newDaemonWithConfig(t, daemon.Config{
+		Version:              "test-version",
+		DBPath:               filepath.Join(t.TempDir(), "pentest.db"),
+		RuntimeRoot:          runtimeRoot,
+		DisableBuiltinSkills: true,
+	})
+	projectID := createProject(t, server, `{"name":"Acme","scope":{"domains":["example.com"]}}`)
+
+	binary := filepath.Join(t.TempDir(), "codex-test")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\necho codex-provider:$*\n"), 0o700); err != nil {
+		t.Fatalf("write provider binary: %v", err)
+	}
+	profileID := createLocalRuntimeProfile(t, server, "Codex Test", runtimeprofile.ProviderCodex, runtimeprofile.Fields{
+		BinaryPath: binary,
+		Model:      "gpt-test",
+	})
+
+	taskID := createTask(t, server, projectID, `{
+		"goal":"enumerate example.com",
+		"runtime_profile_id":`+quoteJSON(profileID)+`,
+		"runner":"host",
+		"run_controls":{"host_activated":true}
+	}`)
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume", nil)
+	server.ServeHTTP(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("expected resume status 409 without native session, got %d with body %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "native session") {
+		t.Fatalf("expected native session error, got %s", resp.Body.String())
+	}
+}
+
 func TestSteerTaskInterruptsActiveRunAndLaunchesResumedContinuation(t *testing.T) {
 	runtimeRoot := t.TempDir()
 	server := newDaemonWithConfig(t, daemon.Config{
@@ -1171,7 +1309,7 @@ func TestSteerTaskInterruptsActiveRunAndLaunchesResumedContinuation(t *testing.T
 		"runner":"host",
 		"run_controls":{"host_activated":true}
 	}`)
-	waitForEventText(t, server, projectID, taskID, "codex-provider:run")
+	waitForEventText(t, server, projectID, taskID, "codex-provider:exec")
 
 	sessionPath := filepath.Join(runtimeRoot, taskID, "runtime-home", "codex", "sessions", "2026", "07", "04", "rollout-live.jsonl")
 	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o700); err != nil {
@@ -1201,16 +1339,25 @@ func TestSandboxSteerConfirmsContainerExitBeforeNativeResume(t *testing.T) {
 	dir := t.TempDir()
 	runtimeRoot := filepath.Join(dir, "runtime-root")
 	dockerLog := filepath.Join(dir, "docker.log")
-	inspectLog := filepath.Join(dir, "inspect.log")
 	countPath := filepath.Join(dir, "docker-count")
+	stoppedPath := filepath.Join(dir, "stopped")
 	containerCLI := filepath.Join(dir, "fake-docker")
 	script := "#!/bin/sh\n" +
-		"if [ \"$1\" = \"inspect\" ]; then\n" +
-		"  echo \"$*\" >> " + shellQuote(inspectLog) + "\n" +
-		"  echo false\n" +
+		"echo \"$*\" >> " + shellQuote(dockerLog) + "\n" +
+		"if [ \"$1\" = \"start\" ]; then\n" +
+		"  id=\"$3\"\n" +
+		"  create_file=" + shellQuote(dir) + "/$id.create\n" +
+		"  echo sandbox-command:$(cat \"$create_file\")\n" +
+		"  case \"$(cat \"$create_file\")\" in\n" +
+		"    *resume*) exit 0 ;;\n" +
+		"  esac\n" +
+		"  while [ ! -f " + shellQuote(stoppedPath) + " ]; do sleep 0.05; done\n" +
 		"  exit 0\n" +
 		"fi\n" +
-		"echo \"$*\" >> " + shellQuote(dockerLog) + "\n" +
+		"if [ \"$1\" = \"stop\" ]; then touch " + shellQuote(stoppedPath) + "; exit 0; fi\n" +
+		"if [ \"$1\" = \"kill\" ]; then touch " + shellQuote(stoppedPath) + "; exit 0; fi\n" +
+		"if [ \"$1\" = \"rm\" ]; then exit 0; fi\n" +
+		"if [ \"$1\" != \"create\" ]; then exit 1; fi\n" +
 		"cidfile=\"\"\n" +
 		"prev=\"\"\n" +
 		"for arg in \"$@\"; do\n" +
@@ -1220,12 +1367,9 @@ func TestSandboxSteerConfirmsContainerExitBeforeNativeResume(t *testing.T) {
 		"count=$(cat " + shellQuote(countPath) + " 2>/dev/null || echo 0)\n" +
 		"count=$((count + 1))\n" +
 		"echo \"$count\" > " + shellQuote(countPath) + "\n" +
+		"echo \"$*\" > " + shellQuote(dir) + "/ctr-$count.create\n" +
 		"if [ -n \"$cidfile\" ]; then echo \"ctr-$count\" > \"$cidfile\"; fi\n" +
-		"echo sandbox-command:$*\n" +
-		"case \"$*\" in\n" +
-		"  *resume*) exit 0 ;;\n" +
-		"esac\n" +
-		"exec sleep 5\n"
+		"echo ctr-$count\n"
 	if err := os.WriteFile(containerCLI, []byte(script), 0o700); err != nil {
 		t.Fatalf("write fake container cli: %v", err)
 	}
@@ -1247,7 +1391,7 @@ func TestSandboxSteerConfirmsContainerExitBeforeNativeResume(t *testing.T) {
 		"runtime_profile_id":`+quoteJSON(profileID)+`,
 		"runner":"sandbox"
 	}`)
-	waitForEventText(t, server, projectID, taskID, "sandbox-command:run")
+	waitForEventText(t, server, projectID, taskID, "sandbox-command:create")
 
 	sessionPath := filepath.Join(runtimeRoot, taskID, "runtime-home", "codex", "sessions", "2026", "07", "04", "sandbox-live.jsonl")
 	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o700); err != nil {
@@ -1268,13 +1412,7 @@ func TestSandboxSteerConfirmsContainerExitBeforeNativeResume(t *testing.T) {
 		t.Fatalf("expected steer interrupt status 202, got %d with body %s", resp.Code, resp.Body.String())
 	}
 
-	inspectRaw, err := os.ReadFile(inspectLog)
-	if err != nil {
-		t.Fatalf("read inspect log: %v", err)
-	}
-	if !strings.Contains(string(inspectRaw), "inspect -f {{.State.Running}} ctr-1") {
-		t.Fatalf("expected steer to inspect stopped container ctr-1, got %s", string(inspectRaw))
-	}
+	waitForDockerLogText(t, dockerLog, "stop ctr-1")
 	waitForEventText(t, server, projectID, taskID, "resume sess-sandbox")
 	waitForEventText(t, server, projectID, taskID, "focus admin.example.com")
 	waitForTaskStatus(t, server, projectID, taskID, "completed")
@@ -1283,7 +1421,7 @@ func TestSandboxSteerConfirmsContainerExitBeforeNativeResume(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read docker log: %v", err)
 	}
-	if got := strings.Count(string(dockerRaw), "run --rm -i --cidfile"); got != 2 {
+	if got := strings.Count(string(dockerRaw), "create -i --cidfile"); got != 2 {
 		t.Fatalf("expected initial and resumed sandbox launches, got %d in log:\n%s", got, string(dockerRaw))
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -73,7 +73,7 @@ const (
 const HostProxyOnlySandboxNetworkName = "pentest-host-proxy-only"
 
 // SandboxCommandRequest contains the data needed to construct a Kali sandbox
-// launch command without starting the container.
+// container create command without starting the container.
 type SandboxCommandRequest struct {
 	Layout          Layout
 	Provider        runtimeprofile.Provider
@@ -129,8 +129,9 @@ func PrepareTaskLayout(rootDir, taskID string, provider runtimeprofile.Provider)
 	return layout, nil
 }
 
-// BuildSandboxCommand constructs a container launch command for a task-local
-// runtime. It does not execute the command.
+// BuildSandboxCommand constructs a container create command for a task-local
+// runtime. It does not execute the command; the runtime harness owns start,
+// stop/kill, logs, wait, and rm for the created container.
 func BuildSandboxCommand(request SandboxCommandRequest) (Command, error) {
 	if strings.TrimSpace(request.Layout.TaskRoot) == "" {
 		return Command{}, fmt.Errorf("task root is required")
@@ -156,8 +157,7 @@ func BuildSandboxCommand(request SandboxCommandRequest) (Command, error) {
 		return Command{}, fmt.Errorf("resolve task root: %w", err)
 	}
 	args := []string{
-		"run",
-		"--rm",
+		"create",
 		"-i",
 	}
 	if strings.TrimSpace(request.ContainerIDFile) != "" {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -125,8 +125,7 @@ func TestBuildSandboxCommandConstructsContainerLaunchWithoutExecution(t *testing
 		t.Fatalf("expected docker program, got %q", command.Program)
 	}
 	expectedArgs := []string{
-		"run",
-		"--rm",
+		"create",
 		"-i",
 		"--cidfile",
 		filepath.Join(layout.Logs, "container.cid"),

--- a/internal/runtime/docker_sandbox.go
+++ b/internal/runtime/docker_sandbox.go
@@ -1,0 +1,166 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"pentest/internal/adapters"
+	"pentest/internal/task"
+)
+
+const dockerStopGrace = 2 * time.Second
+
+// DockerSandboxConfig describes a daemon-owned sandbox container runtime.
+// CreateArgs must be a docker create argv, excluding the container CLI itself.
+type DockerSandboxConfig struct {
+	Name         string
+	ContainerCLI string
+	CreateArgs   []string
+}
+
+type dockerSandboxAdapter struct {
+	config      DockerSandboxConfig
+	mu          sync.Mutex
+	record      func(NativeSessionMetadata) error
+	containerID string
+}
+
+// NewDockerSandboxAdapter returns an adapter that owns the created container
+// lifecycle instead of relying on foreground docker run cancellation.
+func NewDockerSandboxAdapter(config DockerSandboxConfig) Adapter {
+	return &dockerSandboxAdapter{config: config}
+}
+
+func (a *dockerSandboxAdapter) Name() string {
+	if strings.TrimSpace(a.config.Name) != "" {
+		return a.config.Name
+	}
+	return "docker"
+}
+
+func (a *dockerSandboxAdapter) SetMetadataRecorder(record func(NativeSessionMetadata) error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.record = record
+}
+
+func (a *dockerSandboxAdapter) Run(ctx context.Context, goal string, emit func(task.EventKind, task.EventPayload)) error {
+	cli := strings.TrimSpace(a.config.ContainerCLI)
+	if cli == "" {
+		cli = "docker"
+	}
+	if len(a.config.CreateArgs) == 0 || a.config.CreateArgs[0] != "create" {
+		return fmt.Errorf("docker sandbox adapter requires docker create args")
+	}
+
+	create := exec.CommandContext(ctx, cli, a.config.CreateArgs...)
+	rawID, err := create.Output()
+	if err != nil {
+		return fmt.Errorf("create sandbox container: %w", err)
+	}
+	containerID := strings.TrimSpace(string(rawID))
+	if containerID == "" {
+		return fmt.Errorf("create sandbox container returned empty id")
+	}
+	a.mu.Lock()
+	a.containerID = containerID
+	record := a.record
+	a.mu.Unlock()
+	if record != nil {
+		if err := record(NativeSessionMetadata{ContainerID: containerID}); err != nil {
+			return fmt.Errorf("record sandbox container id: %w", err)
+		}
+	}
+	emit(task.EventKindLifecycle, task.EventPayload{
+		"phase":        "container_created",
+		"adapter":      a.Name(),
+		"container_id": containerID,
+	})
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		<-ctx.Done()
+		if err := stopThenKillContainer(cli, containerID, dockerStopGrace); err != nil {
+			emit(task.EventKindLifecycle, task.EventPayload{
+				"phase":        "stop_failed",
+				"adapter":      a.Name(),
+				"container_id": containerID,
+				"error":        err.Error(),
+			})
+		}
+	}()
+
+	start := exec.CommandContext(ctx, cli, "start", "-a", containerID)
+	stdout, err := start.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("open sandbox stdout: %w", err)
+	}
+	stderr, err := start.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("open sandbox stderr: %w", err)
+	}
+	emit(task.EventKindLifecycle, adapters.Redact(task.EventPayload{
+		"phase":        "container_starting",
+		"adapter":      a.Name(),
+		"container_id": containerID,
+		"program":      cli,
+		"args":         []string{"start", "-a", containerID},
+	}))
+	if err := start.Start(); err != nil {
+		return fmt.Errorf("start sandbox container: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		ScanOutput(stdout, "stdout", maxRuntimeOutputLineBytes, emit)
+	}()
+	go func() {
+		defer wg.Done()
+		ScanOutput(stderr, "stderr", maxRuntimeOutputLineBytes, emit)
+	}()
+	wg.Wait()
+	waitErr := start.Wait()
+	if ctx.Err() != nil {
+		<-stopDone
+	}
+	if err := removeContainer(cli, containerID); err != nil {
+		emit(task.EventKindLifecycle, task.EventPayload{
+			"phase":        "cleanup_failed",
+			"adapter":      a.Name(),
+			"container_id": containerID,
+			"error":        err.Error(),
+		})
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if waitErr != nil {
+		return fmt.Errorf("sandbox container failed: %w", waitErr)
+	}
+	return nil
+}
+
+func stopThenKillContainer(containerCLI, containerID string, grace time.Duration) error {
+	stopCtx, cancel := context.WithTimeout(context.Background(), grace)
+	defer cancel()
+	if err := exec.CommandContext(stopCtx, containerCLI, "stop", containerID).Run(); err == nil {
+		return nil
+	}
+	killCtx, killCancel := context.WithTimeout(context.Background(), grace)
+	defer killCancel()
+	if err := exec.CommandContext(killCtx, containerCLI, "kill", containerID).Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func removeContainer(containerCLI, containerID string) error {
+	return exec.Command(containerCLI, "rm", "-f", containerID).Run()
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -29,6 +29,10 @@ type Adapter interface {
 	Run(ctx context.Context, goal string, emit func(task.EventKind, task.EventPayload)) error
 }
 
+type metadataRecordingAdapter interface {
+	SetMetadataRecorder(func(NativeSessionMetadata) error)
+}
+
 // LaunchRequest describes a harness launch for one task continuation.
 type LaunchRequest struct {
 	TaskID           string
@@ -94,6 +98,17 @@ func (h *Harness) Launch(ctx context.Context, req LaunchRequest) error {
 	if req.ContinuationID != "" {
 		if _, err := h.tasks.UpdateContinuationStatus(req.ContinuationID, task.StatusRunning); err != nil {
 			return fmt.Errorf("mark continuation running: %w", err)
+		}
+	}
+	if req.ContinuationID != "" {
+		if recorder, ok := req.Adapter.(metadataRecordingAdapter); ok {
+			recorder.SetMetadataRecorder(func(metadata NativeSessionMetadata) error {
+				if metadata.ContainerID == "" && metadata.NativeSessionID == "" && metadata.NativeSessionPath == "" {
+					return nil
+				}
+				_, err := h.tasks.UpdateContinuationRuntimeMetadata(req.ContinuationID, metadata.ContainerID, metadata.NativeSessionID, metadata.NativeSessionPath)
+				return err
+			})
 		}
 	}
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -324,6 +324,85 @@ func TestCommandRuntimeAdapterCancellationReturnsContextCanceled(t *testing.T) {
 	}
 }
 
+func TestDockerSandboxAdapterRecordsContainerAndStopsByID(t *testing.T) {
+	harness, tasks, projects := newServices(t)
+	proj, _ := projects.Create("P", "", project.Scope{}, project.Defaults{})
+	created, _ := tasks.Create(task.CreateRequest{ProjectID: proj.ID, Goal: "sandbox task", Runner: task.RunnerSandbox})
+	continuation, err := tasks.CreateContinuation(created.ID, "codex-profile", "codex", task.RunnerSandbox)
+	if err != nil {
+		t.Fatalf("create continuation: %v", err)
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "docker.log")
+	stoppedPath := filepath.Join(dir, "stopped")
+	docker := filepath.Join(dir, "docker")
+	script := "#!/bin/sh\n" +
+		"echo \"$*\" >> " + shellQuote(logPath) + "\n" +
+		"case \"$1\" in\n" +
+		"  create) echo ctr-owned ;;\n" +
+		"  start) echo sandbox-started; while [ ! -f " + shellQuote(stoppedPath) + " ]; do sleep 0.05; done ;;\n" +
+		"  stop) touch " + shellQuote(stoppedPath) + " ;;\n" +
+		"  rm) exit 0 ;;\n" +
+		"  *) exit 1 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(docker, []byte(script), 0o700); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- harness.Launch(context.Background(), runtime.LaunchRequest{
+			TaskID:         created.ID,
+			Goal:           created.Goal,
+			ContinuationID: continuation.ID,
+			Adapter: runtime.NewDockerSandboxAdapter(runtime.DockerSandboxConfig{
+				Name:         "codex",
+				ContainerCLI: docker,
+				CreateArgs:   []string{"create", "-i", "image", "codex", "run"},
+			}),
+		})
+	}()
+
+	waitForActive(t, harness, created.ID)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		active, err := tasks.ActiveContinuation(created.ID)
+		if err != nil {
+			t.Fatalf("active continuation: %v", err)
+		}
+		if active != nil && active.ContainerID == "ctr-owned" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	active, err := tasks.ActiveContinuation(created.ID)
+	if err != nil {
+		t.Fatalf("active continuation: %v", err)
+	}
+	if active == nil || active.ContainerID != "ctr-owned" {
+		t.Fatalf("expected active continuation container id ctr-owned, got %#v", active)
+	}
+
+	if !harness.StopAndWait(created.ID, 2*time.Second) {
+		t.Fatal("expected StopAndWait to stop docker sandbox")
+	}
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read docker log: %v", err)
+	}
+	logText := string(raw)
+	if !strings.Contains(logText, "stop ctr-owned") {
+		t.Fatalf("expected docker stop by container id, got log:\n%s", logText)
+	}
+	if !strings.Contains(logText, "rm -f ctr-owned") {
+		t.Fatalf("expected docker rm by container id, got log:\n%s", logText)
+	}
+}
+
 func TestDockerContainerStopConfirmationTreatsRemovedContainerAsExited(t *testing.T) {
 	dir := t.TempDir()
 	cidFile := filepath.Join(dir, "container.cid")

--- a/internal/runtimeplugin/builtin.go
+++ b/internal/runtimeplugin/builtin.go
@@ -26,7 +26,7 @@ func BuiltinPlugins() []Plugin {
 				Sandbox:             true,
 				Host:                true,
 				StreamingTranscript: false,
-				Resume:              true,
+				Resume:              false,
 			},
 			ModelProvider:    ModelProvider{Requirement: "none"},
 			ProfileSchema:    ProfileSchema{Fields: commonFields},
@@ -60,6 +60,11 @@ func BuiltinPlugins() []Plugin {
 			Launch: LaunchTemplate{
 				Args: []string{"{{binary}}", "{{codex_subcommand}}", "--model", "{{model}}", "{{codex_exec_args}}", "{{custom_args}}", "{{codex_goal_prefix}}", "{{goal}}"},
 			},
+			NativeResume: NativeResume{
+				Supported:     true,
+				SessionSource: "codex_session_jsonl",
+				Args:          []string{"{{binary}}", "--model", "{{model}}", "resume", "{{native_session}}", "{{resumed_message}}"},
+			},
 			ProcessEnv:    map[string]string{"CODEX_HOME": "{{runtime_home}}/codex"},
 			CredentialEnv: []string{"OPENAI_API_KEY", "CODEX_API_KEY"},
 			Transcript:    Transcript{Parser: "codex_json"},
@@ -75,7 +80,7 @@ func BuiltinPlugins() []Plugin {
 				Host:                true,
 				MCPConfig:           true,
 				StreamingTranscript: true,
-				Resume:              true,
+				Resume:              false,
 			},
 			ModelProvider: ModelProvider{
 				Requirement:        "required",
@@ -122,7 +127,7 @@ func BuiltinPlugins() []Plugin {
 				Host:                true,
 				MCPConfig:           true,
 				StreamingTranscript: true,
-				Resume:              true,
+				Resume:              false,
 			},
 			ModelProvider: ModelProvider{
 				Requirement:        "required",

--- a/internal/runtimeplugin/plugin.go
+++ b/internal/runtimeplugin/plugin.go
@@ -27,6 +27,7 @@ type Plugin struct {
 	ProfileSchema    ProfileSchema     `json:"profile_schema"`
 	ConfigProjection ConfigProjection  `json:"config_projection"`
 	Launch           LaunchTemplate    `json:"launch"`
+	NativeResume     NativeResume      `json:"native_resume,omitempty"`
 	ProcessEnv       map[string]string `json:"process_env,omitempty"`
 	CredentialEnv    []string          `json:"credential_env,omitempty"`
 	Transcript       Transcript        `json:"transcript"`
@@ -70,6 +71,12 @@ type ConfigProjection struct {
 type LaunchTemplate struct {
 	Args             []string          `json:"args"`
 	SingletonOptions []SingletonOption `json:"singleton_options,omitempty"`
+}
+
+type NativeResume struct {
+	Supported     bool     `json:"supported"`
+	SessionSource string   `json:"session_source,omitempty"`
+	Args          []string `json:"args,omitempty"`
 }
 
 type SingletonOption struct {
@@ -163,6 +170,9 @@ func Validate(plugin Plugin) error {
 	}
 	if len(plugin.Launch.Args) == 0 {
 		return fmt.Errorf("%w: launch args are required", ErrInvalidPlugin)
+	}
+	if plugin.NativeResume.Supported && len(plugin.NativeResume.Args) == 0 {
+		return fmt.Errorf("%w: native_resume args are required when native resume is supported", ErrInvalidPlugin)
 	}
 	seen := map[string]bool{}
 	for _, field := range plugin.ProfileSchema.Fields {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -109,6 +109,18 @@ type TaskContinuation struct {
 	EndedAt           *time.Time `json:"ended_at,omitempty"`
 }
 
+type RuntimeControls struct {
+	NativeResumeAvailable   bool   `json:"native_resume_available"`
+	NativeResumeReason      string `json:"native_resume_reason,omitempty"`
+	HandoffResumeAvailable  bool   `json:"handoff_resume_available"`
+	QueueSteerAvailable     bool   `json:"queue_steer_available"`
+	InterruptSteerAvailable bool   `json:"interrupt_steer_available"`
+	InterruptSteerReason    string `json:"interrupt_steer_reason,omitempty"`
+	NativeSessionCaptured   bool   `json:"native_session_captured"`
+	SameRuntimeProviderOnly bool   `json:"same_runtime_provider_only"`
+	RuntimeProvider         string `json:"runtime_provider,omitempty"`
+}
+
 type SummaryVersion struct {
 	ID          string    `json:"id"`
 	TaskID      string    `json:"task_id"`
@@ -128,6 +140,7 @@ type Task struct {
 	RuntimeProfileID   string            `json:"runtime_profile_id"`
 	RunControls        RunControls       `json:"run_controls"`
 	ScopeSnapshot      ScopeSnapshot     `json:"scope_snapshot"`
+	RuntimeControls    RuntimeControls   `json:"runtime_controls"`
 	ActiveContinuation *TaskContinuation `json:"active_continuation,omitempty"`
 	LatestContinuation *TaskContinuation `json:"latest_continuation,omitempty"`
 	CreatedAt          time.Time         `json:"created_at"`

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -28,9 +28,34 @@ var timelineParseOpts = runtimeoutput.ParseOptions{
 
 // Build projects task events into coalesced timeline items.
 func Build(events []task.Event) []Item {
+	items := make([]Item, 0, len(events))
+	nextSeq := 1
 	turns := make([]runtimeoutput.Turn, 0, len(events))
+	flushTurns := func() {
+		for _, item := range turnsToItems(runtimeoutput.CoalesceStreaming(turns)) {
+			item.Seq = nextSeq
+			nextSeq++
+			items = append(items, item)
+		}
+		turns = turns[:0]
+	}
 	for _, event := range events {
 		if event.Kind == task.EventKindLifecycle {
+			flushTurns()
+			if item, ok := lifecycleItem(event); ok {
+				item.Seq = nextSeq
+				nextSeq++
+				items = append(items, item)
+			}
+			continue
+		}
+		if event.Kind == task.EventKindSteering {
+			flushTurns()
+			if item, ok := steeringItem(event); ok {
+				item.Seq = nextSeq
+				nextSeq++
+				items = append(items, item)
+			}
 			continue
 		}
 		if event.Kind != task.EventKindRuntimeOutput {
@@ -46,7 +71,8 @@ func Build(events []task.Event) []Item {
 		lineTurns, _ := runtimeoutput.ParseLine(text, event.CreatedAt, timelineParseOpts)
 		turns = append(turns, lineTurns...)
 	}
-	return turnsToItems(runtimeoutput.CoalesceStreaming(turns))
+	flushTurns()
+	return items
 }
 
 func turnsToItems(turns []runtimeoutput.Turn) []Item {
@@ -62,6 +88,35 @@ func turnsToItems(turns []runtimeoutput.Turn) []Item {
 		items = append(items, item)
 	}
 	return items
+}
+
+func lifecycleItem(event task.Event) (Item, bool) {
+	phase := stringValue(event.Payload, "phase")
+	if strings.TrimSpace(phase) == "" {
+		return Item{}, false
+	}
+	return Item{
+		Type:      "lifecycle",
+		Content:   "Lifecycle: " + phase,
+		CreatedAt: event.CreatedAt,
+	}, true
+}
+
+func steeringItem(event task.Event) (Item, bool) {
+	phase := stringValue(event.Payload, "phase")
+	if phase == "" {
+		phase = "steering"
+	}
+	directive := stringValue(event.Payload, "directive")
+	content := "Steering: " + phase
+	if strings.TrimSpace(directive) != "" {
+		content += " - " + directive
+	}
+	return Item{
+		Type:      "steering",
+		Content:   content,
+		CreatedAt: event.CreatedAt,
+	}, true
 }
 
 func turnToItem(turn runtimeoutput.Turn) (Item, bool) {

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -21,13 +21,14 @@ func TestBuildParsesThinkingToolUseTextAndResult(t *testing.T) {
 
 	got := timeline.Build(events)
 
-	requireItem(t, got, 0, "thinking", "", "plan recon")
-	requireItem(t, got, 1, "tool_use", "Bash", "")
-	if got[1].Input["command"] != "curl example.com" {
-		t.Fatalf("unexpected tool input: %#v", got[1].Input)
+	requireItem(t, got, 0, "lifecycle", "", "Lifecycle: started")
+	requireItem(t, got, 1, "thinking", "", "plan recon")
+	requireItem(t, got, 2, "tool_use", "Bash", "")
+	if got[2].Input["command"] != "curl example.com" {
+		t.Fatalf("unexpected tool input: %#v", got[2].Input)
 	}
-	requireItem(t, got, 2, "tool_result", "", "200 OK")
-	requireItem(t, got, 3, "text", "", "Done inspecting.")
+	requireItem(t, got, 3, "tool_result", "", "200 OK")
+	requireItem(t, got, 4, "text", "", "Done inspecting.")
 }
 
 func TestBuildCoalescesAdjacentThinkingFragments(t *testing.T) {
@@ -71,6 +72,36 @@ func TestBuildParsesOpenAIToolCallFormat(t *testing.T) {
 
 	requireItem(t, got, 0, "tool_use", "curl", "")
 	requireItem(t, got, 1, "tool_result", "", "OK")
+}
+
+func TestBuildIncludesSteeringAndNativeResumeLifecycle(t *testing.T) {
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindSteering, Payload: task.EventPayload{"phase": "steering_requested", "directive": "focus admin"}},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindLifecycle, Payload: task.EventPayload{"phase": "interrupting"}},
+		{ID: "ev-3", Seq: 3, Kind: task.EventKindLifecycle, Payload: task.EventPayload{"phase": "resuming_native"}},
+		{ID: "ev-4", Seq: 4, Kind: task.EventKindSteering, Payload: task.EventPayload{"phase": "steering_applied", "directive": "focus admin"}},
+	}
+
+	got := timeline.Build(events)
+
+	requireItem(t, got, 0, "steering", "", "Steering: steering_requested - focus admin")
+	requireItem(t, got, 1, "lifecycle", "", "Lifecycle: interrupting")
+	requireItem(t, got, 2, "lifecycle", "", "Lifecycle: resuming_native")
+	requireItem(t, got, 3, "steering", "", "Steering: steering_applied - focus admin")
+}
+
+func TestBuildKeepsControlEventsBetweenRuntimeOutput(t *testing.T) {
+	events := []task.Event{
+		{ID: "ev-1", Seq: 1, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"text","text":"before"}]}}`}},
+		{ID: "ev-2", Seq: 2, Kind: task.EventKindSteering, Payload: task.EventPayload{"phase": "steering_requested", "directive": "focus admin"}},
+		{ID: "ev-3", Seq: 3, Kind: task.EventKindRuntimeOutput, Payload: task.EventPayload{"text": `{"type":"assistant","message":{"content":[{"type":"text","text":"after"}]}}`}},
+	}
+
+	got := timeline.Build(events)
+
+	requireItem(t, got, 0, "text", "", "before")
+	requireItem(t, got, 1, "steering", "", "Steering: steering_requested - focus admin")
+	requireItem(t, got, 2, "text", "", "after")
 }
 
 func requireItem(t *testing.T, items []timeline.Item, index int, typ, tool, content string) {

--- a/web/src/components/task-transcript/timeline-utils.ts
+++ b/web/src/components/task-transcript/timeline-utils.ts
@@ -12,6 +12,9 @@ export function getEventColor(item: TimelineItem): EventColor {
       return "result";
     case "error":
       return "error";
+    case "lifecycle":
+    case "steering":
+      return "result";
     default:
       return "result";
   }
@@ -37,6 +40,10 @@ export function getEventLabel(item: TimelineItem): string {
       return item.tool ? item.tool : "Result";
     case "error":
       return "Error";
+    case "lifecycle":
+      return "Lifecycle";
+    case "steering":
+      return "Steering";
     default:
       return "Event";
   }
@@ -73,6 +80,9 @@ export function getEventSummary(item: TimelineItem): string {
     case "tool_result":
       return item.output?.slice(0, 200) ?? "";
     case "error":
+      return item.content ?? "";
+    case "lifecycle":
+    case "steering":
       return item.content ?? "";
     default:
       return "";

--- a/web/src/components/task-transcript/types.ts
+++ b/web/src/components/task-transcript/types.ts
@@ -1,4 +1,4 @@
-export type TimelineItemType = "tool_use" | "tool_result" | "thinking" | "text" | "error";
+export type TimelineItemType = "tool_use" | "tool_result" | "thinking" | "text" | "error" | "lifecycle" | "steering";
 
 export interface TimelineItem {
   seq: number;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -313,10 +313,23 @@ export interface Task {
   runtime_profile_id: string;
   run_controls: { yolo?: boolean; host_activated?: boolean; sandbox_network?: string; notes?: string; extras?: Record<string, string> };
   scope_snapshot: Scope;
+  runtime_controls?: RuntimeControls;
   active_continuation?: TaskContinuation;
   latest_continuation?: TaskContinuation;
   created_at: string;
   updated_at: string;
+}
+
+export interface RuntimeControls {
+  native_resume_available: boolean;
+  native_resume_reason?: string;
+  handoff_resume_available: boolean;
+  queue_steer_available: boolean;
+  interrupt_steer_available: boolean;
+  interrupt_steer_reason?: string;
+  native_session_captured: boolean;
+  same_runtime_provider_only: boolean;
+  runtime_provider?: string;
 }
 
 export interface TaskContinuation {
@@ -366,7 +379,7 @@ export interface TaskTranscript {
 
 export interface TaskTimelineItem {
   seq: number;
-  type: "tool_use" | "tool_result" | "thinking" | "text" | "error";
+  type: "tool_use" | "tool_result" | "thinking" | "text" | "error" | "lifecycle" | "steering";
   tool?: string;
   content?: string;
   input?: Record<string, unknown>;

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -52,6 +52,15 @@ function stubTaskDetailApi() {
       runtime_profile_id: "profile-1",
       run_controls: {},
       scope_snapshot: {},
+      runtime_controls: {
+        native_resume_available: true,
+        handoff_resume_available: true,
+        queue_steer_available: true,
+        interrupt_steer_available: false,
+        native_session_captured: true,
+        same_runtime_provider_only: true,
+        runtime_provider: "codex",
+      },
       latest_continuation: {
         id: "cont-1",
         task_id: "task-1",
@@ -60,6 +69,7 @@ function stubTaskDetailApi() {
         runtime_provider: "codex",
         runner: "sandbox",
         status: "completed",
+        native_session_id: "sess-1",
         started_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:05Z",
         ended_at: "2026-01-01T00:00:05Z",
@@ -67,7 +77,12 @@ function stubTaskDetailApi() {
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:05Z",
     },
-    "/api/runtime-profiles": { profiles: [{ id: "profile-1", name: "Codex" }] },
+    "/api/runtime-profiles": {
+      profiles: [
+        { id: "profile-1", name: "Codex", provider: "codex" },
+        { id: "profile-2", name: "Fake", provider: "fake" },
+      ],
+    },
   });
 
   return { scrollIntoView };
@@ -102,5 +117,19 @@ describe("TaskDetailPage", () => {
     expect(await screen.findByText("continuation #1")).toBeInTheDocument();
     expect(screen.getByText("runtime: codex")).toBeInTheDocument();
     expect(screen.getByText("continuation status: completed")).toBeInTheDocument();
+    expect(screen.getByText("native session: captured")).toBeInTheDocument();
+    expect(screen.getByText("same runtime only")).toBeInTheDocument();
+  });
+
+  it("separates native resume, handoff resume, and queue steering controls", async () => {
+    stubTaskDetailApi();
+
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /Resume$/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Resume with handoff/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Queue steer/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Use Codex/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Use Fake/ })).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, type RefObject } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Square, Send, Terminal, Activity, GitBranch, MessageSquare, Play, FileText, Shield, ChevronRight, Wrench, User, Bot, ArrowDown, ArrowUp } from "lucide-react";
 import { apiGet, apiPost, type Task, type TaskTimeline, type TaskTimelineItem, type TaskTranscript, type TaskTranscriptEntry } from "@/lib/api";
-import { Button, Card, Input, Badge, Select } from "@/components/ui";
+import { Button, Card, Input, Badge } from "@/components/ui";
 import { BackLink, PageContainer } from "@/components/shared";
 import { AgentTranscriptView } from "@/components/task-transcript/AgentTranscriptView";
 import { collapsedTranscriptTitle } from "./taskDetailView";
@@ -18,8 +18,8 @@ export function TaskDetailPage() {
   const [autoFollow, setAutoFollow] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [steering, setSteering] = useState("");
-  const [steerProfile, setSteerProfile] = useState("");
-  const [profiles, setProfiles] = useState<{ id: string; name: string }[]>([]);
+  const [steeringProfile, setSteeringProfile] = useState("");
+  const [profiles, setProfiles] = useState<{ id: string; name: string; provider?: string }[]>([]);
   const pageRef = useRef<HTMLDivElement>(null);
   const timelineEnd = useRef<HTMLDivElement>(null);
   const autoFollowRef = useRef(true);
@@ -116,7 +116,7 @@ export function TaskDetailPage() {
     }
   }
 
-  async function resume() {
+  async function resumeNative() {
     try {
       await apiPost(`${base}/resume`, {});
       loadAll();
@@ -125,10 +125,37 @@ export function TaskDetailPage() {
     }
   }
 
-  async function steer() {
+  async function resumeHandoff() {
     try {
-      await apiPost(`${base}/steer`, { directive: steering, runtime_profile_id: steerProfile || undefined });
+      await apiPost(`${base}/resume/handoff`, {});
+      loadAll();
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }
+
+  async function queueSteer() {
+    try {
+      await apiPost(`${base}/steer/queue`, {
+        directive: steering,
+        runtime_profile_id: steeringProfile || undefined,
+      });
       setSteering("");
+      setSteeringProfile("");
+      loadAll();
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }
+
+  async function interruptSteer() {
+    try {
+      await apiPost(`${base}/steer`, {
+        directive: steering,
+        runtime_profile_id: steeringProfile || undefined,
+      });
+      setSteering("");
+      setSteeringProfile("");
       loadAll();
     } catch (e) {
       setError((e as Error).message);
@@ -138,6 +165,15 @@ export function TaskDetailPage() {
   if (error) return <PageContainer className="text-destructive">{error}</PageContainer>;
   if (!task) return <PageContainer className="text-muted-foreground">Loading…</PageContainer>;
   const currentContinuation = task.active_continuation ?? task.latest_continuation;
+  const controls = task.runtime_controls;
+  const nativeResumeAvailable = controls?.native_resume_available ?? Boolean(currentContinuation?.native_session_id);
+  const handoffResumeAvailable = controls?.handoff_resume_available ?? !ACTIVE.has(task.status);
+  const queueSteerAvailable = controls?.queue_steer_available ?? true;
+  const interruptSteerAvailable = controls?.interrupt_steer_available ?? nativeResumeAvailable;
+  const nativeResumeReason = controls?.native_resume_reason ?? "Native resume unavailable";
+  const interruptSteerReason = controls?.interrupt_steer_reason ?? nativeResumeReason;
+  const running = ACTIVE.has(task.status);
+  const sameRuntimeProfiles = profiles.filter((profile) => !controls?.runtime_provider || profile.provider === controls.runtime_provider);
 
   return (
     <PageContainer ref={pageRef} className="max-w-4xl">
@@ -146,12 +182,17 @@ export function TaskDetailPage() {
       <div className="mb-2 flex items-center justify-between">
         <h2 className="text-xl font-semibold tracking-tight">{task.goal}</h2>
         <div className="flex gap-2">
-          {!ACTIVE.has(task.status) && (
-            <Button size="sm" variant="outline" onClick={resume}>
+          {!running && (
+            <Button size="sm" variant="outline" onClick={resumeNative} disabled={!nativeResumeAvailable} title={nativeResumeAvailable ? "Resume native session" : nativeResumeReason}>
               <Play className="h-4 w-4" /> Resume
             </Button>
           )}
-          {ACTIVE.has(task.status) && (
+          {!running && (
+            <Button size="sm" variant="outline" onClick={resumeHandoff} disabled={!handoffResumeAvailable}>
+              <FileText className="h-4 w-4" /> Resume with handoff
+            </Button>
+          )}
+          {running && (
             <Button size="sm" variant="destructive" onClick={stop}>
               <Square className="h-4 w-4" /> Stop
             </Button>
@@ -170,6 +211,8 @@ export function TaskDetailPage() {
           <Badge variant="outline">continuation #{currentContinuation.number}</Badge>
           <Badge variant="outline">runtime: {currentContinuation.runtime_provider}</Badge>
           <Badge variant="outline">continuation status: {currentContinuation.status}</Badge>
+          {(controls?.native_session_captured || currentContinuation.native_session_id) && <Badge variant="outline">native session: captured</Badge>}
+          {controls?.same_runtime_provider_only && <Badge variant="outline">same runtime only</Badge>}
         </div>
       )}
 
@@ -191,23 +234,29 @@ export function TaskDetailPage() {
       {/* Steering */}
       <Card className="mb-6 space-y-2">
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <GitBranch className="h-4 w-4" /> Steering (applies to next continuation)
+          <GitBranch className="h-4 w-4" /> Task controls
         </div>
         <Input value={steering} onChange={(e) => setSteering(e.target.value)} placeholder="Focus on admin.example.com next" />
-        <div className="flex gap-2 items-center">
-          <Select
-            className="max-w-xs"
-            value={steerProfile}
-            onChange={(e) => setSteerProfile(e.target.value)}
+        <div className="flex flex-wrap gap-2 items-center">
+          <select
+            className="h-8 max-w-xs rounded-md border border-input bg-background px-2 text-sm"
+            value={steeringProfile}
+            onChange={(e) => setSteeringProfile(e.target.value)}
+            aria-label="Steering runtime profile"
           >
-            <option value="">Keep current profile</option>
-            {profiles.map((p) => (
-              <option key={p.id} value={p.id}>Switch to {p.name}</option>
+            <option value="">Keep current model</option>
+            {sameRuntimeProfiles.map((profile) => (
+              <option key={profile.id} value={profile.id}>Use {profile.name}</option>
             ))}
-          </Select>
-          <Button size="sm" onClick={steer} disabled={!steering.trim()}>
-            <Send className="h-4 w-4 mr-1" /> Steer
+          </select>
+          <Button size="sm" variant="outline" onClick={queueSteer} disabled={!steering.trim() || !queueSteerAvailable}>
+            <Send className="h-4 w-4 mr-1" /> Queue steer
           </Button>
+          {running && (
+            <Button size="sm" onClick={interruptSteer} disabled={!steering.trim() || !interruptSteerAvailable} title={interruptSteerAvailable ? "Interrupt and resume native session" : interruptSteerReason}>
+              <GitBranch className="h-4 w-4 mr-1" /> Interrupt & Steer
+            </Button>
+          )}
         </div>
       </Card>
 


### PR DESCRIPTION
## Summary
- make /resume provider-native and move mechanical handoff to /resume/handoff
- make Interrupt & Steer stop/wait, rebuild sandbox containers, and resume natively with the directive
- expose runtime control capability fields and update task detail controls/timeline projection

## Tests
- go test -count=1 ./internal/task ./internal/runner ./internal/runtime ./internal/adapters ./internal/runtimeplugin ./internal/timeline ./internal/daemon -skip 'TestTrustedMCPProjectionSmoke'
- npm test -- --run TaskDetailPage (web)
- npm run build (web)