### PR TITLE
fix(runtime): make Host process bridge build on Windows

### DIFF
--- a/internal/daemon/runtime_activity_test.go
+++ b/internal/daemon/runtime_activity_test.go
@@ -170,11 +170,15 @@ func TestRuntimeActivityLiveIdleAndBusyForSandboxProviders(t *testing.T) {
 			launchActivityTask(t, server, created)
 
 			// After launch turn settles, health is live/idle independent of Task status.
-			deadline := time.Now().Add(2 * time.Second)
+			// Wait for status to leave pending — harness mark-running can lag under
+			// package-parallel load (CI: status=pending for Pi).
+			deadline := time.Now().Add(5 * time.Second)
 			var body runtimeActivityBody
 			for time.Now().Before(deadline) {
 				body = getTaskActivity(t, server, created.ProjectID, created.ID)
-				if body.RuntimeActivity.Liveness == "live" && body.RuntimeActivity.TurnActivity == "idle" {
+				if body.Status == "running" &&
+					body.RuntimeActivity.Liveness == "live" &&
+					body.RuntimeActivity.TurnActivity == "idle" {
 					break
 				}
 				time.Sleep(10 * time.Millisecond)

--- a/internal/runtime/host_process_unix.go
+++ b/internal/runtime/host_process_unix.go
@@ -1,0 +1,124 @@
+//go:build unix
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// KillHostProcessGroup terminates every process in the group. Used by live
+// bridge Close and by daemon-restart reconciliation of durable host metadata.
+func KillHostProcessGroup(ctx context.Context, pgid int) error {
+	if pgid <= 0 {
+		return fmt.Errorf("invalid host process group id")
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := syscall.Kill(-pgid, 0); err != nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			return ctx.Err()
+		case <-timer.C:
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+// Start launches a host process with Setpgid so Close can signal the entire
+// descendant tree.
+func (LocalHostProcessStarter) Start(_ context.Context, spec HostProcessSpec) (HostProcessHandle, error) {
+	if strings.TrimSpace(spec.Program) == "" {
+		return HostProcessHandle{}, fmt.Errorf("host process program is required")
+	}
+	cmd := exec.Command(spec.Program, spec.Args...)
+	cmd.Dir = spec.Workdir
+	cmd.Env = os.Environ()
+	for key, value := range spec.Env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return HostProcessHandle{}, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return HostProcessHandle{}, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return HostProcessHandle{}, err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		_ = stderr.Close()
+		return HostProcessHandle{}, err
+	}
+	pgid := cmd.Process.Pid
+	if actual, err := syscall.Getpgid(cmd.Process.Pid); err == nil {
+		pgid = actual
+	}
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	var waitOnce sync.Once
+	var waitErr error
+	wait := func() error {
+		waitOnce.Do(func() {
+			waitErr = <-waitCh
+			// Root exit must still reap descendants that may outlive the leader.
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		})
+		return waitErr
+	}
+	killGroup := func(ctx context.Context) error {
+		// Best-effort graceful stop, then force the whole group.
+		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+		done := make(chan struct{})
+		go func() {
+			_ = wait()
+			close(done)
+		}()
+		timer := time.NewTimer(2 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			<-done
+			return ctx.Err()
+		case <-timer.C:
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			<-done
+			return nil
+		}
+	}
+	return HostProcessHandle{
+		IO: SandboxBridgeIO{
+			Stdin: stdin, Stdout: stdout, Diagnostics: stderr, Wait: wait,
+		},
+		ProcessGroupID:   pgid,
+		KillProcessGroup: killGroup,
+	}, nil
+}

--- a/internal/runtime/host_process_windows.go
+++ b/internal/runtime/host_process_windows.go
@@ -1,0 +1,112 @@
+//go:build windows
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// KillHostProcessGroup terminates the host process identified by pgid.
+// Windows stores the root process PID in ProcessGroupID; full process-tree
+// reaping requires Job Objects and is not implemented here.
+func KillHostProcessGroup(ctx context.Context, pgid int) error {
+	if pgid <= 0 {
+		return fmt.Errorf("invalid host process group id")
+	}
+	proc, err := os.FindProcess(pgid)
+	if err != nil {
+		return nil
+	}
+	if err := proc.Kill(); err != nil {
+		// Process may already have exited.
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}
+
+// Start launches a host process. ProcessGroupID is the root PID; Close kills
+// that process rather than a Unix process group.
+func (LocalHostProcessStarter) Start(_ context.Context, spec HostProcessSpec) (HostProcessHandle, error) {
+	if strings.TrimSpace(spec.Program) == "" {
+		return HostProcessHandle{}, fmt.Errorf("host process program is required")
+	}
+	cmd := exec.Command(spec.Program, spec.Args...)
+	cmd.Dir = spec.Workdir
+	cmd.Env = os.Environ()
+	for key, value := range spec.Env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return HostProcessHandle{}, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return HostProcessHandle{}, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return HostProcessHandle{}, err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		_ = stderr.Close()
+		return HostProcessHandle{}, err
+	}
+	pid := cmd.Process.Pid
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	var waitOnce sync.Once
+	var waitErr error
+	wait := func() error {
+		waitOnce.Do(func() {
+			waitErr = <-waitCh
+		})
+		return waitErr
+	}
+	killGroup := func(ctx context.Context) error {
+		_ = cmd.Process.Kill()
+		done := make(chan struct{})
+		go func() {
+			_ = wait()
+			close(done)
+		}()
+		timer := time.NewTimer(2 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			<-done
+			return ctx.Err()
+		case <-timer.C:
+			_ = cmd.Process.Kill()
+			<-done
+			return nil
+		}
+	}
+	return HostProcessHandle{
+		IO: SandboxBridgeIO{
+			Stdin: stdin, Stdout: stdout, Diagnostics: stderr, Wait: wait,
+		},
+		ProcessGroupID:   pid,
+		KillProcessGroup: killGroup,
+	}, nil
+}

--- a/internal/runtime/host_session_bridge.go
+++ b/internal/runtime/host_session_bridge.go
@@ -8,12 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
-	"time"
 )
 
 // HostSessionBridgeConfig describes a Task-owned host provider process. The
@@ -470,114 +466,7 @@ func ParseHostProcessGroupID(value string) (pgid int, ok bool) {
 	return n, true
 }
 
-// KillHostProcessGroup terminates every process in the group. Used by live
-// bridge Close and by daemon-restart reconciliation of durable host metadata.
-func KillHostProcessGroup(ctx context.Context, pgid int) error {
-	if pgid <= 0 {
-		return fmt.Errorf("invalid host process group id")
-	}
-	_ = syscall.Kill(-pgid, syscall.SIGTERM)
-	timer := time.NewTimer(2 * time.Second)
-	defer timer.Stop()
-	ticker := time.NewTicker(25 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		if err := syscall.Kill(-pgid, 0); err != nil {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			_ = syscall.Kill(-pgid, syscall.SIGKILL)
-			return ctx.Err()
-		case <-timer.C:
-			_ = syscall.Kill(-pgid, syscall.SIGKILL)
-			return nil
-		case <-ticker.C:
-		}
-	}
-}
-
-// LocalHostProcessStarter launches a host process with Setpgid so Close can
-// signal the entire descendant tree.
+// LocalHostProcessStarter launches a Task-owned host process. Platform files
+// implement process-group (Unix) or process (Windows) cleanup for Close and
+// daemon-restart reaping.
 type LocalHostProcessStarter struct{}
-
-func (LocalHostProcessStarter) Start(_ context.Context, spec HostProcessSpec) (HostProcessHandle, error) {
-	if strings.TrimSpace(spec.Program) == "" {
-		return HostProcessHandle{}, fmt.Errorf("host process program is required")
-	}
-	cmd := exec.Command(spec.Program, spec.Args...)
-	cmd.Dir = spec.Workdir
-	cmd.Env = os.Environ()
-	for key, value := range spec.Env {
-		cmd.Env = append(cmd.Env, key+"="+value)
-	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return HostProcessHandle{}, err
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		_ = stdin.Close()
-		return HostProcessHandle{}, err
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		_ = stdin.Close()
-		_ = stdout.Close()
-		return HostProcessHandle{}, err
-	}
-	if err := cmd.Start(); err != nil {
-		_ = stdin.Close()
-		_ = stdout.Close()
-		_ = stderr.Close()
-		return HostProcessHandle{}, err
-	}
-	pgid := cmd.Process.Pid
-	if actual, err := syscall.Getpgid(cmd.Process.Pid); err == nil {
-		pgid = actual
-	}
-	waitCh := make(chan error, 1)
-	go func() { waitCh <- cmd.Wait() }()
-	var waitOnce sync.Once
-	var waitErr error
-	wait := func() error {
-		waitOnce.Do(func() {
-			waitErr = <-waitCh
-			// Root exit must still reap descendants that may outlive the leader.
-			_ = syscall.Kill(-pgid, syscall.SIGKILL)
-		})
-		return waitErr
-	}
-	killGroup := func(ctx context.Context) error {
-		// Best-effort graceful stop, then force the whole group.
-		_ = syscall.Kill(-pgid, syscall.SIGTERM)
-		done := make(chan struct{})
-		go func() {
-			_ = wait()
-			close(done)
-		}()
-		timer := time.NewTimer(2 * time.Second)
-		defer timer.Stop()
-		select {
-		case <-done:
-			return nil
-		case <-ctx.Done():
-			_ = syscall.Kill(-pgid, syscall.SIGKILL)
-			<-done
-			return ctx.Err()
-		case <-timer.C:
-			_ = syscall.Kill(-pgid, syscall.SIGKILL)
-			<-done
-			return nil
-		}
-	}
-	return HostProcessHandle{
-		IO: SandboxBridgeIO{
-			Stdin: stdin, Stdout: stdout, Diagnostics: stderr, Wait: wait,
-		},
-		ProcessGroupID:   pgid,
-		KillProcessGroup: killGroup,
-	}, nil
-}

--- a/internal/runtime/host_session_bridge_test.go
+++ b/internal/runtime/host_session_bridge_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -46,64 +45,6 @@ done
 	if response.ID != "req-1" || string(response.Result) != `{"ok":true}` {
 		t.Fatalf("response = %#v", response)
 	}
-}
-
-func TestHostSessionBridgeKillsProcessGroupOnClose(t *testing.T) {
-	root := t.TempDir()
-	marker := filepath.Join(root, "alive")
-	childMarker := filepath.Join(root, "child-alive")
-	script := filepath.Join(root, "hold-group.sh")
-	// Parent holds; child holds. Closing the bridge must reap both via process group.
-	if err := os.WriteFile(script, []byte(`#!/bin/sh
-touch "`+marker+`"
-( touch "`+childMarker+`"; while true; do sleep 0.1; done ) &
-while true; do sleep 0.1; done
-`), 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	bridge, err := runtime.NewHostSessionBridge(runtime.HostSessionBridgeConfig{
-		TaskID:  "task-host-kill",
-		Program: script,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := bridge.Start(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	pgid := bridge.ProcessGroupID()
-	if pgid <= 0 {
-		t.Fatalf("process group id = %d", pgid)
-	}
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(marker); err == nil {
-			if _, err := os.Stat(childMarker); err == nil {
-				break
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if _, err := os.Stat(marker); err != nil {
-		t.Fatal("parent process did not start")
-	}
-	if _, err := os.Stat(childMarker); err != nil {
-		t.Fatal("child process did not start")
-	}
-
-	if err := bridge.Close(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	// After close, no process in the group should remain.
-	deadline = time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(-pgid, 0); err != nil {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("process group %d still has live members after Close", pgid)
 }
 
 func TestHostSessionBridgeRegistryBindsOneProcessPerTask(t *testing.T) {

--- a/internal/runtime/host_session_bridge_unix_test.go
+++ b/internal/runtime/host_session_bridge_unix_test.go
@@ -1,0 +1,73 @@
+//go:build unix
+
+package runtime_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"pentest/internal/runtime"
+)
+
+func TestHostSessionBridgeKillsProcessGroupOnClose(t *testing.T) {
+	root := t.TempDir()
+	marker := filepath.Join(root, "alive")
+	childMarker := filepath.Join(root, "child-alive")
+	script := filepath.Join(root, "hold-group.sh")
+	// Parent holds; child holds. Closing the bridge must reap both via process group.
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+touch "`+marker+`"
+( touch "`+childMarker+`"; while true; do sleep 0.1; done ) &
+while true; do sleep 0.1; done
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	bridge, err := runtime.NewHostSessionBridge(runtime.HostSessionBridgeConfig{
+		TaskID:  "task-host-kill",
+		Program: script,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	pgid := bridge.ProcessGroupID()
+	if pgid <= 0 {
+		t.Fatalf("process group id = %d", pgid)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			if _, err := os.Stat(childMarker); err == nil {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatal("parent process did not start")
+	}
+	if _, err := os.Stat(childMarker); err != nil {
+		t.Fatal("child process did not start")
+	}
+
+	if err := bridge.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// After close, no process in the group should remain.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(-pgid, 0); err != nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process group %d still has live members after Close", pgid)
+}
+


### PR DESCRIPTION
## Summary
- Split Unix process-group APIs out of `host_session_bridge.go` so release binary builds succeed on Windows.
- Windows uses root-PID kill (best-effort); Unix keeps process-group reaping.
- Wait longer for Task status `running` in sandbox Runtime Activity tests (CI flake on Pi).

## Test plan
- [x] `GOOS=windows GOARCH=amd64/arm64 go build ./cmd/pentestd`
- [x] All six release targets cross-compile
- [x] `go test ./internal/runtime -run HostSession|HostProcess`
- [x] `go test ./internal/daemon -run TestRuntimeActivityLiveIdleAndBusyForSandboxProviders`