### PR TITLE
fix(runtime): persist resume reasoning_effort on turn_selection

### DIFF
--- a/internal/daemon/runtime_turn_selection_test.go
+++ b/internal/daemon/runtime_turn_selection_test.go
@@ -1672,3 +1672,203 @@ func TestPiV2LaunchDoesNotDeadlockListingGlobalProviders(t *testing.T) {
 		t.Fatal("Pi v2 launch deadlocked listing global Model Providers inside CreateContinuation")
 	}
 }
+
+func TestHasSelectionIncludesReasoningEffortOnly(t *testing.T) {
+	if !(taskContinuationSelectionInput{ReasoningEffort: "xhigh"}).hasSelection() {
+		t.Fatal("effort-only input must count as a Runtime Turn Selection")
+	}
+	if (taskContinuationSelectionInput{}).hasSelection() {
+		t.Fatal("empty input must not count as a selection")
+	}
+}
+
+// Resume must retain an explicit reasoning_effort from the request body on
+// turn_selection even when an older conversation turn still says high.
+func TestResumeReasoningEffortOnlyUpdatesTurnSelection(t *testing.T) {
+	root := t.TempDir()
+	binary := filepath.Join(root, "codex")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\necho ok\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewServer(Config{
+		DBPath: filepath.Join(root, "pentest.db"), RuntimeRoot: filepath.Join(root, "runs"),
+		DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	projectRecord, err := server.projects.Create("Project", "", project.Scope{Domains: []string{"example.com"}}, project.Defaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, err := server.profiles.Create("Codex", runtimeprofile.ProviderCodex, runtimeprofile.Fields{
+		Model: "gpt-test", ReasoningEffort: "high", BinaryPath: binary,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := server.tasks.Create(task.CreateRequest{
+		ProjectID: projectRecord.ID, Goal: "inspect", RuntimeProfileID: profile.ID, Runner: task.RunnerHost,
+		RunControls: task.RunControls{HostActivated: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate turn 1 conversation selection stuck at high (older than the
+	// resume config that follows).
+	if _, err := server.tasks.AppendEvent(created.ID, task.EventKindConversation, task.EventPayload{
+		"role":                       "user",
+		"text":                       "first turn",
+		"model_provider_id":          "",
+		"model":                      "gpt-test",
+		"requested_reasoning_effort": "high",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateStatus(created.ID, task.StatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	// Ensure conversation timestamp is strictly older than the resume config.
+	time.Sleep(5 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectRecord.ID+"/tasks/"+created.ID+"/resume", strings.NewReader(`{
+		"reasoning_effort":"xhigh"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	server.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("resume status = %d body %s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		RuntimeControls struct {
+			TurnSelection *struct {
+				ReasoningEffort string `json:"reasoning_effort"`
+				Model           string `json:"model"`
+			} `json:"turn_selection"`
+		} `json:"runtime_controls"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.RuntimeControls.TurnSelection == nil {
+		t.Fatal("expected turn_selection on resume response")
+	}
+	if body.RuntimeControls.TurnSelection.ReasoningEffort != "xhigh" {
+		t.Fatalf("resume turn_selection.reasoning_effort = %q, want xhigh", body.RuntimeControls.TurnSelection.ReasoningEffort)
+	}
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectRecord.ID+"/tasks/"+created.ID, nil)
+	detailResp := httptest.NewRecorder()
+	server.ServeHTTP(detailResp, detailReq)
+	if detailResp.Code != http.StatusOK {
+		t.Fatalf("detail status = %d body %s", detailResp.Code, detailResp.Body.String())
+	}
+	var detail struct {
+		RuntimeControls struct {
+			TurnSelection *struct {
+				ReasoningEffort string `json:"reasoning_effort"`
+			} `json:"turn_selection"`
+		} `json:"runtime_controls"`
+	}
+	if err := json.NewDecoder(detailResp.Body).Decode(&detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail.RuntimeControls.TurnSelection == nil || detail.RuntimeControls.TurnSelection.ReasoningEffort != "xhigh" {
+		t.Fatalf("GET turn_selection after resume = %#v, want xhigh", detail.RuntimeControls.TurnSelection)
+	}
+
+	// Stop harness so the test process can exit cleanly.
+	if server.harness != nil {
+		server.harness.StopAndWait(created.ID, 2*time.Second)
+	}
+}
+
+func TestResumeFullSelectionKeepsXHighOverOlderConversation(t *testing.T) {
+	root := t.TempDir()
+	binary := filepath.Join(root, "codex")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\necho ok\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewServer(Config{
+		DBPath: filepath.Join(root, "pentest.db"), RuntimeRoot: filepath.Join(root, "runs"),
+		DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	projectRecord, err := server.projects.Create("Project", "", project.Scope{Domains: []string{"example.com"}}, project.Defaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, err := server.modelProviders.Create(modelprovider.CreateRequest{
+		Name: "Hub", BaseURL: "https://hub.example.test/v1",
+		Protocols: []modelprovider.Protocol{modelprovider.ProtocolOpenAIResponses},
+		Catalog:   modelprovider.Catalog{Manual: []string{"deepseek-v4-flash"}, DefaultModel: "deepseek-v4-flash"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HUB_API_KEY", "sk-test")
+	// Bind env for launch-ready if needed — profile uses explicit model.
+	profile, err := server.profiles.Create("Codex", runtimeprofile.ProviderCodex, runtimeprofile.Fields{
+		ModelProviderID: provider.ID, ModelOverride: "deepseek-v4-flash",
+		ReasoningEffort: "high", BinaryPath: binary,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := server.tasks.Create(task.CreateRequest{
+		ProjectID: projectRecord.ID, Goal: "inspect", RuntimeProfileID: profile.ID, Runner: task.RunnerHost,
+		RunControls: task.RunControls{HostActivated: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.AppendEvent(created.ID, task.EventKindConversation, task.EventPayload{
+		"role":                       "user",
+		"text":                       "first turn",
+		"model_provider_id":          provider.ID,
+		"model":                      "deepseek-v4-flash",
+		"requested_reasoning_effort": "high",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateStatus(created.ID, task.StatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * time.Millisecond)
+
+	body := fmt.Sprintf(`{
+		"model_provider_id":%q,
+		"model":"deepseek-v4-flash",
+		"reasoning_effort":"xhigh"
+	}`, provider.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectRecord.ID+"/tasks/"+created.ID+"/resume", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	server.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("resume status = %d body %s", resp.Code, resp.Body.String())
+	}
+	var accepted struct {
+		RuntimeControls struct {
+			TurnSelection *struct {
+				ReasoningEffort string `json:"reasoning_effort"`
+			} `json:"turn_selection"`
+		} `json:"runtime_controls"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&accepted); err != nil {
+		t.Fatal(err)
+	}
+	if accepted.RuntimeControls.TurnSelection == nil || accepted.RuntimeControls.TurnSelection.ReasoningEffort != "xhigh" {
+		t.Fatalf("resume turn_selection = %#v, want xhigh", accepted.RuntimeControls.TurnSelection)
+	}
+	if server.harness != nil {
+		server.harness.StopAndWait(created.ID, 2*time.Second)
+	}
+}

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -49,9 +49,12 @@ type taskContinuationSelectionInput struct {
 }
 
 func (input taskContinuationSelectionInput) hasSelection() bool {
+	// Effort-only changes are real Runtime Turn Selection. Resume/queue must
+	// record them; otherwise turn_selection stays stuck on the prior default.
 	return strings.TrimSpace(input.RuntimeProfileID) != "" ||
 		strings.TrimSpace(input.ModelProviderID) != "" ||
-		input.selectedModel() != ""
+		input.selectedModel() != "" ||
+		strings.TrimSpace(input.ReasoningEffort) != ""
 }
 
 func (input taskContinuationSelectionInput) hasRuntimeProfileSelection() bool {
@@ -2915,12 +2918,24 @@ func stringSliceFromConfig(value any) []string {
 }
 
 func (server *Server) currentTurnSelection(found task.Task) (runtime.ProviderSessionRequest, error) {
-	// Prefer the last turn's attached selection so the composer retains what
-	// the operator actually submitted, not a profile default.
-	if selection, ok := server.precedingConversationTurnSelection(found.ID); ok {
-		return selection, nil
+	// Prefer the most recent applied selection:
+	// - Conversation / steering events capture native same-session turns
+	//   (no Configuration Version).
+	// - Runtime Config Versions capture launch / resume / queue / restart
+	//   selections. After resume records xhigh, config must win over an older
+	//   conversation that still says high.
+	convSelection, convAt, convOK := server.precedingConversationTurnSelectionTimed(found.ID)
+	configSelection, configAt, configErr := server.selectionFromCapturedRuntimeConfigTimed(found)
+	if configErr != nil {
+		if convOK {
+			return convSelection, nil
+		}
+		return runtime.ProviderSessionRequest{}, configErr
 	}
-	return server.selectionFromCapturedRuntimeConfig(found)
+	if convOK && !convAt.IsZero() && (configAt.IsZero() || convAt.After(configAt)) {
+		return convSelection, nil
+	}
+	return configSelection, nil
 }
 
 // selectionFromCapturedRuntimeConfig resolves Model Provider / model / effort
@@ -2928,9 +2943,14 @@ func (server *Server) currentTurnSelection(found task.Task) (runtime.ProviderSes
 // Profile fields are only a fallback — launch-resolved and legacy profiles may
 // leave provider/model empty on the Profile while the captured snapshot is true.
 func (server *Server) selectionFromCapturedRuntimeConfig(found task.Task) (runtime.ProviderSessionRequest, error) {
+	selection, _, err := server.selectionFromCapturedRuntimeConfigTimed(found)
+	return selection, err
+}
+
+func (server *Server) selectionFromCapturedRuntimeConfigTimed(found task.Task) (runtime.ProviderSessionRequest, time.Time, error) {
 	profile, err := server.resolveTaskRuntimeProfile(found)
 	if err != nil {
-		return runtime.ProviderSessionRequest{}, err
+		return runtime.ProviderSessionRequest{}, time.Time{}, err
 	}
 	modelProviderID := strings.TrimSpace(profile.Fields.ModelProviderID)
 	model := strings.TrimSpace(profile.Fields.ModelOverride)
@@ -2938,12 +2958,15 @@ func (server *Server) selectionFromCapturedRuntimeConfig(found task.Task) (runti
 		model = strings.TrimSpace(profile.Fields.Model)
 	}
 	launchEffort := ""
+	var configAt time.Time
 	versions, err := server.tasks.RuntimeConfigVersions(found.ID)
 	if err != nil {
-		return runtime.ProviderSessionRequest{}, err
+		return runtime.ProviderSessionRequest{}, time.Time{}, err
 	}
 	if len(versions) > 0 {
-		latest := versions[len(versions)-1].Config
+		latestVersion := versions[len(versions)-1]
+		configAt = latestVersion.CreatedAt
+		latest := latestVersion.Config
 		// Snapshot first (actual projected provider/model), then explicit
 		// captured overrides from launch or later continuation selection.
 		if snapshotProvider, snapshotModel := modelProviderSnapshotFields(latest["model_provider_snapshot"]); true {
@@ -2980,13 +3003,13 @@ func (server *Server) selectionFromCapturedRuntimeConfig(found task.Task) (runti
 	}
 	requested, err := runtimeprofile.ResolveRequestedReasoningEffort("", launchEffort, profile.Fields.ReasoningEffort)
 	if err != nil {
-		return runtime.ProviderSessionRequest{}, err
+		return runtime.ProviderSessionRequest{}, time.Time{}, err
 	}
 	return runtime.ProviderSessionRequest{
 		ModelProviderID:          modelProviderID,
 		Model:                    model,
 		RequestedReasoningEffort: string(requested),
-	}, nil
+	}, configAt, nil
 }
 
 func modelProviderSnapshotFields(raw any) (providerID, model string) {
@@ -3007,9 +3030,14 @@ func modelProviderSnapshotFields(raw any) (providerID, model string) {
 }
 
 func (server *Server) precedingConversationTurnSelection(taskID string) (runtime.ProviderSessionRequest, bool) {
+	selection, _, ok := server.precedingConversationTurnSelectionTimed(taskID)
+	return selection, ok
+}
+
+func (server *Server) precedingConversationTurnSelectionTimed(taskID string) (runtime.ProviderSessionRequest, time.Time, bool) {
 	events, err := server.tasks.Events(taskID)
 	if err != nil {
-		return runtime.ProviderSessionRequest{}, false
+		return runtime.ProviderSessionRequest{}, time.Time{}, false
 	}
 	for index := len(events) - 1; index >= 0; index-- {
 		event := events[index]
@@ -3036,15 +3064,15 @@ func (server *Server) precedingConversationTurnSelection(taskID string) (runtime
 		}
 		requested, err := runtimeprofile.NormalizeReasoningEffort(effort)
 		if err != nil {
-			return runtime.ProviderSessionRequest{}, false
+			return runtime.ProviderSessionRequest{}, time.Time{}, false
 		}
 		return runtime.ProviderSessionRequest{
 			ModelProviderID:          strings.TrimSpace(providerID),
 			Model:                    strings.TrimSpace(model),
 			RequestedReasoningEffort: string(requested),
-		}, true
+		}, event.CreatedAt, true
 	}
-	return runtime.ProviderSessionRequest{}, false
+	return runtime.ProviderSessionRequest{}, time.Time{}, false
 }
 
 func nativeSteerIdempotencyConflict(prior task.Event, message string, selection runtime.ProviderSessionRequest) string {


### PR DESCRIPTION
## Summary
- Fixes the E2E defect where `/resume` with `reasoning_effort: xhigh` returned `turn_selection.reasoning_effort: high` and the UI reset after refresh.
- `hasSelection()` now includes effort-only changes.
- `currentTurnSelection` prefers the more recent of Runtime Config Version vs conversation/steering events.

## Test plan
- [x] `TestHasSelectionIncludesReasoningEffortOnly`
- [x] `TestResumeReasoningEffortOnlyUpdatesTurnSelection`
- [x] `TestResumeFullSelectionKeepsXHighOverOlderConversation`
- [x] Related Codex/Claude native steer + resume tests