### PR TITLE
ci: stabilize post-merge checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,4 +110,5 @@ jobs:
         env:
           PENTEST_SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci
           SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci
+          PENTEST_DAEMON_WAIT_SECONDS: "120"
         run: scripts/with-pentestd-live.sh make smoke-sandbox-mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,17 +93,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: docker/setup-buildx-action@v4
-      - name: Validate full sandbox image build
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/pentest-sandbox/Dockerfile
-          target: runtime
-          platforms: linux/amd64
-          push: false
-          load: false
-          tags: cyberpenda-sandbox:ci-validation
       - name: Build sandbox smoke probe image
         run: make build-sandbox-smoke-image
       - name: Smoke sandbox MCP (no LLM)

--- a/internal/daemon/assisted_conclusion_test.go
+++ b/internal/daemon/assisted_conclusion_test.go
@@ -2517,7 +2517,7 @@ func waitForAssistedProviderRequests(t *testing.T, session *runtime.FakeProvider
 
 func waitForBlackboardConclusionState(t *testing.T, server *Server, projectID, taskID string, state task.BlackboardConclusionState) task.Task {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		request := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID+"/tasks/"+taskID, nil)
 		response := httptest.NewRecorder()

--- a/internal/daemon/session_runtime_handlers_test.go
+++ b/internal/daemon/session_runtime_handlers_test.go
@@ -852,18 +852,26 @@ func TestSessionLaunchUsesProjectFreeOwnerAndPersistentProviderControls(t *testi
 	if err != nil || active == nil || active.Number != 2 {
 		t.Fatalf("Session replacement continuation = %#v, %v", active, err)
 	}
-	events, err := server.sessions.Events(created.ID)
-	if err != nil {
-		t.Fatalf("read Session replacement events: %v", err)
-	}
+	var events []session.Event
 	var sawReplacement, sawAttachment bool
-	for _, event := range events {
-		if event.Payload["continuation_id"] == active.ID {
-			sawReplacement = true
+	eventDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(eventDeadline) {
+		events, err = server.sessions.Events(created.ID)
+		if err != nil {
+			t.Fatalf("read Session replacement events: %v", err)
 		}
-		if event.Kind == session.EventKindAttachment && event.Payload["filename"] == "interrupt-notes.txt" {
-			sawAttachment = event.Payload["continuation_id"] == launchRequest.Continuation.ID
+		for _, event := range events {
+			if event.Payload["continuation_id"] == active.ID {
+				sawReplacement = true
+			}
+			if event.Kind == session.EventKindAttachment && event.Payload["filename"] == "interrupt-notes.txt" {
+				sawAttachment = event.Payload["continuation_id"] == launchRequest.Continuation.ID
+			}
 		}
+		if sawReplacement {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 	if !sawReplacement {
 		t.Fatalf("Session replacement emitted no events on continuation %q: %#v", active.ID, events)

--- a/scripts/ci_sandbox_build_test.go
+++ b/scripts/ci_sandbox_build_test.go
@@ -181,6 +181,7 @@ func TestPullRequestSandboxSmokeDoesNotLoadTheFullKaliImage(t *testing.T) {
 	assertContains(t, workflow, "make build-sandbox-smoke-image")
 	assertContains(t, workflow, "PENTEST_SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci")
 	assertContains(t, workflow, "\n          SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci")
+	assertContains(t, workflow, "\n          PENTEST_DAEMON_WAIT_SECONDS: \"120\"")
 }
 
 func TestManualSandboxWorkflowBuildsAndPublishesImagePerPlatform(t *testing.T) {

--- a/scripts/ci_sandbox_build_test.go
+++ b/scripts/ci_sandbox_build_test.go
@@ -150,7 +150,7 @@ func TestSandboxDockerfileKeepsProviderBridgeSourceInLateCacheLayer(t *testing.T
 	}
 }
 
-func TestPullRequestSandboxSmokeDoesNotLoadTheFullKaliImage(t *testing.T) {
+func TestPullRequestSandboxSmokeSkipsFullKaliImageBuild(t *testing.T) {
 	repoRoot := repoRoot(t)
 	dockerfileBytes, err := os.ReadFile(filepath.Join(repoRoot, "docker", "pentest-sandbox", "Dockerfile"))
 	if err != nil {
@@ -174,14 +174,25 @@ func TestPullRequestSandboxSmokeDoesNotLoadTheFullKaliImage(t *testing.T) {
 		t.Fatalf("read CI workflow: %v", err)
 	}
 	workflow := string(workflowBytes)
-	assertContains(t, workflow, "Validate full sandbox image build")
-	assertContains(t, workflow, "uses: docker/build-push-action@v7")
-	assertContains(t, workflow, "target: runtime")
-	assertContains(t, workflow, "load: false")
-	assertContains(t, workflow, "make build-sandbox-smoke-image")
-	assertContains(t, workflow, "PENTEST_SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci")
-	assertContains(t, workflow, "\n          SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci")
-	assertContains(t, workflow, "\n          PENTEST_DAEMON_WAIT_SECONDS: \"120\"")
+	smokeJobStart := strings.Index(workflow, "  smoke-sandbox-mcp:")
+	if smokeJobStart == -1 {
+		t.Fatal("CI workflow must include the Sandbox MCP smoke job")
+	}
+	smokeJob := workflow[smokeJobStart:]
+	for _, forbidden := range []string{
+		"Validate full sandbox image build",
+		"docker/setup-buildx-action",
+		"docker/build-push-action",
+		"target: runtime",
+	} {
+		if strings.Contains(smokeJob, forbidden) {
+			t.Fatalf("Sandbox MCP smoke job must not build the full Kali image: found %q", forbidden)
+		}
+	}
+	assertContains(t, smokeJob, "make build-sandbox-smoke-image")
+	assertContains(t, smokeJob, "PENTEST_SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci")
+	assertContains(t, smokeJob, "\n          SANDBOX_IMAGE: cyberpenda-sandbox-smoke:ci")
+	assertContains(t, smokeJob, "\n          PENTEST_DAEMON_WAIT_SECONDS: \"120\"")
 }
 
 func TestManualSandboxWorkflowBuildsAndPublishesImagePerPlatform(t *testing.T) {


### PR DESCRIPTION
## Problem\n\nThe post-merge CI run for #196 exposed three cold-run timing problems:\n\n- The Blackboard conclusion state test used a fixed 2-second asynchronous wait.\n- The Session replacement test read events immediately after the active Runtime Continuation changed, before its first event was durable.\n- The Sandbox smoke used a 30-second daemon health deadline while go run was still downloading and compiling dependencies.\n\nThe Sandbox smoke job also rebuilt the complete Kali runtime image, which was unrelated to the MCP smoke and added about seven minutes.\n\n## Fix\n\n- Allow 5 seconds for the Blackboard conclusion state transition.\n- Wait for the replacement Runtime Continuation to emit its first durable Session event.\n- Set PENTEST_DAEMON_WAIT_SECONDS to 120 seconds.\n- Keep PR CI on the lightweight smoke image target. Full runtime image builds remain in the publication workflow.\n- Add regression assertions for the timeout and lightweight smoke boundary.\n\n## Verification\n\n- Blackboard conclusion timing test passed 100 consecutive runs.\n- Session replacement timing test passed 200 consecutive runs.\n- Sandbox workflow regression test passed.\n- make test-ci passed.\n- git diff --check passed.