### PR TITLE
Finish continuation model selection controls

### DIFF
--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -31,6 +32,18 @@ var (
 	errNativeResumeUnavailable  = errors.New("native resume unavailable")
 	errNativeSessionUnavailable = errors.New("native session unavailable")
 )
+
+type taskContinuationSelectionInput struct {
+	RuntimeProfileID string         `json:"runtime_profile_id"`
+	ModelProviderID  string         `json:"model_provider_id"`
+	ModelOverride    string         `json:"model_override"`
+	SubmittedBy      string         `json:"submitted_by"`
+	Config           map[string]any `json:"config"`
+}
+
+func (input taskContinuationSelectionInput) hasSelection() bool {
+	return strings.TrimSpace(input.RuntimeProfileID) != "" || strings.TrimSpace(input.ModelProviderID) != ""
+}
 
 func (server *Server) handleCreateTask(response http.ResponseWriter, request *http.Request) {
 	projectID := request.PathValue("id")
@@ -742,11 +755,27 @@ func (server *Server) handleResumeTask(response http.ResponseWriter, request *ht
 		writeError(response, http.StatusConflict, "task is already running")
 		return
 	}
+	var input taskContinuationSelectionInput
+	if err := decodeOptionalJSON(request, &input); err != nil {
+		writeError(response, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
 	if !server.acquireTaskControl(taskID) {
 		writeError(response, http.StatusConflict, "task control operation already active")
 		return
 	}
 	defer server.releaseTaskControl(taskID)
+	if input.hasSelection() {
+		if _, ok := server.recordSelectedRuntimeConfig(response, found, "", input); !ok {
+			return
+		}
+		refreshed, err := server.tasks.Get(taskID)
+		if err != nil {
+			writeTaskError(response, err)
+			return
+		}
+		found = refreshed
+	}
 	found, resumeGoal, plan, err := server.prepareNativeResumeContinuation(found, "")
 	if err != nil {
 		server.writeResumePreparationError(response, err)
@@ -980,10 +1009,8 @@ func (server *Server) handleQueueSteerTask(response http.ResponseWriter, request
 		return
 	}
 	var input struct {
-		Directive        string         `json:"directive"`
-		RuntimeProfileID string         `json:"runtime_profile_id"`
-		SubmittedBy      string         `json:"submitted_by"`
-		Config           map[string]any `json:"config"`
+		Directive string `json:"directive"`
+		taskContinuationSelectionInput
 	}
 	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
 		writeError(response, http.StatusBadRequest, "invalid JSON body")
@@ -1004,14 +1031,20 @@ func (server *Server) handleQueueSteerTask(response http.ResponseWriter, request
 	if input.RuntimeProfileID != "" {
 		payload["runtime_profile_id"] = input.RuntimeProfileID
 	}
+	if input.ModelProviderID != "" {
+		payload["model_provider_id"] = input.ModelProviderID
+	}
+	if input.ModelOverride != "" {
+		payload["model_override"] = input.ModelOverride
+	}
 	event, err := server.tasks.AppendEvent(taskID, task.EventKindSteering, payload)
 	if err != nil {
 		writeTaskError(response, err)
 		return
 	}
 	var configVersion *task.RuntimeConfigVersion
-	if input.RuntimeProfileID != "" {
-		recorded, ok := server.recordSteeredRuntimeConfig(response, found, event.ID, input.RuntimeProfileID, input.Config)
+	if input.hasSelection() {
+		recorded, ok := server.recordSelectedRuntimeConfig(response, found, event.ID, input.taskContinuationSelectionInput)
 		if !ok {
 			return
 		}
@@ -1045,10 +1078,8 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 	}
 
 	var input struct {
-		Directive        string         `json:"directive"`
-		RuntimeProfileID string         `json:"runtime_profile_id"`
-		SubmittedBy      string         `json:"submitted_by"`
-		Config           map[string]any `json:"config"`
+		Directive string `json:"directive"`
+		taskContinuationSelectionInput
 	}
 	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
 		writeError(response, http.StatusBadRequest, "invalid JSON body")
@@ -1078,6 +1109,12 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 	if input.RuntimeProfileID != "" {
 		payload["runtime_profile_id"] = input.RuntimeProfileID
 	}
+	if input.ModelProviderID != "" {
+		payload["model_provider_id"] = input.ModelProviderID
+	}
+	if input.ModelOverride != "" {
+		payload["model_override"] = input.ModelOverride
+	}
 
 	event, err := server.tasks.AppendEvent(taskID, task.EventKindSteering, payload)
 	if err != nil {
@@ -1086,8 +1123,8 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 	}
 
 	var configVersion *task.RuntimeConfigVersion
-	if input.RuntimeProfileID != "" {
-		recorded, ok := server.recordSteeredRuntimeConfig(response, found, event.ID, input.RuntimeProfileID, input.Config)
+	if input.hasSelection() {
+		recorded, ok := server.recordSelectedRuntimeConfig(response, found, event.ID, input.taskContinuationSelectionInput)
 		if !ok {
 			return
 		}
@@ -1162,42 +1199,123 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 	})
 }
 
-func (server *Server) recordSteeredRuntimeConfig(response http.ResponseWriter, found task.Task, steeringEventID string, runtimeProfileID string, config map[string]any) (task.RuntimeConfigVersion, bool) {
-	currentProfile, err := server.resolveTaskRuntimeProfile(found)
-	if err != nil {
-		if errors.Is(err, runtimeprofile.ErrNotFound) {
-			writeError(response, http.StatusBadRequest, "runtime profile not found")
-			return task.RuntimeConfigVersion{}, false
-		}
-		writeError(response, http.StatusInternalServerError, "load runtime profile")
-		return task.RuntimeConfigVersion{}, false
+func decodeOptionalJSON(request *http.Request, target any) error {
+	if request.Body == nil {
+		return nil
 	}
-	requestedProfile, err := server.profiles.Get(runtimeProfileID)
-	if err != nil {
-		if errors.Is(err, runtimeprofile.ErrNotFound) {
-			writeError(response, http.StatusBadRequest, "runtime profile not found")
-			return task.RuntimeConfigVersion{}, false
-		}
-		writeError(response, http.StatusInternalServerError, "load runtime profile")
-		return task.RuntimeConfigVersion{}, false
+	err := json.NewDecoder(request.Body).Decode(target)
+	if errors.Is(err, io.EOF) {
+		return nil
 	}
-	if requestedProfile.Provider != currentProfile.Provider {
-		writeError(response, http.StatusBadRequest, "steering runtime profile must keep the same runtime provider")
+	return err
+}
+
+func (server *Server) recordSelectedRuntimeConfig(response http.ResponseWriter, found task.Task, steeringEventID string, input taskContinuationSelectionInput) (task.RuntimeConfigVersion, bool) {
+	requestedProfile, ok := server.resolveTaskContinuationRuntimeProfile(response, found, input)
+	if !ok {
 		return task.RuntimeConfigVersion{}, false
 	}
 
+	config := input.Config
 	if config == nil {
 		config = map[string]any{}
 	}
-	config["runtime_profile_id"] = runtimeProfileID
+	config["runtime_profile_id"] = requestedProfile.ID
 	config["runner"] = found.Runner
-	config["steering_event_id"] = steeringEventID
-	recorded, err := server.tasks.RecordRuntimeConfig(found.ID, runtimeProfileID, config)
+	if steeringEventID != "" {
+		config["steering_event_id"] = steeringEventID
+	}
+	if requestedProfile.Fields.ModelProviderID != "" {
+		config["model_provider_id"] = requestedProfile.Fields.ModelProviderID
+	}
+	if requestedProfile.Fields.ModelOverride != "" {
+		config["model_override"] = requestedProfile.Fields.ModelOverride
+	}
+	recorded, err := server.tasks.RecordRuntimeConfig(found.ID, requestedProfile.ID, config)
 	if err != nil {
 		writeTaskError(response, err)
 		return task.RuntimeConfigVersion{}, false
 	}
 	return recorded, true
+}
+
+func (server *Server) resolveTaskContinuationRuntimeProfile(response http.ResponseWriter, found task.Task, input taskContinuationSelectionInput) (runtimeprofile.Profile, bool) {
+	currentProfile, err := server.resolveTaskRuntimeProfile(found)
+	if err != nil {
+		if errors.Is(err, runtimeprofile.ErrNotFound) {
+			writeError(response, http.StatusBadRequest, "runtime profile not found")
+			return runtimeprofile.Profile{}, false
+		}
+		writeError(response, http.StatusInternalServerError, "load runtime profile")
+		return runtimeprofile.Profile{}, false
+	}
+	return server.resolveSelectedRuntimeProfile(response, currentProfile, input)
+}
+
+func (server *Server) resolveSelectedRuntimeProfile(response http.ResponseWriter, currentProfile runtimeprofile.Profile, input taskContinuationSelectionInput) (runtimeprofile.Profile, bool) {
+	runtimeProfileID := strings.TrimSpace(input.RuntimeProfileID)
+	modelProviderID := strings.TrimSpace(input.ModelProviderID)
+	if runtimeProfileID != "" && modelProviderID != "" {
+		writeError(response, http.StatusBadRequest, "choose runtime_profile_id or model_provider_id, not both")
+		return runtimeprofile.Profile{}, false
+	}
+	if runtimeProfileID != "" {
+		requestedProfile, err := server.profiles.Get(runtimeProfileID)
+		if err != nil {
+			if errors.Is(err, runtimeprofile.ErrNotFound) {
+				writeError(response, http.StatusBadRequest, "runtime profile not found")
+				return runtimeprofile.Profile{}, false
+			}
+			writeError(response, http.StatusInternalServerError, "load runtime profile")
+			return runtimeprofile.Profile{}, false
+		}
+		if requestedProfile.Provider != currentProfile.Provider {
+			writeError(response, http.StatusBadRequest, "steering runtime profile must keep the same runtime provider")
+			return runtimeprofile.Profile{}, false
+		}
+		return requestedProfile, true
+	}
+	if modelProviderID == "" {
+		return currentProfile, true
+	}
+
+	providerName := modelProviderID
+	if server.modelProviders != nil {
+		provider, err := server.modelProviders.Get(modelProviderID)
+		if err != nil {
+			if errors.Is(err, modelprovider.ErrNotFound) {
+				writeError(response, http.StatusBadRequest, "model provider not found")
+				return runtimeprofile.Profile{}, false
+			}
+			writeError(response, http.StatusInternalServerError, "load model provider")
+			return runtimeprofile.Profile{}, false
+		}
+		providerName = provider.Name
+	}
+
+	modelOverride := strings.TrimSpace(input.ModelOverride)
+	if strings.TrimSpace(currentProfile.Fields.ModelProviderID) == modelProviderID &&
+		strings.TrimSpace(currentProfile.Fields.ModelOverride) == modelOverride {
+		return currentProfile, true
+	}
+	fields := currentProfile.Fields
+	fields.ModelProviderID = modelProviderID
+	fields.ModelOverride = modelOverride
+	fields.ModelProviderProtocol = ""
+	fields.Model = ""
+	fields.Endpoint = ""
+	fields.APIKeys = nil
+	name := runtimeprofile.LaunchProfileName(runtimeprofile.LaunchSelection{
+		Provider:        currentProfile.Provider,
+		ModelProviderID: modelProviderID,
+		ModelOverride:   modelOverride,
+	}, providerName)
+	created, err := server.profiles.CreateLaunchResolved(name, currentProfile.Provider, fields)
+	if err != nil {
+		writeError(response, http.StatusBadRequest, err.Error())
+		return runtimeprofile.Profile{}, false
+	}
+	return created, true
 }
 
 func (server *Server) resolveTaskRuntimeProfile(found task.Task) (runtimeprofile.Profile, error) {

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -928,6 +928,24 @@ func quoteJSON(value string) string {
 	return string(raw)
 }
 
+func createModelProvider(t *testing.T, server *daemon.Server, body string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/model-providers", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	server.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected create model provider status 201, got %d with body %s", resp.Code, resp.Body.String())
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode model provider: %v", err)
+	}
+	return created.ID
+}
+
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
@@ -1193,6 +1211,102 @@ func TestQueueSteerRecordsSameProviderRuntimeProfileForNextContinuation(t *testi
 	waitForTaskStatus(t, server, projectID, taskID, "completed")
 }
 
+func TestQueueSteerRecordsSameRuntimeModelSelection(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	server := newDaemonWithConfig(t, daemon.Config{
+		Version:              "test-version",
+		DBPath:               filepath.Join(t.TempDir(), "pentest.db"),
+		RuntimeRoot:          runtimeRoot,
+		DisableBuiltinSkills: true,
+	})
+	projectID := createProject(t, server, `{"name":"Acme","scope":{"domains":["example.com"]}}`)
+
+	binary := filepath.Join(t.TempDir(), "codex-test")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\necho codex-provider:$*\n"), 0o700); err != nil {
+		t.Fatalf("write provider binary: %v", err)
+	}
+	profileID := createLocalRuntimeProfile(t, server, "Codex Test", runtimeprofile.ProviderCodex, runtimeprofile.Fields{
+		BinaryPath: binary,
+		Model:      "gpt-test",
+	})
+	taskID := createTask(t, server, projectID, `{
+		"goal":"enumerate example.com",
+		"runtime_profile_id":`+quoteJSON(profileID)+`,
+		"runner":"host",
+		"run_controls":{"host_activated":true}
+	}`)
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
+
+	providerID := createModelProvider(t, server, `{
+		"name":"MiMo",
+		"base_url":"https://api.example.test/v1",
+		"protocols":["openai_responses"],
+		"catalog":{"manual":["mimo-v2-flash","mimo-v2-pro"],"default_model":"mimo-v2-flash"}
+	}`)
+
+	steerResp := httptest.NewRecorder()
+	steerReq := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/steer/queue", bytes.NewReader([]byte(`{
+		"directive":"continue with mimo pro",
+		"model_provider_id":`+quoteJSON(providerID)+`,
+		"model_override":"mimo-v2-pro"
+	}`)))
+	steerReq.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(steerResp, steerReq)
+	if steerResp.Code != http.StatusOK {
+		t.Fatalf("expected queue steer status 200, got %d with body %s", steerResp.Code, steerResp.Body.String())
+	}
+	var queued struct {
+		RuntimeConfigVersion *struct {
+			RuntimeProfileID string         `json:"runtime_profile_id"`
+			Config           map[string]any `json:"config"`
+		} `json:"runtime_config_version"`
+	}
+	if err := json.NewDecoder(steerResp.Body).Decode(&queued); err != nil {
+		t.Fatalf("decode queue steer: %v", err)
+	}
+	if queued.RuntimeConfigVersion == nil {
+		t.Fatal("expected queued runtime config version")
+	}
+	queuedProfileID := queued.RuntimeConfigVersion.RuntimeProfileID
+	if queuedProfileID == "" || queuedProfileID == profileID {
+		t.Fatalf("expected launch-resolved continuation profile, got %q", queuedProfileID)
+	}
+	if queued.RuntimeConfigVersion.Config["model_provider_id"] != providerID {
+		t.Fatalf("expected queued model provider %q, got %#v", providerID, queued.RuntimeConfigVersion.Config)
+	}
+	if queued.RuntimeConfigVersion.Config["model_override"] != "mimo-v2-pro" {
+		t.Fatalf("expected queued model override, got %#v", queued.RuntimeConfigVersion.Config)
+	}
+
+	getProfile := httptest.NewRequest(http.MethodGet, "/api/runtime-profiles/"+queuedProfileID, nil)
+	getResp := httptest.NewRecorder()
+	server.ServeHTTP(getResp, getProfile)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("expected get profile status 200, got %d with body %s", getResp.Code, getResp.Body.String())
+	}
+	var profile struct {
+		Provider string `json:"provider"`
+		Kind     string `json:"kind"`
+		Fields   struct {
+			BinaryPath      string `json:"binary_path"`
+			ModelProviderID string `json:"model_provider_id"`
+			ModelOverride   string `json:"model_override"`
+		} `json:"fields"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	if profile.Provider != "codex" || profile.Kind != "launch_resolve" {
+		t.Fatalf("expected same-runtime launch profile, got %#v", profile)
+	}
+	if profile.Fields.BinaryPath != binary {
+		t.Fatalf("expected continuation profile to preserve binary path %q, got %q", binary, profile.Fields.BinaryPath)
+	}
+	if profile.Fields.ModelProviderID != providerID || profile.Fields.ModelOverride != "mimo-v2-pro" {
+		t.Fatalf("expected continuation model selection, got %#v", profile.Fields)
+	}
+}
+
 func TestResumeTaskUsesCodexNativeResumeWhenSessionExists(t *testing.T) {
 	runtimeRoot := t.TempDir()
 	server := newDaemonWithConfig(t, daemon.Config{
@@ -1238,6 +1352,103 @@ func TestResumeTaskUsesCodexNativeResumeWhenSessionExists(t *testing.T) {
 
 	waitForEventText(t, server, projectID, taskID, "resume sess-123")
 	waitForTaskStatus(t, server, projectID, taskID, "completed")
+}
+
+func TestResumeTaskUsesContinuationModelSelectionWithoutDroppingRuntimeFields(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	server := newDaemonWithConfig(t, daemon.Config{
+		Version:              "test-version",
+		DBPath:               filepath.Join(t.TempDir(), "pentest.db"),
+		RuntimeRoot:          runtimeRoot,
+		DisableBuiltinSkills: true,
+	})
+	projectID := createProject(t, server, `{"name":"Acme","scope":{"domains":["example.com"]}}`)
+
+	binary := filepath.Join(t.TempDir(), "codex-test")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\necho codex-provider:$*\n"), 0o700); err != nil {
+		t.Fatalf("write provider binary: %v", err)
+	}
+	profileID := createLocalRuntimeProfile(t, server, "Codex Test", runtimeprofile.ProviderCodex, runtimeprofile.Fields{
+		BinaryPath: binary,
+		Model:      "gpt-test",
+	})
+	taskID := createTask(t, server, projectID, `{
+		"goal":"enumerate example.com",
+		"runtime_profile_id":`+quoteJSON(profileID)+`,
+		"runner":"host",
+		"run_controls":{"host_activated":true}
+	}`)
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
+
+	sessionPath := filepath.Join(runtimeRoot, taskID, "runtime-home", "codex", "sessions", "2026", "07", "04", "rollout-test.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o700); err != nil {
+		t.Fatalf("mkdir session path: %v", err)
+	}
+	sessionMeta := `{"timestamp":"2026-07-04T00:00:00Z","type":"session_meta","payload":{"session_id":"sess-456","cwd":"` + runtimeRoot + `"}}` + "\n"
+	if err := os.WriteFile(sessionPath, []byte(sessionMeta), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+	t.Setenv("MIMO_API_KEY", "sk-test")
+	providerID := createModelProvider(t, server, `{
+		"name":"MiMo",
+		"base_url":"https://api.example.test/v1",
+		"protocols":["openai_responses"],
+		"catalog":{"manual":["mimo-v2-pro"],"default_model":"mimo-v2-pro"}
+	}`)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+taskID+"/resume", bytes.NewReader([]byte(`{
+		"model_provider_id":`+quoteJSON(providerID)+`,
+		"model_override":"mimo-v2-pro"
+	}`)))
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("expected resume status 202, got %d with body %s", resp.Code, resp.Body.String())
+	}
+	waitForEventText(t, server, projectID, taskID, "resume sess-456")
+	waitForTaskStatus(t, server, projectID, taskID, "completed")
+
+	detailResp := httptest.NewRecorder()
+	detailReq := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID+"/tasks/"+taskID, nil)
+	server.ServeHTTP(detailResp, detailReq)
+	if detailResp.Code != http.StatusOK {
+		t.Fatalf("expected get task status 200, got %d with body %s", detailResp.Code, detailResp.Body.String())
+	}
+	var resumed struct {
+		LatestContinuation *struct {
+			RuntimeProfileID string `json:"runtime_profile_id"`
+		} `json:"latest_continuation"`
+	}
+	if err := json.NewDecoder(detailResp.Body).Decode(&resumed); err != nil {
+		t.Fatalf("decode resumed task: %v", err)
+	}
+	if resumed.LatestContinuation == nil || resumed.LatestContinuation.RuntimeProfileID == profileID {
+		t.Fatalf("expected continuation-specific runtime profile, got %#v", resumed.LatestContinuation)
+	}
+
+	getProfile := httptest.NewRequest(http.MethodGet, "/api/runtime-profiles/"+resumed.LatestContinuation.RuntimeProfileID, nil)
+	getResp := httptest.NewRecorder()
+	server.ServeHTTP(getResp, getProfile)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("expected get profile status 200, got %d with body %s", getResp.Code, getResp.Body.String())
+	}
+	var profile struct {
+		Fields struct {
+			BinaryPath      string `json:"binary_path"`
+			ModelProviderID string `json:"model_provider_id"`
+			ModelOverride   string `json:"model_override"`
+		} `json:"fields"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	if profile.Fields.BinaryPath != binary {
+		t.Fatalf("expected continuation profile to preserve binary path %q, got %q", binary, profile.Fields.BinaryPath)
+	}
+	if profile.Fields.ModelProviderID != providerID || profile.Fields.ModelOverride != "mimo-v2-pro" {
+		t.Fatalf("expected continuation model selection, got %#v", profile.Fields)
+	}
 }
 
 func TestResumeTaskFailsWhenNativeSessionIsMissing(t *testing.T) {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
@@ -24,7 +25,7 @@ function stubTaskDetailApi() {
     configurable: true,
   });
 
-  mockApi({
+  const fetchMock = mockApi({
     "/api/projects/project-1/tasks/task-1/timeline": {
       task_id: "task-1",
       items: [{ seq: 1, type: "text", content: "Timeline opened first", created_at: "2026-01-01T00:00:00Z" }],
@@ -79,13 +80,53 @@ function stubTaskDetailApi() {
     },
     "/api/runtime-profiles": {
       profiles: [
-        { id: "profile-1", name: "Codex", provider: "codex" },
-        { id: "profile-2", name: "Fake", provider: "fake" },
+        { id: "profile-1", name: "Codex", provider: "codex", fields: {} },
+        { id: "profile-2", name: "Fake", provider: "fake", fields: {} },
+      ],
+    },
+    "/api/model-providers": {
+      providers: [
+        {
+          id: "mimo",
+          name: "MiMo",
+          base_url: "https://api.example.test/v1",
+          protocols: ["openai_responses"],
+          api_key_env: "MIMO_API_KEY",
+          catalog: { manual: ["mimo-v2-flash", "mimo-v2-pro"], default_model: "mimo-v2-flash" },
+        },
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          base_url: "https://api.anthropic.test/v1",
+          protocols: ["anthropic_messages"],
+          api_key_env: "ANTHROPIC_API_KEY",
+          catalog: { manual: ["claude-sonnet"], default_model: "claude-sonnet" },
+        },
+      ],
+    },
+    "/api/runtime-plugins": {
+      plugins: [
+        {
+          schema_version: 1,
+          id: "codex",
+          name: "Codex",
+          binary: { default: "codex" },
+          capabilities: { sandbox: true, host: true, mcp_config: true, streaming_transcript: true, resume: true },
+          model_provider: {
+            requirement: "required",
+            supported_protocols: ["openai_responses"],
+            protocol_preference: ["openai_responses"],
+          },
+          profile_schema: { fields: [] },
+          config_projection: { primitive: "codex" },
+          launch: { args: [] },
+          transcript: { parser: "codex" },
+        },
       ],
     },
   });
 
-  return { scrollIntoView };
+  return { fetchMock, scrollIntoView };
 }
 
 describe("TaskDetailPage", () => {
@@ -129,7 +170,34 @@ describe("TaskDetailPage", () => {
     expect(await screen.findByRole("button", { name: /Resume$/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Resume with handoff/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Queue steer/ })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /Use Codex/ })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: /Use Fake/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Continuation model provider" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "MiMo" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Anthropic" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Use Codex/ })).not.toBeInTheDocument();
+  });
+
+  it("queues steering with a continuation model selection", async () => {
+    const { fetchMock } = stubTaskDetailApi();
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await screen.findByText("Timeline opened first");
+    await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model provider" }), "mimo");
+    await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model" }), "mimo-v2-pro");
+    await user.type(screen.getByPlaceholderText("Focus on admin.example.com next"), "continue with mimo");
+    await user.click(screen.getByRole("button", { name: /Queue steer/ }));
+
+    const steerCall = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes("/api/projects/project-1/tasks/task-1/steer/queue"),
+    );
+    expect(steerCall?.[1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({
+        directive: "continue with mimo",
+        model_provider_id: "mimo",
+        model_override: "mimo-v2-pro",
+      }),
+    });
   });
 });

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState, useRef, type RefObject } from "react";
+import { useEffect, useMemo, useState, useRef, type RefObject } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Square, Send, Terminal, Activity, GitBranch, MessageSquare, Play, FileText, Shield, ChevronRight, Wrench, User, Bot, ArrowDown, ArrowUp } from "lucide-react";
-import { apiGet, apiPost, type Task, type TaskTimeline, type TaskTimelineItem, type TaskTranscript, type TaskTranscriptEntry } from "@/lib/api";
+import { apiGet, apiPost, type ModelProvider, type RuntimePlugin, type RuntimeProfile, type Task, type TaskTimeline, type TaskTimelineItem, type TaskTranscript, type TaskTranscriptEntry } from "@/lib/api";
 import { Button, Card, Input, Badge } from "@/components/ui";
 import { BackLink, PageContainer } from "@/components/shared";
 import { AgentTranscriptView } from "@/components/task-transcript/AgentTranscriptView";
 import { collapsedTranscriptTitle } from "./taskDetailView";
+import { selectableModelProviders } from "./runtimeProfileForm";
+import { modelsForProvider } from "./taskLaunchForm";
 
 const ACTIVE = new Set(["running", "paused"]);
 
@@ -18,8 +20,11 @@ export function TaskDetailPage() {
   const [autoFollow, setAutoFollow] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [steering, setSteering] = useState("");
-  const [steeringProfile, setSteeringProfile] = useState("");
-  const [profiles, setProfiles] = useState<{ id: string; name: string; provider?: string }[]>([]);
+  const [continuationModelProvider, setContinuationModelProvider] = useState("");
+  const [continuationModelOverride, setContinuationModelOverride] = useState("");
+  const [profiles, setProfiles] = useState<RuntimeProfile[]>([]);
+  const [modelProviders, setModelProviders] = useState<ModelProvider[]>([]);
+  const [runtimePlugins, setRuntimePlugins] = useState<RuntimePlugin[]>([]);
   const pageRef = useRef<HTMLDivElement>(null);
   const timelineEnd = useRef<HTMLDivElement>(null);
   const autoFollowRef = useRef(true);
@@ -48,7 +53,11 @@ export function TaskDetailPage() {
     // Initial load on mount/task change. loadAll() is reused by the poll loop
     // and event handlers.
     loadAll();
-    apiGet<{ profiles: { id: string; name: string }[] }>("/api/runtime-profiles").then((d) => setProfiles(d.profiles ?? [])).catch(() => {});
+    Promise.all([
+      apiGet<{ profiles: RuntimeProfile[] }>("/api/runtime-profiles").then((d) => setProfiles(d.profiles ?? [])),
+      apiGet<{ providers: ModelProvider[] }>("/api/model-providers").then((d) => setModelProviders(d.providers ?? [])),
+      apiGet<{ plugins: RuntimePlugin[] }>("/api/runtime-plugins").then((d) => setRuntimePlugins(d.plugins ?? [])),
+    ]).catch(() => {});
   }, [projectId, taskId]);
   /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
@@ -93,6 +102,37 @@ export function TaskDetailPage() {
     }
   }, [activeView, timeline, transcript]);
 
+  const currentProfileRuntimeProvider = profiles.find((profile) => profile.id === task?.runtime_profile_id)?.provider;
+  const currentRuntimeProvider =
+    task?.runtime_controls?.runtime_provider ??
+    task?.active_continuation?.runtime_provider ??
+    task?.latest_continuation?.runtime_provider ??
+    currentProfileRuntimeProvider;
+  const runtimePlugin = runtimePlugins.find((plugin) => plugin.id === currentRuntimeProvider);
+  const continuationModelProviders = selectableModelProviders(
+    modelProviders,
+    runtimePlugin,
+    continuationModelProvider,
+  );
+  const selectedContinuationModelProvider =
+    continuationModelProviders.find((provider) => provider.id === continuationModelProvider) ??
+    modelProviders.find((provider) => provider.id === continuationModelProvider);
+  const continuationModelOptions = useMemo(
+    () => modelsForProvider(selectedContinuationModelProvider),
+    [selectedContinuationModelProvider],
+  );
+
+  useEffect(() => {
+    if (!continuationModelProvider) {
+      if (continuationModelOverride) setContinuationModelOverride("");
+      return;
+    }
+    if (continuationModelOverride && continuationModelOptions.includes(continuationModelOverride)) {
+      return;
+    }
+    setContinuationModelOverride(continuationModelOptions[0] ?? "");
+  }, [continuationModelProvider, continuationModelOptions, continuationModelOverride]);
+
   function scrollToLatest() {
     const container = findScrollContainer(pageRef.current);
     autoFollowRef.current = true;
@@ -118,7 +158,8 @@ export function TaskDetailPage() {
 
   async function resumeNative() {
     try {
-      await apiPost(`${base}/resume`, {});
+      await apiPost(`${base}/resume`, continuationModelPayload());
+      resetContinuationModelSelection();
       loadAll();
     } catch (e) {
       setError((e as Error).message);
@@ -138,10 +179,10 @@ export function TaskDetailPage() {
     try {
       await apiPost(`${base}/steer/queue`, {
         directive: steering,
-        runtime_profile_id: steeringProfile || undefined,
+        ...continuationModelPayload(),
       });
       setSteering("");
-      setSteeringProfile("");
+      resetContinuationModelSelection();
       loadAll();
     } catch (e) {
       setError((e as Error).message);
@@ -152,14 +193,37 @@ export function TaskDetailPage() {
     try {
       await apiPost(`${base}/steer`, {
         directive: steering,
-        runtime_profile_id: steeringProfile || undefined,
+        ...continuationModelPayload(),
       });
       setSteering("");
-      setSteeringProfile("");
+      resetContinuationModelSelection();
       loadAll();
     } catch (e) {
       setError((e as Error).message);
     }
+  }
+
+  function continuationModelPayload() {
+    const providerID = continuationModelProvider.trim();
+    if (!providerID) return {};
+    const payload: { model_provider_id: string; model_override?: string } = {
+      model_provider_id: providerID,
+    };
+    const modelOverride = continuationModelOverride.trim();
+    if (modelOverride) payload.model_override = modelOverride;
+    return payload;
+  }
+
+  function resetContinuationModelSelection() {
+    setContinuationModelProvider("");
+    setContinuationModelOverride("");
+  }
+
+  function selectContinuationModelProvider(providerID: string) {
+    setContinuationModelProvider(providerID);
+    const provider = continuationModelProviders.find((item) => item.id === providerID) ??
+      modelProviders.find((item) => item.id === providerID);
+    setContinuationModelOverride(modelsForProvider(provider)[0] ?? "");
   }
 
   if (error) return <PageContainer className="text-destructive">{error}</PageContainer>;
@@ -173,7 +237,6 @@ export function TaskDetailPage() {
   const nativeResumeReason = controls?.native_resume_reason ?? "Native resume unavailable";
   const interruptSteerReason = controls?.interrupt_steer_reason ?? nativeResumeReason;
   const running = ACTIVE.has(task.status);
-  const sameRuntimeProfiles = profiles.filter((profile) => !controls?.runtime_provider || profile.provider === controls.runtime_provider);
 
   return (
     <PageContainer ref={pageRef} className="max-w-4xl">
@@ -240,13 +303,26 @@ export function TaskDetailPage() {
         <div className="flex flex-wrap gap-2 items-center">
           <select
             className="h-8 max-w-xs rounded-md border border-input bg-background px-2 text-sm"
-            value={steeringProfile}
-            onChange={(e) => setSteeringProfile(e.target.value)}
-            aria-label="Steering runtime profile"
+            value={continuationModelProvider}
+            onChange={(e) => selectContinuationModelProvider(e.target.value)}
+            aria-label="Continuation model provider"
           >
-            <option value="">Keep current model</option>
-            {sameRuntimeProfiles.map((profile) => (
-              <option key={profile.id} value={profile.id}>Use {profile.name}</option>
+            <option value="">Keep current model provider</option>
+            {continuationModelProviders.map((provider) => (
+              <option key={provider.id} value={provider.id}>{provider.name}</option>
+            ))}
+          </select>
+          <select
+            className="h-8 max-w-xs rounded-md border border-input bg-background px-2 text-sm disabled:opacity-60"
+            value={continuationModelOverride}
+            onChange={(e) => setContinuationModelOverride(e.target.value)}
+            aria-label="Continuation model"
+            disabled={!continuationModelProvider || continuationModelOptions.length === 0}
+          >
+            {continuationModelOptions.length === 0 ? (
+              <option value="">Default model</option>
+            ) : continuationModelOptions.map((model) => (
+              <option key={model} value={model}>{model}</option>
             ))}
           </select>
           <Button size="sm" variant="outline" onClick={queueSteer} disabled={!steering.trim() || !queueSteerAvailable}>


### PR DESCRIPTION
## Summary
- replace Task Detail's generic steering runtime-profile selector with continuation-scoped model provider/model controls
- accept model_provider_id/model_override on native resume, queue steer, and interrupt steer while preserving the current runtime profile's runtime-specific fields
- add backend and frontend coverage for continuation model selection and same-runtime preservation

## Verification
- rtk env GOCACHE=/private/tmp/pentest-go-cache go test -count=1 ./...
- rtk npm test
- rtk npm run build