### PR TITLE
Fix whole-codebase audit findings

### DIFF
--- a/internal/challengeworkflow/service.go
+++ b/internal/challengeworkflow/service.go
@@ -442,7 +442,7 @@ func (service *Service) Submit(ctx context.Context, request SubmitRequest) (Subm
 
 func (service *Service) Abandon(ctx context.Context, request AbandonRequest) (AbandonResult, error) {
 	var result AbandonResult
-	_, adapter, err := service.prepare(request.ProjectID, request.TaskID, request.Platform, request.OperationID)
+	taskValue, adapter, err := service.prepare(request.ProjectID, request.TaskID, request.Platform, request.OperationID)
 	if err != nil {
 		return result, err
 	}
@@ -450,9 +450,18 @@ func (service *Service) Abandon(ctx context.Context, request AbandonRequest) (Ab
 	if replay, found, err := loadReplay[AbandonResult](service.db, request.TaskID, request.OperationID, hash); err != nil || found {
 		return replay, err
 	}
+	known, err := service.operationKnown(request.TaskID, request.OperationID, hash)
+	if err != nil {
+		return result, err
+	}
 	attempt, err := service.openAttempt(request.ProjectID, request.TaskID, request.Platform, request.ExternalAttemptID)
 	if err != nil {
 		return result, err
+	}
+	if !known {
+		if err := service.checkOperationPolicy(taskValue, attempt); err != nil {
+			return result, err
+		}
 	}
 	if err := service.reserve(request.ProjectID, request.TaskID, request.Platform, request.OperationID, "abandon", hash, request.ExternalAttemptID, request); err != nil {
 		return result, err
@@ -481,7 +490,7 @@ func (service *Service) Abandon(ctx context.Context, request AbandonRequest) (Ab
 
 func (service *Service) Finalize(ctx context.Context, request FinalizeRequest) (FinalizeResult, error) {
 	var result FinalizeResult
-	_, adapter, err := service.prepare(request.ProjectID, request.TaskID, request.Platform, request.OperationID)
+	taskValue, adapter, err := service.prepare(request.ProjectID, request.TaskID, request.Platform, request.OperationID)
 	if err != nil {
 		return result, err
 	}
@@ -489,9 +498,18 @@ func (service *Service) Finalize(ctx context.Context, request FinalizeRequest) (
 	if replay, found, err := loadReplay[FinalizeResult](service.db, request.TaskID, request.OperationID, hash); err != nil || found {
 		return replay, err
 	}
+	known, err := service.operationKnown(request.TaskID, request.OperationID, hash)
+	if err != nil {
+		return result, err
+	}
 	attempt, err := service.attempt(request.ProjectID, request.TaskID, request.Platform, request.ExternalAttemptID)
 	if err != nil {
 		return result, err
+	}
+	if !known {
+		if err := service.checkOperationPolicy(taskValue, attempt); err != nil {
+			return result, err
+		}
 	}
 	if err := service.reserve(request.ProjectID, request.TaskID, request.Platform, request.OperationID, "finalize", hash, request.ExternalAttemptID, request); err != nil {
 		return result, err
@@ -583,13 +601,16 @@ func (service *Service) checkTimePolicy(taskValue task.Task, lastProgress string
 	if policy.MaxWallTimeSeconds > 0 && wall >= policy.MaxWallTimeSeconds {
 		return service.policyBlocked(taskValue.ID, PolicyMaxWallTime, policy.MaxWallTimeSeconds, wall)
 	}
-	if policy.MaxNoProgressSeconds > 0 && lastProgress != "" {
-		stamp, err := time.Parse(time.RFC3339Nano, lastProgress)
-		if err == nil {
-			elapsed := int(now.Sub(stamp).Seconds())
-			if elapsed >= policy.MaxNoProgressSeconds {
-				return service.policyBlocked(taskValue.ID, PolicyMaxNoProgress, policy.MaxNoProgressSeconds, elapsed)
+	if policy.MaxNoProgressSeconds > 0 {
+		progressAt := taskValue.CreatedAt
+		if lastProgress != "" {
+			if stamp, err := time.Parse(time.RFC3339Nano, lastProgress); err == nil {
+				progressAt = stamp
 			}
+		}
+		elapsed := int(now.Sub(progressAt).Seconds())
+		if elapsed >= policy.MaxNoProgressSeconds {
+			return service.policyBlocked(taskValue.ID, PolicyMaxNoProgress, policy.MaxNoProgressSeconds, elapsed)
 		}
 	}
 	return nil

--- a/internal/challengeworkflow/service_test.go
+++ b/internal/challengeworkflow/service_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"pentest/internal/blackboardv2"
 	"pentest/internal/challengeworkflow"
@@ -15,8 +16,10 @@ import (
 )
 
 type platformStub struct {
-	claimCalls  int
-	submitCalls int
+	claimCalls    int
+	submitCalls   int
+	abandonCalls  int
+	finalizeCalls int
 }
 
 func TestChallengeWorkflowRequiresCTFChallengeTaskTypeSnapshot(t *testing.T) {
@@ -116,10 +119,12 @@ func (stub *platformStub) Submit(_ context.Context, request challengeworkflow.Pl
 }
 
 func (stub *platformStub) Abandon(context.Context, challengeworkflow.PlatformAbandonRequest) (challengeworkflow.PlatformAbandonResponse, error) {
+	stub.abandonCalls++
 	return challengeworkflow.PlatformAbandonResponse{Summary: "abandoned", Rating: 2090}, nil
 }
 
 func (stub *platformStub) Finalize(context.Context, challengeworkflow.PlatformFinalizeRequest) (challengeworkflow.PlatformFinalizeResponse, error) {
+	stub.finalizeCalls++
 	return challengeworkflow.PlatformFinalizeResponse{Summary: "finalized"}, nil
 }
 
@@ -296,5 +301,68 @@ func TestSubmitEnforcesWrongSubmissionPolicyBeforeExternalCall(t *testing.T) {
 	}
 	if platform.submitCalls != 1 || recorder.submissions != 1 {
 		t.Fatalf("calls = platform %d, recorder %d; want 1 each", platform.submitCalls, recorder.submissions)
+	}
+}
+
+func TestFirstClaimEnforcesNoProgressPolicyFromTaskCreation(t *testing.T) {
+	db, projects, tasks, proj, createdTask := newFixture(t, task.TaskPolicy{MaxNoProgressSeconds: 1})
+	oldCreatedAt := time.Now().UTC().Add(-2 * time.Second).Format(time.RFC3339Nano)
+	if _, err := db.Exec(`UPDATE tasks SET created_at=? WHERE id=?`, oldCreatedAt, createdTask.ID); err != nil {
+		t.Fatalf("age Task: %v", err)
+	}
+	platform := &platformStub{}
+	service := challengeworkflow.NewService(db, projects, tasks, map[string]challengeworkflow.PlatformAdapter{"arena": platform}, &recorderStub{})
+
+	_, err := service.Claim(context.Background(), challengeworkflow.ClaimRequest{
+		ProjectID: proj.ID, TaskID: createdTask.ID, Platform: "arena", OperationID: "claim-after-no-progress", ChallengeID: "3121",
+	})
+	var policyError *challengeworkflow.PolicyError
+	if !errors.As(err, &policyError) || policyError.Code != challengeworkflow.PolicyMaxNoProgress {
+		t.Fatalf("first Claim error = %v", err)
+	}
+	if platform.claimCalls != 0 {
+		t.Fatalf("platform Claim calls = %d, want 0", platform.claimCalls)
+	}
+}
+
+func TestAbandonAndFinalizeEnforceTaskPolicyBeforeExternalCall(t *testing.T) {
+	for _, operation := range []string{"abandon", "finalize"} {
+		t.Run(operation, func(t *testing.T) {
+			db, projects, tasks, proj, createdTask := newFixture(t, task.TaskPolicy{MaxWrongSubmissions: 1})
+			platform := &platformStub{}
+			service := challengeworkflow.NewService(db, projects, tasks, map[string]challengeworkflow.PlatformAdapter{"arena": platform}, &recorderStub{})
+			claim, err := service.Claim(context.Background(), challengeworkflow.ClaimRequest{
+				ProjectID: proj.ID, TaskID: createdTask.ID, Platform: "arena", OperationID: "claim-" + operation, ChallengeID: "3121",
+			})
+			if err != nil {
+				t.Fatalf("Claim: %v", err)
+			}
+			if _, err := service.Submit(context.Background(), challengeworkflow.SubmitRequest{
+				ProjectID: proj.ID, TaskID: createdTask.ID, Platform: "arena", OperationID: "submit-" + operation,
+				ExternalAttemptID: claim.ExternalAttemptID, Candidate: "wrong",
+			}); err != nil {
+				t.Fatalf("Submit: %v", err)
+			}
+
+			switch operation {
+			case "abandon":
+				_, err = service.Abandon(context.Background(), challengeworkflow.AbandonRequest{
+					ProjectID: proj.ID, TaskID: createdTask.ID, Platform: "arena", OperationID: "abandon-blocked",
+					ExternalAttemptID: claim.ExternalAttemptID, Reason: "stop",
+				})
+			case "finalize":
+				_, err = service.Finalize(context.Background(), challengeworkflow.FinalizeRequest{
+					ProjectID: proj.ID, TaskID: createdTask.ID, Platform: "arena", OperationID: "finalize-blocked",
+					ExternalAttemptID: claim.ExternalAttemptID,
+				})
+			}
+			var policyError *challengeworkflow.PolicyError
+			if !errors.As(err, &policyError) || policyError.Code != challengeworkflow.PolicyMaxWrongSubmissions {
+				t.Fatalf("%s error = %v", operation, err)
+			}
+			if platform.abandonCalls != 0 || platform.finalizeCalls != 0 {
+				t.Fatalf("platform calls after blocked %s = abandon %d finalize %d", operation, platform.abandonCalls, platform.finalizeCalls)
+			}
+		})
 	}
 }

--- a/internal/daemon/modelprovider_handlers.go
+++ b/internal/daemon/modelprovider_handlers.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -102,10 +101,10 @@ func (server *Server) handleRefreshModelProviderModels(response http.ResponseWri
 	}
 	client := server.modelRefreshClient
 	if client == nil {
-		client = http.DefaultClient
+		client = modelprovider.NewCatalogHTTPClient()
 	}
 	if value, ok := server.materializeModelProviderCredential(provider.APIKeyEnv); ok {
-		updated, err := server.modelProviders.RefreshModelsWithKey(context.Background(), provider.ID, client, value)
+		updated, err := server.modelProviders.RefreshModelsWithKey(request.Context(), provider.ID, client, value)
 		if err != nil {
 			writeModelProviderError(response, err)
 			return
@@ -113,7 +112,7 @@ func (server *Server) handleRefreshModelProviderModels(response http.ResponseWri
 		writeJSON(response, http.StatusOK, updated)
 		return
 	}
-	updated, err := server.modelProviders.RefreshModels(context.Background(), provider.ID, client)
+	updated, err := server.modelProviders.RefreshModels(request.Context(), provider.ID, client)
 	if err != nil {
 		writeModelProviderError(response, err)
 		return

--- a/internal/daemon/modelprovider_test.go
+++ b/internal/daemon/modelprovider_test.go
@@ -2,12 +2,15 @@ package daemon_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"pentest/internal/daemon"
 )
@@ -421,5 +424,50 @@ func TestModelProviderAPIRefreshPreservesCatalogOnUpstreamError(t *testing.T) {
 	}
 	if len(fetched.Catalog.Refreshed) != 1 || fetched.Catalog.Refreshed[0] != "prior-refreshed" {
 		t.Fatalf("refreshed catalog changed after upstream failure: %#v", fetched.Catalog.Refreshed)
+	}
+}
+
+func TestModelProviderAPIRefreshCancelsUpstreamWithRequest(t *testing.T) {
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		close(started)
+		select {
+		case <-request.Context().Done():
+			close(cancelled)
+			return nil, request.Context().Err()
+		case <-time.After(500 * time.Millisecond):
+			return nil, errors.New("upstream request was not cancelled")
+		}
+	})
+	server := newRefreshServer(t, transport)
+	id, apiKeyEnv := createRefreshProvider(t, server, `{
+		"name":"Cancellation",
+		"base_url":"https://api.example.test/v1",
+		"protocols":["openai_chat_completions"],
+		"catalog":{"manual":["manual"],"default_model":"manual"}
+	}`)
+	t.Setenv(apiKeyEnv, "sk-test")
+
+	requestContext, cancel := context.WithCancel(context.Background())
+	refresh := httptest.NewRequest(http.MethodPost, "/api/model-providers/"+id+"/refresh-models", nil).WithContext(requestContext)
+	done := make(chan struct{})
+	go func() {
+		server.ServeHTTP(httptest.NewRecorder(), refresh)
+		close(done)
+	}()
+	<-started
+	cancel()
+	select {
+	case <-cancelled:
+	case <-done:
+		t.Fatal("refresh handler returned without cancelling its upstream request")
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("refresh handler did not stop after request cancellation")
+	}
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("refresh handler stayed alive after upstream cancellation")
 	}
 }

--- a/internal/daemon/reason_task_handlers.go
+++ b/internal/daemon/reason_task_handlers.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"pentest/internal/blackboardv2"
+	"pentest/internal/project"
+	"pentest/internal/reasontask"
+)
+
+func (server *Server) handleListReasonTaskProposals(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	proposals, err := server.reasonTasks.List(projectID)
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, "list Reason Task proposals")
+		return
+	}
+	writeJSON(response, http.StatusOK, struct {
+		Proposals []reasontask.Proposal `json:"proposals"`
+	}{Proposals: proposals})
+}
+
+func (server *Server) handleProposeReasonTaskChanges(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	var input struct {
+		NextTaskGoals               []string              `json:"next_task_goals"`
+		ExplorationObjectiveChanges []string              `json:"exploration_objective_changes"`
+		ReadinessJudgment           string                `json:"readiness_judgment"`
+		Changes                     []blackboardv2.Change `json:"changes"`
+	}
+	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+		writeError(response, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	proposal, err := server.reasonTasks.Propose(reasontask.ProposeRequest{
+		ProjectID: projectID, ReasonTaskID: request.PathValue("task_id"), NextTaskGoals: input.NextTaskGoals,
+		ExplorationObjectiveChanges: input.ExplorationObjectiveChanges,
+		ReadinessJudgment:           input.ReadinessJudgment, Changes: input.Changes,
+	})
+	if err != nil {
+		writeReasonTaskError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusCreated, proposal)
+}
+
+func (server *Server) handleApproveReasonTaskProposal(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	proposal, result, err := server.reasonTasks.Approve(request.Context(), projectID, request.PathValue("proposal_id"))
+	if err != nil {
+		writeReasonTaskError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, struct {
+		Proposal reasontask.Proposal       `json:"proposal"`
+		Result   blackboardv2.ChangeResult `json:"result"`
+	}{Proposal: proposal, Result: result})
+}
+
+func (server *Server) handleRejectReasonTaskProposal(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	proposal, err := server.reasonTasks.Reject(projectID, request.PathValue("proposal_id"))
+	if err != nil {
+		writeReasonTaskError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, proposal)
+}
+
+func writeReasonTaskError(response http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, project.ErrNotFound), errors.Is(err, reasontask.ErrNotFound):
+		writeError(response, http.StatusNotFound, err.Error())
+	case errors.Is(err, reasontask.ErrInvalid), errors.Is(err, reasontask.ErrNotReason):
+		writeError(response, http.StatusBadRequest, err.Error())
+	case errors.Is(err, reasontask.ErrNotProposed):
+		writeError(response, http.StatusConflict, err.Error())
+	default:
+		writeError(response, http.StatusBadRequest, err.Error())
+	}
+}

--- a/internal/daemon/reason_task_http_test.go
+++ b/internal/daemon/reason_task_http_test.go
@@ -1,0 +1,77 @@
+package daemon_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"pentest/internal/reasontask"
+)
+
+func TestReasonTaskLaunchAndProposalApprovalHTTP(t *testing.T) {
+	server := newDaemon(t)
+	projectID := createProject(t, server, `{"name":"Engagement","kind":"pentest","scope":{"domains":["example.com"]}}`)
+	profileID := createRuntimeProfile(t, server, `{"name":"Fake","provider":"fake"}`)
+
+	launch := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/reason-tasks", strings.NewReader(`{
+		"runtime_profile_id":"`+profileID+`","runner":"host","run_controls":{"host_activated":true}
+	}`))
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, launch)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("launch Reason Task status %d body %s", response.Code, response.Body.String())
+	}
+	var launched struct {
+		ID   string `json:"id"`
+		Goal string `json:"goal"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&launched); err != nil || launched.ID == "" || launched.Goal != reasontask.LaunchGoal {
+		t.Fatalf("launched Reason Task = %#v, error=%v", launched, err)
+	}
+
+	proposalBody := `{
+		"next_task_goals":["Confirm the administration surface"],
+		"exploration_objective_changes":["Use targeted validation"],
+		"readiness_judgment":"Ready after consolidation",
+		"changes":[{"op":"create","key":"objective:targeted-validation","type":"objective","record":{"status":"open","objective":"Validate the administration surface"}}]
+	}`
+	propose := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/reason-tasks/"+launched.ID+"/proposals", strings.NewReader(proposalBody))
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, propose)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("Reason Task proposal status %d body %s", response.Code, response.Body.String())
+	}
+	var proposal struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&proposal); err != nil || proposal.Status != "proposed" {
+		t.Fatalf("proposal = %#v, error=%v", proposal, err)
+	}
+
+	snapshot := func() string {
+		request := httptest.NewRequest(http.MethodGet, "/api/v2/projects/"+projectID+"/blackboard/snapshot", nil)
+		result := httptest.NewRecorder()
+		server.ServeHTTP(result, request)
+		if result.Code != http.StatusOK {
+			t.Fatalf("snapshot status %d body %s", result.Code, result.Body.String())
+		}
+		return result.Body.String()
+	}
+	if strings.Contains(snapshot(), "objective:targeted-validation") {
+		t.Fatal("Reason Task proposal changed Blackboard before approval")
+	}
+
+	approve := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/reason-task-proposals/"+proposal.ID+"/approve", bytes.NewReader(nil))
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, approve)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"status":"approved"`) {
+		t.Fatalf("approve proposal status %d body %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(snapshot(), "objective:targeted-validation") {
+		t.Fatal("approved Reason Task proposal did not change Blackboard")
+	}
+}

--- a/internal/daemon/scope_expansion_handlers.go
+++ b/internal/daemon/scope_expansion_handlers.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"pentest/internal/project"
+	"pentest/internal/scopeexpansion"
+)
+
+func (server *Server) handleListScopeExpansions(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	proposals, err := server.scopeExpansions.List(projectID)
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, "list Scope Expansions")
+		return
+	}
+	writeJSON(response, http.StatusOK, struct {
+		Expansions []scopeexpansion.Proposal `json:"expansions"`
+	}{Expansions: proposals})
+}
+
+func (server *Server) handleProposeScopeExpansion(response http.ResponseWriter, request *http.Request) {
+	projectID := request.PathValue("id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	var input struct {
+		Addition        project.Scope `json:"addition"`
+		DiscoverySource string        `json:"discovery_source"`
+		Reason          string        `json:"reason"`
+		Risk            string        `json:"risk"`
+	}
+	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+		writeError(response, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	proposal, err := server.scopeExpansions.Propose(scopeexpansion.ProposeRequest{
+		ProjectID: projectID, Addition: input.Addition, DiscoverySource: input.DiscoverySource,
+		Reason: input.Reason, Risk: input.Risk,
+		Origin: scopeexpansion.TrustedOrigin{Kind: scopeexpansion.TrustedOriginOperator},
+	})
+	if err != nil {
+		writeScopeExpansionError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusCreated, proposal)
+}
+
+func (server *Server) handleApproveScopeExpansion(response http.ResponseWriter, request *http.Request) {
+	server.handleScopeExpansionDecision(response, request, true)
+}
+
+func (server *Server) handleRejectScopeExpansion(response http.ResponseWriter, request *http.Request) {
+	server.handleScopeExpansionDecision(response, request, false)
+}
+
+func (server *Server) handleScopeExpansionDecision(response http.ResponseWriter, request *http.Request, approve bool) {
+	projectID := request.PathValue("id")
+	if !server.requireProject(response, projectID) {
+		return
+	}
+	var proposal scopeexpansion.Proposal
+	var updated project.Project
+	var err error
+	if approve {
+		proposal, updated, err = server.scopeExpansions.Approve(projectID, request.PathValue("expansion_id"))
+	} else {
+		proposal, updated, err = server.scopeExpansions.Reject(projectID, request.PathValue("expansion_id"))
+	}
+	if err != nil {
+		writeScopeExpansionError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, struct {
+		Expansion scopeexpansion.Proposal `json:"expansion"`
+		Project   project.Project         `json:"project"`
+	}{Expansion: proposal, Project: updated})
+}
+
+func writeScopeExpansionError(response http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, project.ErrNotFound), errors.Is(err, scopeexpansion.ErrNotFound):
+		writeError(response, http.StatusNotFound, err.Error())
+	case errors.Is(err, scopeexpansion.ErrInvalid), errors.Is(err, scopeexpansion.ErrTrustedOrigin):
+		writeError(response, http.StatusBadRequest, err.Error())
+	case errors.Is(err, scopeexpansion.ErrNotProposed):
+		writeError(response, http.StatusConflict, err.Error())
+	default:
+		writeError(response, http.StatusInternalServerError, "Scope Expansion failed")
+	}
+}

--- a/internal/daemon/scope_expansion_test.go
+++ b/internal/daemon/scope_expansion_test.go
@@ -1,0 +1,66 @@
+package daemon_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pentest/internal/daemon"
+)
+
+func TestScopeExpansionHTTPRequiresApprovalBeforeItChangesScope(t *testing.T) {
+	server, err := daemon.NewServer(daemon.Config{
+		Version: "test-version", DBPath: filepath.Join(t.TempDir(), "pentest.db"), DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatalf("create Server: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+	projectID := createProject(t, server, `{"name":"Engagement","kind":"pentest","scope":{"domains":["example.com"]}}`)
+
+	propose := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/scope-expansions", strings.NewReader(`{
+		"addition":{"domains":["api.example.com"],"ports":["8443"]},
+		"discovery_source":"Project Fact fact:api",
+		"reason":"New application endpoint",
+		"risk":"Adds authenticated testing"
+	}`))
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, propose)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("propose status %d body %s", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "origin_") || strings.Contains(response.Body.String(), "continuation_id") {
+		t.Fatalf("ordinary Scope Expansion response exposed Trusted Origin: %s", response.Body.String())
+	}
+	var proposal struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&proposal); err != nil || proposal.Status != "proposed" {
+		t.Fatalf("decode proposal = %#v, %v", proposal, err)
+	}
+
+	getBefore := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID, nil)
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, getBefore)
+	if strings.Contains(response.Body.String(), "api.example.com") {
+		t.Fatalf("Scope changed before approval: %s", response.Body.String())
+	}
+
+	approve := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/scope-expansions/"+proposal.ID+"/approve", nil)
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, approve)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"status":"approved"`) {
+		t.Fatalf("approve status %d body %s", response.Code, response.Body.String())
+	}
+
+	getAfter := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID, nil)
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, getAfter)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "api.example.com") || !strings.Contains(response.Body.String(), "8443") {
+		t.Fatalf("approved Scope = status %d body %s", response.Code, response.Body.String())
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -26,11 +26,13 @@ import (
 	"pentest/internal/preflight"
 	"pentest/internal/project"
 	"pentest/internal/projectinterface"
+	"pentest/internal/reasontask"
 	"pentest/internal/runner"
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeextension"
 	"pentest/internal/runtimeplugin"
 	"pentest/internal/runtimeprofile"
+	"pentest/internal/scopeexpansion"
 	"pentest/internal/session"
 	"pentest/internal/skill"
 	"pentest/internal/steering"
@@ -80,9 +82,8 @@ type Config struct {
 	// tests that need an empty Skill library; production leaves built-ins on.
 	DisableBuiltinSkills bool
 	// ModelRefreshClient is the HTTP client used to call upstream /v1/models
-	// during Model Catalog Refresh. Nil means http.DefaultClient, which is the
-	// production behavior; tests inject a stubbed transport so the refresh API
-	// can be exercised end to end without real network traffic.
+	// during Model Catalog Refresh. Nil uses a bounded production client; tests
+	// inject a controlled transport.
 	ModelRefreshClient *http.Client
 	// ProviderSessionFactory is optional. When nil, launches retain the legacy
 	// one-shot Adapter path and native session controls remain unavailable until
@@ -99,6 +100,8 @@ type Server struct {
 	logger                  *log.Logger
 	db                      *store.DB
 	projects                *project.Service
+	scopeExpansions         *scopeexpansion.Service
+	reasonTasks             *reasontask.Service
 	runtimePlugins          *runtimeplugin.Registry
 	runtimeExtensions       *runtimeextension.Registry
 	profiles                *runtimeprofile.Service
@@ -195,6 +198,7 @@ func NewServer(config Config) (*Server, error) {
 		}
 	}
 	creds := credential.NewService(db)
+	projects := project.NewService(db)
 	tasks := task.NewService(db, nil)
 	artifactRoot := strings.TrimSpace(config.ArtifactRoot)
 	if artifactRoot == "" {
@@ -221,19 +225,24 @@ func NewServer(config Config) (*Server, error) {
 		return nil, err
 	}
 	providerControlCtx, providerControlCancel := context.WithCancel(context.Background())
+	modelRefreshClient := config.ModelRefreshClient
+	if modelRefreshClient == nil {
+		modelRefreshClient = modelprovider.NewCatalogHTTPClient()
+	}
 	server := &Server{
 		mux:                http.NewServeMux(),
 		version:            config.Version,
 		logger:             config.Logger,
 		db:                 db,
-		projects:           project.NewService(db),
+		projects:           projects,
+		scopeExpansions:    scopeexpansion.NewService(db, projects),
 		runtimePlugins:     runtimePlugins,
 		runtimeExtensions:  runtimeExtensions,
 		profiles:           profiles,
 		modelProviders:     modelProviders,
 		skills:             skills,
 		creds:              creds,
-		modelRefreshClient: config.ModelRefreshClient,
+		modelRefreshClient: modelRefreshClient,
 		preflight: preflight.NewService(profiles, creds, skills).
 			WithModelProviders(modelProviders, runtimePlugins).
 			WithRuntimeExtensions(runtimeExtensions),
@@ -281,6 +290,7 @@ func NewServer(config Config) (*Server, error) {
 	server.tasks.SetContinuationTerminalMarker(server.projectInterfaceGrants)
 	server.sessions.SetContinuationTerminalMarker(server.projectInterfaceGrants)
 	server.blackboardV2 = blackboardv2.NewServiceWithEvidence(db, blackboardv2.EvidenceConfig{ArtifactRoot: artifactRoot, RuntimeRoot: runtimeRoot})
+	server.reasonTasks = reasontask.NewService(db, server.blackboardV2)
 	server.challengeWorkflow = challengeworkflow.NewService(db, server.projects, server.tasks, config.ChallengePlatforms, challengeworkflow.NewBlackboardRecorder(server.blackboardV2, server.tasks, runtimeRoot))
 	server.finishReadiness = finishreadiness.NewService(db, server.tasks)
 	server.tasks.SetContinuationReconciler(server.blackboardV2)
@@ -761,6 +771,15 @@ func (server *Server) routes() {
 	server.mux.HandleFunc("GET /api/workspace/navigation", server.handleWorkspaceNavigation)
 	server.mux.HandleFunc("GET /api/projects", server.handleListProjects)
 	server.mux.HandleFunc("POST /api/projects", server.handleCreateProject)
+	server.mux.HandleFunc("GET /api/projects/{id}/scope-expansions", server.handleListScopeExpansions)
+	server.mux.HandleFunc("POST /api/projects/{id}/scope-expansions", server.handleProposeScopeExpansion)
+	server.mux.HandleFunc("POST /api/projects/{id}/scope-expansions/{expansion_id}/approve", server.handleApproveScopeExpansion)
+	server.mux.HandleFunc("POST /api/projects/{id}/scope-expansions/{expansion_id}/reject", server.handleRejectScopeExpansion)
+	server.mux.HandleFunc("POST /api/projects/{id}/reason-tasks", server.handleCreateReasonTask)
+	server.mux.HandleFunc("GET /api/projects/{id}/reason-task-proposals", server.handleListReasonTaskProposals)
+	server.mux.HandleFunc("POST /api/projects/{id}/reason-tasks/{task_id}/proposals", server.handleProposeReasonTaskChanges)
+	server.mux.HandleFunc("POST /api/projects/{id}/reason-task-proposals/{proposal_id}/approve", server.handleApproveReasonTaskProposal)
+	server.mux.HandleFunc("POST /api/projects/{id}/reason-task-proposals/{proposal_id}/reject", server.handleRejectReasonTaskProposal)
 	server.mux.HandleFunc("GET /api/projects/{id}", server.handleGetProject)
 	server.mux.HandleFunc("PATCH /api/projects/{id}", server.handleUpdateProject)
 	server.mux.HandleFunc("POST /api/projects/{id}/kind-conversion/preview", server.handlePreviewProjectKindConversion)

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -28,6 +28,7 @@ import (
 	"pentest/internal/preflight"
 	"pentest/internal/project"
 	"pentest/internal/projectinterface"
+	"pentest/internal/reasontask"
 	"pentest/internal/runner"
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeprofile"
@@ -79,6 +80,14 @@ func (input taskContinuationSelectionInput) selectedModel() string {
 }
 
 func (server *Server) handleCreateTask(response http.ResponseWriter, request *http.Request) {
+	server.handleCreateTaskWithPurpose(response, request, false)
+}
+
+func (server *Server) handleCreateReasonTask(response http.ResponseWriter, request *http.Request) {
+	server.handleCreateTaskWithPurpose(response, request, true)
+}
+
+func (server *Server) handleCreateTaskWithPurpose(response http.ResponseWriter, request *http.Request, reasonTask bool) {
 	projectID := request.PathValue("id")
 	if !server.requireProject(response, projectID) {
 		return
@@ -95,7 +104,9 @@ func (server *Server) handleCreateTask(response http.ResponseWriter, request *ht
 	if input.RunControls.Extras == nil && input.Extras != nil {
 		input.RunControls.Extras = input.Extras
 	}
-	if input.Type != task.TypePentest && input.Type != task.TypeCTFChallenge {
+	if reasonTask {
+		input.Goal = reasontask.LaunchGoal
+	} else if input.Type != task.TypePentest && input.Type != task.TypeCTFChallenge {
 		writeTaskError(response, task.ErrInvalidTaskType)
 		return
 	}
@@ -107,6 +118,9 @@ func (server *Server) handleCreateTask(response http.ResponseWriter, request *ht
 	}
 	input.RuntimeProfileID = defaulted.runtimeProfileID
 	input.Runner = defaulted.runner
+	if reasonTask {
+		input.Type = task.Type(defaulted.project.Kind)
+	}
 	if input.RunControls.BlackboardConclusionMode == task.BlackboardConclusionModeAssisted {
 		profile, profileErr := server.profiles.Get(input.RuntimeProfileID)
 		if profileErr != nil {
@@ -168,6 +182,12 @@ func (server *Server) handleCreateTask(response http.ResponseWriter, request *ht
 	if err != nil {
 		writeTaskError(response, err)
 		return
+	}
+	if reasonTask {
+		if err := server.reasonTasks.Register(projectID, created.ID); err != nil {
+			writeError(response, http.StatusInternalServerError, "register Reason Task")
+			return
+		}
 	}
 
 	// The stored Task goal stays exactly as typed; only the launch goal handed

--- a/internal/modelprovider/modelprovider.go
+++ b/internal/modelprovider/modelprovider.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,6 +25,14 @@ const (
 	ProtocolOpenAIChatCompletions Protocol = "openai_chat_completions"
 	ProtocolOpenAIResponses       Protocol = "openai_responses"
 	ProtocolAnthropicMessages     Protocol = "anthropic_messages"
+)
+
+const (
+	// MaxCatalogResponseBytes bounds memory used by one Model Catalog Refresh.
+	MaxCatalogResponseBytes = 4 * 1024 * 1024
+	// CatalogRefreshTimeout bounds a production upstream request even when its
+	// caller does not provide an earlier context deadline.
+	CatalogRefreshTimeout = 30 * time.Second
 )
 
 var validProtocols = map[Protocol]bool{
@@ -79,7 +88,14 @@ var (
 	ErrDuplicateEndpointProtocol = errors.New("model provider endpoint protocol is duplicated")
 	ErrInvalidEndpointBaseURL    = errors.New("model provider endpoint base URL is invalid")
 	ErrInUse                     = errors.New("model provider is referenced by a runtime profile")
+	ErrCatalogResponseTooLarge   = errors.New("model catalog response exceeds size limit")
 )
+
+// NewCatalogHTTPClient returns the bounded production client for Model
+// Catalog Refresh. Tests can still inject a client with a controlled transport.
+func NewCatalogHTTPClient() *http.Client {
+	return &http.Client{Timeout: CatalogRefreshTimeout}
+}
 
 type Service struct {
 	db *store.DB
@@ -242,7 +258,7 @@ func (s *Service) RefreshModelsWithKey(ctx context.Context, id string, client *h
 		return Provider{}, fmt.Errorf("model provider API key env %s is not configured", provider.APIKeyEnv)
 	}
 	if client == nil {
-		client = http.DefaultClient
+		client = NewCatalogHTTPClient()
 	}
 	refreshURL, err := CatalogRefreshURL(provider)
 	if err != nil {
@@ -261,12 +277,19 @@ func (s *Service) RefreshModelsWithKey(ctx context.Context, id string, client *h
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return Provider{}, fmt.Errorf("refresh model catalog: upstream status %d", resp.StatusCode)
 	}
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, int64(MaxCatalogResponseBytes)+1))
+	if err != nil {
+		return Provider{}, fmt.Errorf("read model catalog: %w", err)
+	}
+	if len(responseBody) > MaxCatalogResponseBytes {
+		return Provider{}, ErrCatalogResponseTooLarge
+	}
 	var payload struct {
 		Data []struct {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return Provider{}, fmt.Errorf("parse model catalog: %w", err)
 	}
 	var ids []string

--- a/internal/modelprovider/modelprovider_test.go
+++ b/internal/modelprovider/modelprovider_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"pentest/internal/modelprovider"
@@ -494,6 +496,35 @@ func TestRefreshModelsFailurePreservesCatalog(t *testing.T) {
 	}
 	if !reflect.DeepEqual(after.Catalog, provider.Catalog) {
 		t.Fatalf("catalog changed on failure: %#v", after.Catalog)
+	}
+}
+
+func TestRefreshModelsRejectsOversizedCatalogResponse(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		body := `{"data":[{"id":"` + strings.Repeat("x", modelprovider.MaxCatalogResponseBytes) + `"}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{},
+		}, nil
+	})}
+	svc := modelprovider.NewService(newStore(t))
+	provider, err := svc.Create(modelprovider.CreateRequest{
+		Name: "Bounded", BaseURL: "https://api.example.test/v1",
+		Protocols: []modelprovider.Protocol{modelprovider.ProtocolOpenAIChatCompletions},
+		Catalog:   modelprovider.Catalog{Manual: []string{"manual"}, DefaultModel: "manual"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	_, err = svc.RefreshModelsWithKey(context.Background(), provider.ID, client, "sk-test")
+	if !errors.Is(err, modelprovider.ErrCatalogResponseTooLarge) {
+		t.Fatalf("oversized catalog error = %v", err)
+	}
+	after, getErr := svc.Get(provider.ID)
+	if getErr != nil || !reflect.DeepEqual(after.Catalog, provider.Catalog) {
+		t.Fatalf("catalog after oversized response = %#v, error=%v", after.Catalog, getErr)
 	}
 }
 

--- a/internal/owner/assisted_conclusion.go
+++ b/internal/owner/assisted_conclusion.go
@@ -1,6 +1,12 @@
 package owner
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
 
 // BlackboardConclusionReceiptState is the shared durable protocol state for
 // one completed assisted Work Turn. Task and Session persist it in separate
@@ -48,6 +54,141 @@ type SemanticDebtWatermarks struct {
 
 func (watermarks SemanticDebtWatermarks) Valid() bool {
 	return watermarks.SemanticPersistence >= 0 && watermarks.SourceWork >= watermarks.SemanticPersistence
+}
+
+// ConclusionCheckpointInput is the owner-neutral input for one durable
+// assisted-conclusion checkpoint. Owner adapters prove aggregate and
+// Continuation ownership after this shared normalization step.
+type ConclusionCheckpointInput struct {
+	OwnerID         string
+	ContinuationID  string
+	SourceRequestID string
+	SourceSessionID string
+	SourceTurnID    string
+	ModelProviderID string
+	Model           string
+	ReasoningEffort string
+	Watermarks      SemanticDebtWatermarks
+}
+
+// Normalize removes transport whitespace and validates fields that have the
+// same meaning for Task and Session owners.
+func (input ConclusionCheckpointInput) Normalize() (ConclusionCheckpointInput, bool) {
+	input.OwnerID = strings.TrimSpace(input.OwnerID)
+	input.ContinuationID = strings.TrimSpace(input.ContinuationID)
+	input.SourceRequestID = strings.TrimSpace(input.SourceRequestID)
+	input.SourceSessionID = strings.TrimSpace(input.SourceSessionID)
+	input.SourceTurnID = strings.TrimSpace(input.SourceTurnID)
+	input.ModelProviderID = strings.TrimSpace(input.ModelProviderID)
+	input.Model = strings.TrimSpace(input.Model)
+	input.ReasoningEffort = strings.TrimSpace(input.ReasoningEffort)
+	valid := input.OwnerID != "" && input.ContinuationID != "" && input.SourceRequestID != "" &&
+		input.SourceSessionID != "" && input.SourceTurnID != "" && input.ModelProviderID != "" &&
+		input.Model != "" && input.Watermarks.Valid()
+	return input, valid
+}
+
+// InitialConclusionCheckpoint selects the shared initial obligation state and
+// Timeline phase from semantic-debt watermarks.
+func InitialConclusionCheckpoint(watermarks SemanticDebtWatermarks) (BlackboardConclusionReceiptState, string) {
+	if watermarks.SourceWork <= watermarks.SemanticPersistence {
+		return BlackboardConclusionReceiptClean, "persistence_current"
+	}
+	return BlackboardConclusionReceiptPending, "pending_detected"
+}
+
+// ConclusionRepairAllowed applies the one-repair automatic-turn budget.
+func ConclusionRepairAllowed(code BlackboardConclusionErrorCode, automaticTurns, repairs, versionRegenerations, explicitRetries int) bool {
+	return code == BlackboardConclusionErrorInvalidResult && automaticTurns < BlackboardConclusionAutomaticTurnLimit &&
+		repairs == 0 && versionRegenerations == 0 && explicitRetries == 0
+}
+
+// ConclusionVersionRegenerationAllowed applies the one-regeneration
+// automatic-turn budget.
+func ConclusionVersionRegenerationAllowed(versionRegenerations, automaticTurns, explicitRetries int) bool {
+	return versionRegenerations == 0 && automaticTurns < BlackboardConclusionAutomaticTurnLimit && explicitRetries == 0
+}
+
+// ConclusionRecoveryEligible reports whether a pre-apply obligation can move
+// to action_required during fail-closed recovery.
+func ConclusionRecoveryEligible(state BlackboardConclusionReceiptState) bool {
+	switch state {
+	case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptDispatchRequested,
+		BlackboardConclusionReceiptRepairDispatchRequested, BlackboardConclusionReceiptVersionSyncRequested,
+		BlackboardConclusionReceiptVersionRegenerationDispatchRequested, BlackboardConclusionReceiptAwaitingResult:
+		return true
+	default:
+		return false
+	}
+}
+
+// ConclusionFailureActionCode maps a terminal failed result to its stable
+// operator-visible error code.
+func ConclusionFailureActionCode(code BlackboardConclusionErrorCode, repairs, versionRegenerations int) BlackboardConclusionErrorCode {
+	if code == BlackboardConclusionErrorInvalidResult && repairs > 0 && versionRegenerations == 0 {
+		return BlackboardConclusionErrorRepairExhausted
+	}
+	return code
+}
+
+// ConclusionWorkTurnConflictOutcome maps the shared conflict budget to its
+// stable error code and Timeline reason.
+func ConclusionWorkTurnConflictOutcome(explicitRetries int) (BlackboardConclusionErrorCode, string) {
+	if explicitRetries >= BlackboardConclusionWorkTurnConflictLimit {
+		return BlackboardConclusionErrorWorkTurnNeverSettled, "work_turn_never_settled"
+	}
+	return BlackboardConclusionErrorRuntimeRecoveryRequired, "work_turn_conflict"
+}
+
+// ConclusionRetryDecision is the shared validation result for an
+// operator-authorized conclusion retry.
+type ConclusionRetryDecision string
+
+const (
+	ConclusionRetryAllowed             ConclusionRetryDecision = "allowed"
+	ConclusionRetryInvalidState        ConclusionRetryDecision = "invalid_state"
+	ConclusionRetryNeverSettled        ConclusionRetryDecision = "never_settled"
+	ConclusionRetryAcceptanceAmbiguous ConclusionRetryDecision = "acceptance_ambiguous"
+	ConclusionRetryCooldown            ConclusionRetryDecision = "cooldown"
+)
+
+// ConclusionRetryDecisionFor validates retry state, terminal reasons, and the
+// durable cooldown without owner-specific storage concerns.
+func ConclusionRetryDecisionFor(state BlackboardConclusionReceiptState, code BlackboardConclusionErrorCode, recoveryReason ConclusionRecoveryReason, nextEligibleAt *time.Time, now time.Time) ConclusionRetryDecision {
+	if state != BlackboardConclusionReceiptActionRequired {
+		return ConclusionRetryInvalidState
+	}
+	if code == BlackboardConclusionErrorWorkTurnNeverSettled {
+		return ConclusionRetryNeverSettled
+	}
+	if recoveryReason == ConclusionRecoveryAcceptanceAmbiguous {
+		return ConclusionRetryAcceptanceAmbiguous
+	}
+	if nextEligibleAt == nil || now.Before(*nextEligibleAt) {
+		return ConclusionRetryCooldown
+	}
+	return ConclusionRetryAllowed
+}
+
+// ConclusionRequestLineage derives the initial dispatch and apply keys from
+// length-framed provider correlation values.
+func ConclusionRequestLineage(continuationID, sourceTurnID string) (string, string) {
+	lineage := fmt.Sprintf("%d:%s%d:%s", len(continuationID), continuationID, len(sourceTurnID), sourceTurnID)
+	digest := CanonicalConclusionSHA256([]byte(lineage))
+	return "conclude:v1:" + digest, "assisted-apply:v1:" + digest
+}
+
+// ConclusionAttemptRequestID derives a stable identity for a repair, version,
+// retry, or recovery dispatch.
+func ConclusionAttemptRequestID(kind, continuationID, sourceTurnID string, number int, key string) string {
+	lineage := fmt.Sprintf("%s:%d:%s:%d:%s:%d:%s", kind, len(continuationID), continuationID, len(sourceTurnID), sourceTurnID, number, key)
+	return "conclude-" + kind + ":v1:" + CanonicalConclusionSHA256([]byte(lineage))
+}
+
+// CanonicalConclusionSHA256 returns the shared lower-case content digest.
+func CanonicalConclusionSHA256(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
 }
 
 // ConclusionValidationDetail is the bounded public reason for one rejected

--- a/internal/owner/assisted_conclusion_test.go
+++ b/internal/owner/assisted_conclusion_test.go
@@ -1,0 +1,89 @@
+package owner
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConclusionCheckpointInputNormalizesAndValidatesOwnerNeutralFields(t *testing.T) {
+	input := ConclusionCheckpointInput{
+		OwnerID: " task-1 ", ContinuationID: " continuation-1 ", SourceRequestID: " request-1 ",
+		SourceSessionID: " session-1 ", SourceTurnID: " turn-1 ", ModelProviderID: " provider-1 ",
+		Model: " model-1 ", ReasoningEffort: " high ",
+		Watermarks: SemanticDebtWatermarks{SourceWork: 3, SemanticPersistence: 1},
+	}
+	normalized, valid := input.Normalize()
+	if !valid || normalized.OwnerID != "task-1" || normalized.ContinuationID != "continuation-1" ||
+		normalized.ModelProviderID != "provider-1" || normalized.ReasoningEffort != "high" {
+		t.Fatalf("normalized checkpoint = %#v, valid=%v", normalized, valid)
+	}
+	input.Model = " "
+	if _, valid := input.Normalize(); valid {
+		t.Fatal("checkpoint without a model is valid")
+	}
+}
+
+func TestConclusionProtocolRulesAreSharedAcrossOwners(t *testing.T) {
+	state, phase := InitialConclusionCheckpoint(SemanticDebtWatermarks{SourceWork: 2, SemanticPersistence: 2})
+	if state != BlackboardConclusionReceiptClean || phase != "persistence_current" {
+		t.Fatalf("current checkpoint = %q, %q", state, phase)
+	}
+	state, phase = InitialConclusionCheckpoint(SemanticDebtWatermarks{SourceWork: 3, SemanticPersistence: 2})
+	if state != BlackboardConclusionReceiptPending || phase != "pending_detected" {
+		t.Fatalf("debt checkpoint = %q, %q", state, phase)
+	}
+
+	if !ConclusionRepairAllowed(BlackboardConclusionErrorInvalidResult, 1, 0, 0, 0) {
+		t.Fatal("first invalid result must allow one bounded repair")
+	}
+	if ConclusionRepairAllowed(BlackboardConclusionErrorInvalidResult, 2, 0, 0, 0) ||
+		ConclusionRepairAllowed(BlackboardConclusionErrorToolUseForbidden, 1, 0, 0, 0) {
+		t.Fatal("repair rule exceeded its bounded protocol")
+	}
+	if !ConclusionVersionRegenerationAllowed(0, 1, 0) || ConclusionVersionRegenerationAllowed(1, 1, 0) {
+		t.Fatal("version-regeneration rule did not preserve its one-turn budget")
+	}
+	if !ConclusionRecoveryEligible(BlackboardConclusionReceiptRepairDispatchRequested) ||
+		ConclusionRecoveryEligible(BlackboardConclusionReceiptApplied) {
+		t.Fatal("recovery eligibility accepted a terminal protocol state")
+	}
+}
+
+func TestConclusionLineageIsStableAndUnambiguous(t *testing.T) {
+	requestID, applyKey := ConclusionRequestLineage("ab", "c")
+	otherRequestID, _ := ConclusionRequestLineage("a", "bc")
+	if requestID == otherRequestID || requestID == "" || applyKey == "" {
+		t.Fatalf("lineage request=%q other=%q apply=%q", requestID, otherRequestID, applyKey)
+	}
+	if got := ConclusionAttemptRequestID("repair", "ab", "c", 1, ""); got == requestID || got == "" {
+		t.Fatalf("repair request id = %q", got)
+	}
+}
+
+func TestConclusionFailureAndRetryDecisionsAreOwnerNeutral(t *testing.T) {
+	if got := ConclusionFailureActionCode(BlackboardConclusionErrorInvalidResult, 1, 0); got != BlackboardConclusionErrorRepairExhausted {
+		t.Fatalf("second invalid result code = %q", got)
+	}
+	code, reason := ConclusionWorkTurnConflictOutcome(BlackboardConclusionWorkTurnConflictLimit)
+	if code != BlackboardConclusionErrorWorkTurnNeverSettled || reason != "work_turn_never_settled" {
+		t.Fatalf("exhausted conflict outcome = %q, %q", code, reason)
+	}
+	now := time.Now().UTC()
+	eligible := now.Add(-time.Second)
+	if decision := ConclusionRetryDecisionFor(
+		BlackboardConclusionReceiptActionRequired, BlackboardConclusionErrorInvalidResult, "", &eligible, now,
+	); decision != ConclusionRetryAllowed {
+		t.Fatalf("eligible retry decision = %q", decision)
+	}
+	if decision := ConclusionRetryDecisionFor(
+		BlackboardConclusionReceiptActionRequired, BlackboardConclusionErrorWorkTurnNeverSettled, "", &eligible, now,
+	); decision != ConclusionRetryNeverSettled {
+		t.Fatalf("never-settled retry decision = %q", decision)
+	}
+	if decision := ConclusionRetryDecisionFor(
+		BlackboardConclusionReceiptActionRequired, BlackboardConclusionErrorRuntimeRecoveryRequired,
+		ConclusionRecoveryAcceptanceAmbiguous, &eligible, now,
+	); decision != ConclusionRetryAcceptanceAmbiguous {
+		t.Fatalf("ambiguous retry decision = %q", decision)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -266,7 +266,7 @@ func previewKindConversionTx(tx *sql.Tx, id, targetKind string) (KindConversionP
 		return preview, nil
 	}
 	var activeTasks int
-	if err := tx.QueryRow(`SELECT COUNT(*) FROM tasks WHERE project_id=? AND status NOT IN ('completed','failed','stopped')`, id).Scan(&activeTasks); err != nil {
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM tasks WHERE project_id=? AND status NOT IN ('completed','failed','stopped','interrupted')`, id).Scan(&activeTasks); err != nil {
 		return KindConversionPreview{}, fmt.Errorf("count active Tasks: %w", err)
 	}
 	if activeTasks > 0 {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -134,10 +134,15 @@ func TestProjectKindConversionPreviewBlocksActiveTasksAndIncompatibleKnowledge(t
 }
 
 func TestProjectKindConversionChangesOnlyKindWhenPreviewIsReady(t *testing.T) {
-	service := newTestService(t)
+	service, db := newTestServiceWithDB(t)
 	created, err := service.CreateWithKind("Challenge", "", project.KindPentest, project.Scope{URLs: []string{"https://arena.test"}}, project.Defaults{})
 	if err != nil {
 		t.Fatalf("create Project: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(`INSERT INTO tasks(id,project_id,goal,status,runner,runtime_profile_id,run_controls_json,scope_snapshot_json,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?)`,
+		"task-interrupted", created.ID, "terminal work", "interrupted", "sandbox", "profile", `{}`, `{}`, now, now); err != nil {
+		t.Fatalf("insert interrupted Task: %v", err)
 	}
 
 	preview, err := service.PreviewKindConversion(created.ID, project.KindCTFChallenge)

--- a/internal/reasontask/reason_task.go
+++ b/internal/reasontask/reason_task.go
@@ -1,0 +1,245 @@
+// Package reasontask owns operator-triggered planning Tasks and their
+// approval-required Blackboard proposals.
+package reasontask
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"pentest/internal/blackboardv2"
+	"pentest/internal/store"
+)
+
+const LaunchGoal = "Read the complete Runtime Blackboard Snapshot and prepare an approval-required proposal for next Task Goals, Exploration Objective changes, and a readiness judgment. Do not mutate Blackboard records directly."
+
+type Status string
+
+const (
+	StatusProposed Status = "proposed"
+	StatusApproved Status = "approved"
+	StatusRejected Status = "rejected"
+)
+
+type Proposal struct {
+	ID                          string                `json:"id"`
+	ProjectID                   string                `json:"project_id"`
+	ReasonTaskID                string                `json:"reason_task_id"`
+	NextTaskGoals               []string              `json:"next_task_goals"`
+	ExplorationObjectiveChanges []string              `json:"exploration_objective_changes"`
+	ReadinessJudgment           string                `json:"readiness_judgment"`
+	Changes                     []blackboardv2.Change `json:"changes"`
+	Status                      Status                `json:"status"`
+	CreatedAt                   time.Time             `json:"created_at"`
+	DecidedAt                   *time.Time            `json:"decided_at,omitempty"`
+}
+
+type ProposeRequest struct {
+	ProjectID                   string
+	ReasonTaskID                string
+	NextTaskGoals               []string
+	ExplorationObjectiveChanges []string
+	ReadinessJudgment           string
+	Changes                     []blackboardv2.Change
+}
+
+var (
+	ErrInvalid     = errors.New("invalid Reason Task proposal")
+	ErrNotFound    = errors.New("Reason Task proposal not found")
+	ErrNotProposed = errors.New("Reason Task proposal is not proposed")
+	ErrNotReason   = errors.New("Task is not a registered Reason Task")
+)
+
+type Service struct {
+	db    *store.DB
+	board *blackboardv2.Service
+}
+
+func NewService(db *store.DB, board *blackboardv2.Service) *Service {
+	return &Service{db: db, board: board}
+}
+
+// Register records the server-owned Reason Task role after normal Task Launch
+// has captured its Project Scope and Runtime configuration.
+func (service *Service) Register(projectID, taskID string) error {
+	projectID, taskID = strings.TrimSpace(projectID), strings.TrimSpace(taskID)
+	var actualProjectID string
+	if err := service.db.QueryRow(`SELECT project_id FROM tasks WHERE id=?`, taskID).Scan(&actualProjectID); err != nil || actualProjectID != projectID {
+		return ErrNotReason
+	}
+	_, err := service.db.Exec(`INSERT OR IGNORE INTO reason_tasks(task_id,project_id,created_at) VALUES(?,?,?)`, taskID, projectID, time.Now().UTC().Format(time.RFC3339Nano))
+	return err
+}
+
+func (service *Service) Propose(request ProposeRequest) (Proposal, error) {
+	request.ProjectID, request.ReasonTaskID = strings.TrimSpace(request.ProjectID), strings.TrimSpace(request.ReasonTaskID)
+	request.NextTaskGoals = normalizeText(request.NextTaskGoals)
+	request.ExplorationObjectiveChanges = normalizeText(request.ExplorationObjectiveChanges)
+	request.ReadinessJudgment = strings.TrimSpace(request.ReadinessJudgment)
+	if request.ProjectID == "" || request.ReasonTaskID == "" || len(request.NextTaskGoals) == 0 ||
+		len(request.ExplorationObjectiveChanges) == 0 || request.ReadinessJudgment == "" || len(request.Changes) == 0 {
+		return Proposal{}, ErrInvalid
+	}
+	var registered int
+	if err := service.db.QueryRow(`SELECT COUNT(*) FROM reason_tasks WHERE task_id=? AND project_id=?`, request.ReasonTaskID, request.ProjectID).Scan(&registered); err != nil {
+		return Proposal{}, err
+	}
+	if registered != 1 {
+		return Proposal{}, ErrNotReason
+	}
+	changesJSON, err := json.Marshal(request.Changes)
+	if err != nil {
+		return Proposal{}, ErrInvalid
+	}
+	var normalizedChanges []blackboardv2.Change
+	if err := json.Unmarshal(changesJSON, &normalizedChanges); err != nil {
+		return Proposal{}, fmt.Errorf("%w: %v", ErrInvalid, err)
+	}
+	metadataJSON, err := json.Marshal(struct {
+		NextTaskGoals               []string `json:"next_task_goals"`
+		ExplorationObjectiveChanges []string `json:"exploration_objective_changes"`
+		ReadinessJudgment           string   `json:"readiness_judgment"`
+	}{request.NextTaskGoals, request.ExplorationObjectiveChanges, request.ReadinessJudgment})
+	if err != nil {
+		return Proposal{}, err
+	}
+	now := time.Now().UTC()
+	proposal := Proposal{
+		ID: newID(), ProjectID: request.ProjectID, ReasonTaskID: request.ReasonTaskID,
+		NextTaskGoals: request.NextTaskGoals, ExplorationObjectiveChanges: request.ExplorationObjectiveChanges,
+		ReadinessJudgment: request.ReadinessJudgment, Changes: normalizedChanges, Status: StatusProposed, CreatedAt: now,
+	}
+	if _, err := service.db.Exec(`INSERT INTO reason_task_proposals
+		(id,project_id,reason_task_id,proposal_json,change_batch_json,status,created_at) VALUES(?,?,?,?,?,?,?)`,
+		proposal.ID, proposal.ProjectID, proposal.ReasonTaskID, string(metadataJSON), string(changesJSON), string(proposal.Status), now.Format(time.RFC3339Nano)); err != nil {
+		return Proposal{}, err
+	}
+	return proposal, nil
+}
+
+func (service *Service) List(projectID string) ([]Proposal, error) {
+	rows, err := service.db.Query(`SELECT id,project_id,reason_task_id,proposal_json,change_batch_json,status,created_at,decided_at
+		FROM reason_task_proposals WHERE project_id=? ORDER BY created_at,id`, strings.TrimSpace(projectID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	proposals := []Proposal{}
+	for rows.Next() {
+		proposal, err := scanProposal(rows)
+		if err != nil {
+			return nil, err
+		}
+		proposals = append(proposals, proposal)
+	}
+	return proposals, rows.Err()
+}
+
+func (service *Service) Approve(ctx context.Context, projectID, proposalID string) (Proposal, blackboardv2.ChangeResult, error) {
+	proposal, err := service.load(projectID, proposalID)
+	if err != nil {
+		return Proposal{}, blackboardv2.ChangeResult{}, err
+	}
+	if proposal.Status != StatusProposed {
+		return Proposal{}, blackboardv2.ChangeResult{}, ErrNotProposed
+	}
+	result, err := service.board.Apply(ctx, proposal.ProjectID, blackboardv2.ChangeBatch{
+		Schema: "semantic-change-batch/v2", IdempotencyKey: "reason-task-proposal:" + proposal.ID, Changes: proposal.Changes,
+	})
+	if err != nil {
+		return Proposal{}, blackboardv2.ChangeResult{}, err
+	}
+	now := time.Now().UTC()
+	update, err := service.db.Exec(`UPDATE reason_task_proposals SET status=?,decided_at=? WHERE id=? AND project_id=? AND status=?`,
+		string(StatusApproved), now.Format(time.RFC3339Nano), proposal.ID, proposal.ProjectID, string(StatusProposed))
+	if err != nil {
+		return Proposal{}, blackboardv2.ChangeResult{}, err
+	}
+	changed, _ := update.RowsAffected()
+	if changed != 1 {
+		return Proposal{}, blackboardv2.ChangeResult{}, ErrNotProposed
+	}
+	proposal.Status, proposal.DecidedAt = StatusApproved, &now
+	return proposal, result, nil
+}
+
+func (service *Service) Reject(projectID, proposalID string) (Proposal, error) {
+	proposal, err := service.load(projectID, proposalID)
+	if err != nil {
+		return Proposal{}, err
+	}
+	if proposal.Status != StatusProposed {
+		return Proposal{}, ErrNotProposed
+	}
+	now := time.Now().UTC()
+	result, err := service.db.Exec(`UPDATE reason_task_proposals SET status=?,decided_at=? WHERE id=? AND project_id=? AND status=?`,
+		string(StatusRejected), now.Format(time.RFC3339Nano), proposal.ID, proposal.ProjectID, string(StatusProposed))
+	if err != nil {
+		return Proposal{}, err
+	}
+	changed, _ := result.RowsAffected()
+	if changed != 1 {
+		return Proposal{}, ErrNotProposed
+	}
+	proposal.Status, proposal.DecidedAt = StatusRejected, &now
+	return proposal, nil
+}
+
+func (service *Service) load(projectID, proposalID string) (Proposal, error) {
+	proposal, err := scanProposal(service.db.QueryRow(`SELECT id,project_id,reason_task_id,proposal_json,change_batch_json,status,created_at,decided_at
+		FROM reason_task_proposals WHERE id=? AND project_id=?`, strings.TrimSpace(proposalID), strings.TrimSpace(projectID)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Proposal{}, ErrNotFound
+	}
+	return proposal, err
+}
+
+func scanProposal(row interface{ Scan(...any) error }) (Proposal, error) {
+	var proposal Proposal
+	var metadataJSON, changesJSON, status, createdAt string
+	var decidedAt sql.NullString
+	if err := row.Scan(&proposal.ID, &proposal.ProjectID, &proposal.ReasonTaskID, &metadataJSON, &changesJSON, &status, &createdAt, &decidedAt); err != nil {
+		return Proposal{}, err
+	}
+	var metadata struct {
+		NextTaskGoals               []string `json:"next_task_goals"`
+		ExplorationObjectiveChanges []string `json:"exploration_objective_changes"`
+		ReadinessJudgment           string   `json:"readiness_judgment"`
+	}
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		return Proposal{}, err
+	}
+	if err := json.Unmarshal([]byte(changesJSON), &proposal.Changes); err != nil {
+		return Proposal{}, err
+	}
+	proposal.NextTaskGoals, proposal.ExplorationObjectiveChanges = metadata.NextTaskGoals, metadata.ExplorationObjectiveChanges
+	proposal.ReadinessJudgment, proposal.Status = metadata.ReadinessJudgment, Status(status)
+	var err error
+	if proposal.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
+		return Proposal{}, err
+	}
+	if decidedAt.Valid {
+		parsed, err := time.Parse(time.RFC3339Nano, decidedAt.String)
+		if err != nil {
+			return Proposal{}, err
+		}
+		proposal.DecidedAt = &parsed
+	}
+	return proposal, nil
+}
+
+func normalizeText(values []string) []string {
+	result := []string{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func newID() string { return fmt.Sprintf("reason-proposal-%d", time.Now().UTC().UnixNano()) }

--- a/internal/reasontask/reason_task_test.go
+++ b/internal/reasontask/reason_task_test.go
@@ -1,0 +1,71 @@
+package reasontask_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"pentest/internal/blackboardv2"
+	"pentest/internal/project"
+	"pentest/internal/reasontask"
+	"pentest/internal/store"
+	"pentest/internal/task"
+)
+
+func TestReasonTaskProposalCannotMutateBlackboardBeforeApproval(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))
+	if err != nil {
+		t.Fatalf("open Store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	projects := project.NewService(db)
+	createdProject, _ := projects.CreateWithKind("Engagement", "", project.KindPentest, project.Scope{}, project.Defaults{})
+	tasks := task.NewService(db, projects)
+	planningTask, err := tasks.Create(task.CreateRequest{
+		ProjectID: createdProject.ID, Type: task.TypePentest,
+		Goal: "Prepare an approval-required Reason Task proposal", Runner: task.RunnerSandbox,
+	})
+	if err != nil {
+		t.Fatalf("create planning Task: %v", err)
+	}
+	board := blackboardv2.NewService(db)
+	service := reasontask.NewService(db, board)
+	if err := service.Register(createdProject.ID, planningTask.ID); err != nil {
+		t.Fatalf("register Reason Task: %v", err)
+	}
+
+	proposal, err := service.Propose(reasontask.ProposeRequest{
+		ProjectID: createdProject.ID, ReasonTaskID: planningTask.ID,
+		NextTaskGoals:               []string{"Confirm the new administration surface"},
+		ExplorationObjectiveChanges: []string{"Replace the broad discovery objective with targeted validation"},
+		ReadinessJudgment:           "The Project is ready for targeted validation after consolidation.",
+		Changes: []blackboardv2.Change{{
+			Op: "create", Key: "objective:targeted-validation", Type: "objective",
+			Record: map[string]any{"status": "open", "objective": "Validate the administration surface"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("store Reason Task proposal: %v", err)
+	}
+	if proposal.Status != reasontask.StatusProposed {
+		t.Fatalf("proposal = %#v", proposal)
+	}
+	if _, err := board.ReadCurrent(context.Background(), createdProject.ID, "objective:targeted-validation"); err == nil {
+		t.Fatalf("proposal mutated Blackboard before approval: %v", err)
+	}
+
+	approved, result, err := service.Approve(context.Background(), createdProject.ID, proposal.ID)
+	if err != nil {
+		t.Fatalf("approve Reason Task proposal: %v", err)
+	}
+	if approved.Status != reasontask.StatusApproved || result.Revision < 1 {
+		t.Fatalf("approved proposal = %#v, result=%#v", approved, result)
+	}
+	if _, err := board.ReadCurrent(context.Background(), createdProject.ID, "objective:targeted-validation"); err != nil {
+		t.Fatalf("approved Blackboard change missing: %v", err)
+	}
+	if _, _, err := service.Approve(context.Background(), createdProject.ID, proposal.ID); !errors.Is(err, reasontask.ErrNotProposed) {
+		t.Fatalf("second approval error = %v", err)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -322,7 +322,7 @@ func namedVolumeSubpath(volumeRoot, candidate string) (string, bool) {
 }
 
 func namedVolumeSubpathOption(program string) string {
-	if strings.EqualFold(filepath.Base(program), "podman") {
+	if kindFromCLIName(program) == EnginePodman {
 		return "subpath"
 	}
 	return "volume-subpath"

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -237,31 +237,35 @@ func TestBuildSandboxCommandMountsASeparateOwnerWorkdirFromTheNamedVolume(t *tes
 }
 
 func TestBuildSandboxCommandUsesPodmanNamedVolumeSubpathSyntax(t *testing.T) {
-	volumeRoot := filepath.Join(t.TempDir(), "data")
-	layout, err := runner.PrepareTaskLayout(filepath.Join(volumeRoot, "runs"), "task-podman", runtimeprofile.ProviderPi)
-	if err != nil {
-		t.Fatalf("prepare layout: %v", err)
-	}
+	for _, containerCLI := range []string{"podman", "podman.exe", "podman-remote"} {
+		t.Run(containerCLI, func(t *testing.T) {
+			volumeRoot := filepath.Join(t.TempDir(), "data")
+			layout, err := runner.PrepareTaskLayout(filepath.Join(volumeRoot, "runs"), "task-podman", runtimeprofile.ProviderPi)
+			if err != nil {
+				t.Fatalf("prepare layout: %v", err)
+			}
 
-	command, err := runner.BuildSandboxCommand(runner.SandboxCommandRequest{
-		Layout: layout, Provider: runtimeprofile.ProviderPi, ContainerCLI: "podman",
-		TaskVolume: "cyberpenda-data", TaskVolumeRoot: volumeRoot, RuntimeCommand: []string{"pi", "--mode", "rpc"},
-	})
-	if err != nil {
-		t.Fatalf("build command: %v", err)
-	}
-	joined := strings.Join(command.Args, " ")
-	if !strings.Contains(joined, "type=volume,src=cyberpenda-data,dst=/task,subpath=runs/task-podman") {
-		t.Fatalf("expected Podman subpath syntax, got %v", command.Args)
-	}
-	if strings.Contains(joined, "volume-subpath=") {
-		t.Fatalf("Podman command contains Docker-only volume-subpath syntax: %v", command.Args)
-	}
-	if !strings.Contains(joined, "--add-host=host.docker.internal:host-gateway") {
-		t.Fatalf("expected host.docker.internal gateway, got %v", command.Args)
-	}
-	if !strings.Contains(joined, "--add-host=host.containers.internal:host-gateway") {
-		t.Fatalf("expected host.containers.internal gateway for Podman, got %v", command.Args)
+			command, err := runner.BuildSandboxCommand(runner.SandboxCommandRequest{
+				Layout: layout, Provider: runtimeprofile.ProviderPi, ContainerCLI: containerCLI,
+				TaskVolume: "cyberpenda-data", TaskVolumeRoot: volumeRoot, RuntimeCommand: []string{"pi", "--mode", "rpc"},
+			})
+			if err != nil {
+				t.Fatalf("build command: %v", err)
+			}
+			joined := strings.Join(command.Args, " ")
+			if !strings.Contains(joined, "type=volume,src=cyberpenda-data,dst=/task,subpath=runs/task-podman") {
+				t.Fatalf("expected Podman subpath syntax, got %v", command.Args)
+			}
+			if strings.Contains(joined, "volume-subpath=") {
+				t.Fatalf("Podman command contains Docker-only volume-subpath syntax: %v", command.Args)
+			}
+			if !strings.Contains(joined, "--add-host=host.docker.internal:host-gateway") {
+				t.Fatalf("expected host.docker.internal gateway, got %v", command.Args)
+			}
+			if !strings.Contains(joined, "--add-host=host.containers.internal:host-gateway") {
+				t.Fatalf("expected host.containers.internal gateway for Podman, got %v", command.Args)
+			}
+		})
 	}
 }
 

--- a/internal/scopeexpansion/scope_expansion.go
+++ b/internal/scopeexpansion/scope_expansion.go
@@ -1,0 +1,288 @@
+// Package scopeexpansion owns proposed additions to Project Scope. A proposal
+// does not authorize work until an operator approves it.
+package scopeexpansion
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"pentest/internal/project"
+	"pentest/internal/store"
+)
+
+type Status string
+
+const (
+	StatusProposed Status = "proposed"
+	StatusApproved Status = "approved"
+	StatusRejected Status = "rejected"
+)
+
+type TrustedOriginKind string
+
+const (
+	TrustedOriginOperator TrustedOriginKind = "operator"
+	TrustedOriginRuntime  TrustedOriginKind = "runtime"
+)
+
+// TrustedOrigin is internal integrity data. It is stored with the proposal but
+// omitted from ordinary API JSON.
+type TrustedOrigin struct {
+	Kind           TrustedOriginKind `json:"-"`
+	TaskID         string            `json:"-"`
+	ContinuationID string            `json:"-"`
+}
+
+type Proposal struct {
+	ID              string        `json:"id"`
+	ProjectID       string        `json:"project_id"`
+	Addition        project.Scope `json:"addition"`
+	DiscoverySource string        `json:"discovery_source"`
+	Reason          string        `json:"reason"`
+	Risk            string        `json:"risk"`
+	Status          Status        `json:"status"`
+	TrustedOrigin   TrustedOrigin `json:"-"`
+	CreatedAt       time.Time     `json:"created_at"`
+	DecidedAt       *time.Time    `json:"decided_at,omitempty"`
+}
+
+type ProposeRequest struct {
+	ProjectID       string
+	Addition        project.Scope
+	DiscoverySource string
+	Reason          string
+	Risk            string
+	Origin          TrustedOrigin
+}
+
+var (
+	ErrInvalid       = errors.New("invalid Scope Expansion")
+	ErrNotFound      = errors.New("Scope Expansion not found")
+	ErrNotProposed   = errors.New("Scope Expansion is not proposed")
+	ErrTrustedOrigin = errors.New("Scope Expansion Trusted Origin is not proven")
+)
+
+type Service struct {
+	db       *store.DB
+	projects *project.Service
+}
+
+func NewService(db *store.DB, projects *project.Service) *Service {
+	return &Service{db: db, projects: projects}
+}
+
+func (service *Service) Propose(request ProposeRequest) (Proposal, error) {
+	request.ProjectID = strings.TrimSpace(request.ProjectID)
+	request.DiscoverySource = strings.TrimSpace(request.DiscoverySource)
+	request.Reason = strings.TrimSpace(request.Reason)
+	request.Risk = strings.TrimSpace(request.Risk)
+	request.Origin.TaskID = strings.TrimSpace(request.Origin.TaskID)
+	request.Origin.ContinuationID = strings.TrimSpace(request.Origin.ContinuationID)
+	request.Addition = normalizeScope(request.Addition)
+	if request.ProjectID == "" || request.DiscoverySource == "" || request.Reason == "" || request.Risk == "" || !scopeHasAddition(request.Addition) {
+		return Proposal{}, ErrInvalid
+	}
+	if _, err := service.projects.Get(request.ProjectID); err != nil {
+		return Proposal{}, err
+	}
+	if err := service.validateTrustedOrigin(request.ProjectID, request.Origin); err != nil {
+		return Proposal{}, err
+	}
+	additionJSON, err := json.Marshal(request.Addition)
+	if err != nil {
+		return Proposal{}, fmt.Errorf("encode Scope Expansion: %w", err)
+	}
+	now := time.Now().UTC()
+	proposal := Proposal{
+		ID: newID(), ProjectID: request.ProjectID, Addition: request.Addition,
+		DiscoverySource: request.DiscoverySource, Reason: request.Reason, Risk: request.Risk,
+		Status: StatusProposed, TrustedOrigin: request.Origin, CreatedAt: now,
+	}
+	var taskID, continuationID any
+	if request.Origin.Kind == TrustedOriginRuntime {
+		taskID, continuationID = request.Origin.TaskID, request.Origin.ContinuationID
+	}
+	if _, err := service.db.Exec(`INSERT INTO scope_expansions
+		(id,project_id,addition_json,discovery_source,reason,risk,status,origin_kind,origin_task_id,origin_continuation_id,created_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?)`, proposal.ID, proposal.ProjectID, string(additionJSON), proposal.DiscoverySource,
+		proposal.Reason, proposal.Risk, string(proposal.Status), string(proposal.TrustedOrigin.Kind), taskID, continuationID,
+		now.Format(time.RFC3339Nano)); err != nil {
+		return Proposal{}, fmt.Errorf("store Scope Expansion: %w", err)
+	}
+	return proposal, nil
+}
+
+func (service *Service) List(projectID string) ([]Proposal, error) {
+	rows, err := service.db.Query(`SELECT id,project_id,addition_json,discovery_source,reason,risk,status,origin_kind,origin_task_id,origin_continuation_id,created_at,decided_at
+		FROM scope_expansions WHERE project_id=? ORDER BY created_at,id`, strings.TrimSpace(projectID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	proposals := []Proposal{}
+	for rows.Next() {
+		proposal, err := scanProposal(rows)
+		if err != nil {
+			return nil, err
+		}
+		proposals = append(proposals, proposal)
+	}
+	return proposals, rows.Err()
+}
+
+func (service *Service) Approve(projectID, proposalID string) (Proposal, project.Project, error) {
+	return service.decide(projectID, proposalID, StatusApproved)
+}
+
+func (service *Service) Reject(projectID, proposalID string) (Proposal, project.Project, error) {
+	return service.decide(projectID, proposalID, StatusRejected)
+}
+
+func (service *Service) decide(projectID, proposalID string, decision Status) (Proposal, project.Project, error) {
+	projectID, proposalID = strings.TrimSpace(projectID), strings.TrimSpace(proposalID)
+	tx, err := service.db.Begin()
+	if err != nil {
+		return Proposal{}, project.Project{}, err
+	}
+	defer tx.Rollback()
+	proposal, err := scanProposal(tx.QueryRow(`SELECT id,project_id,addition_json,discovery_source,reason,risk,status,origin_kind,origin_task_id,origin_continuation_id,created_at,decided_at
+		FROM scope_expansions WHERE id=? AND project_id=?`, proposalID, projectID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Proposal{}, project.Project{}, ErrNotFound
+	}
+	if err != nil {
+		return Proposal{}, project.Project{}, err
+	}
+	if proposal.Status != StatusProposed {
+		return Proposal{}, project.Project{}, ErrNotProposed
+	}
+	now := time.Now().UTC()
+	if decision == StatusApproved {
+		var scopeJSON string
+		if err := tx.QueryRow(`SELECT scope_json FROM projects WHERE id=?`, projectID).Scan(&scopeJSON); err != nil {
+			return Proposal{}, project.Project{}, err
+		}
+		var current project.Scope
+		if err := json.Unmarshal([]byte(scopeJSON), &current); err != nil {
+			return Proposal{}, project.Project{}, fmt.Errorf("decode Project Scope: %w", err)
+		}
+		merged := mergeScope(current, proposal.Addition)
+		mergedJSON, err := json.Marshal(merged)
+		if err != nil {
+			return Proposal{}, project.Project{}, err
+		}
+		if _, err := tx.Exec(`UPDATE projects SET scope_json=?,updated_at=? WHERE id=?`, string(mergedJSON), now.Format(time.RFC3339Nano), projectID); err != nil {
+			return Proposal{}, project.Project{}, err
+		}
+	}
+	result, err := tx.Exec(`UPDATE scope_expansions SET status=?,decided_at=? WHERE id=? AND status=?`, string(decision), now.Format(time.RFC3339Nano), proposal.ID, string(StatusProposed))
+	if err != nil {
+		return Proposal{}, project.Project{}, err
+	}
+	changed, _ := result.RowsAffected()
+	if changed != 1 {
+		return Proposal{}, project.Project{}, ErrNotProposed
+	}
+	if err := tx.Commit(); err != nil {
+		return Proposal{}, project.Project{}, err
+	}
+	proposal.Status, proposal.DecidedAt = decision, &now
+	updated, err := service.projects.Get(projectID)
+	return proposal, updated, err
+}
+
+func (service *Service) validateTrustedOrigin(projectID string, origin TrustedOrigin) error {
+	switch origin.Kind {
+	case TrustedOriginOperator:
+		if origin.TaskID != "" || origin.ContinuationID != "" {
+			return ErrTrustedOrigin
+		}
+		return nil
+	case TrustedOriginRuntime:
+		var foundProjectID, foundTaskID string
+		err := service.db.QueryRow(`SELECT tasks.project_id,task_continuations.task_id FROM task_continuations
+			JOIN tasks ON tasks.id=task_continuations.task_id WHERE task_continuations.id=?`, origin.ContinuationID).Scan(&foundProjectID, &foundTaskID)
+		if err != nil || foundProjectID != projectID || foundTaskID != origin.TaskID {
+			return ErrTrustedOrigin
+		}
+		return nil
+	default:
+		return ErrTrustedOrigin
+	}
+}
+
+func scanProposal(row interface{ Scan(...any) error }) (Proposal, error) {
+	var proposal Proposal
+	var additionJSON, status, originKind, createdAt string
+	var taskID, continuationID, decidedAt sql.NullString
+	if err := row.Scan(&proposal.ID, &proposal.ProjectID, &additionJSON, &proposal.DiscoverySource, &proposal.Reason, &proposal.Risk,
+		&status, &originKind, &taskID, &continuationID, &createdAt, &decidedAt); err != nil {
+		return Proposal{}, err
+	}
+	if err := json.Unmarshal([]byte(additionJSON), &proposal.Addition); err != nil {
+		return Proposal{}, err
+	}
+	proposal.Status = Status(status)
+	proposal.TrustedOrigin = TrustedOrigin{Kind: TrustedOriginKind(originKind), TaskID: taskID.String, ContinuationID: continuationID.String}
+	var err error
+	if proposal.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
+		return Proposal{}, err
+	}
+	if decidedAt.Valid {
+		parsed, err := time.Parse(time.RFC3339Nano, decidedAt.String)
+		if err != nil {
+			return Proposal{}, err
+		}
+		proposal.DecidedAt = &parsed
+	}
+	return proposal, nil
+}
+
+func normalizeScope(scope project.Scope) project.Scope {
+	scope.Domains = normalizeValues(scope.Domains)
+	scope.IPs = normalizeValues(scope.IPs)
+	scope.CIDRs = normalizeValues(scope.CIDRs)
+	scope.URLs = normalizeValues(scope.URLs)
+	scope.Ports = normalizeValues(scope.Ports)
+	scope.Excluded = normalizeValues(scope.Excluded)
+	scope.TestingLimits = normalizeValues(scope.TestingLimits)
+	scope.Capabilities = normalizeValues(scope.Capabilities)
+	scope.Notes = ""
+	return scope
+}
+
+func normalizeValues(values []string) []string {
+	result, seen := []string{}, map[string]bool{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" && !seen[value] {
+			seen[value] = true
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func scopeHasAddition(scope project.Scope) bool {
+	return len(scope.Domains)+len(scope.IPs)+len(scope.CIDRs)+len(scope.URLs)+len(scope.Ports)+len(scope.Excluded)+len(scope.TestingLimits)+len(scope.Capabilities) > 0
+}
+
+func mergeScope(current, addition project.Scope) project.Scope {
+	current.Domains = normalizeValues(append(current.Domains, addition.Domains...))
+	current.IPs = normalizeValues(append(current.IPs, addition.IPs...))
+	current.CIDRs = normalizeValues(append(current.CIDRs, addition.CIDRs...))
+	current.URLs = normalizeValues(append(current.URLs, addition.URLs...))
+	current.Ports = normalizeValues(append(current.Ports, addition.Ports...))
+	current.Excluded = normalizeValues(append(current.Excluded, addition.Excluded...))
+	current.TestingLimits = normalizeValues(append(current.TestingLimits, addition.TestingLimits...))
+	current.Capabilities = normalizeValues(append(current.Capabilities, addition.Capabilities...))
+	return current
+}
+
+func newID() string {
+	return fmt.Sprintf("scope-expansion-%d", time.Now().UTC().UnixNano())
+}

--- a/internal/scopeexpansion/scope_expansion_test.go
+++ b/internal/scopeexpansion/scope_expansion_test.go
@@ -1,0 +1,83 @@
+package scopeexpansion_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"pentest/internal/project"
+	"pentest/internal/scopeexpansion"
+	"pentest/internal/store"
+	"pentest/internal/task"
+)
+
+func TestScopeExpansionRequiresApprovalAndRetainsRuntimeTrustedOrigin(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))
+	if err != nil {
+		t.Fatalf("open Store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	projects := project.NewService(db)
+	createdProject, err := projects.CreateWithKind("Engagement", "", project.KindPentest, project.Scope{Domains: []string{"example.com"}}, project.Defaults{})
+	if err != nil {
+		t.Fatalf("create Project: %v", err)
+	}
+	tasks := task.NewService(db, projects)
+	createdTask, err := tasks.Create(task.CreateRequest{ProjectID: createdProject.ID, Type: task.TypePentest, Goal: "discover", Runner: task.RunnerSandbox})
+	if err != nil {
+		t.Fatalf("create Task: %v", err)
+	}
+	continuation, err := tasks.CreateContinuation(createdTask.ID, "profile", "fake", task.RunnerSandbox)
+	if err != nil {
+		t.Fatalf("create Continuation: %v", err)
+	}
+	service := scopeexpansion.NewService(db, projects)
+
+	proposal, err := service.Propose(scopeexpansion.ProposeRequest{
+		ProjectID:       createdProject.ID,
+		Addition:        project.Scope{Domains: []string{"api.example.com"}, Ports: []string{"8443"}},
+		DiscoverySource: "Project Fact fact:api", Reason: "New application endpoint", Risk: "Adds authenticated testing",
+		Origin: scopeexpansion.TrustedOrigin{Kind: scopeexpansion.TrustedOriginRuntime, TaskID: createdTask.ID, ContinuationID: continuation.ID},
+	})
+	if err != nil {
+		t.Fatalf("propose Scope Expansion: %v", err)
+	}
+	if proposal.Status != scopeexpansion.StatusProposed || proposal.TrustedOrigin.Kind != scopeexpansion.TrustedOriginRuntime || proposal.TrustedOrigin.ContinuationID != continuation.ID {
+		t.Fatalf("proposal = %#v", proposal)
+	}
+	before, err := projects.Get(createdProject.ID)
+	if err != nil || len(before.Scope.Domains) != 1 {
+		t.Fatalf("Scope changed before approval: %#v, %v", before.Scope, err)
+	}
+
+	approved, updatedProject, err := service.Approve(createdProject.ID, proposal.ID)
+	if err != nil {
+		t.Fatalf("approve Scope Expansion: %v", err)
+	}
+	if approved.Status != scopeexpansion.StatusApproved || len(updatedProject.Scope.Domains) != 2 || updatedProject.Scope.Domains[1] != "api.example.com" || len(updatedProject.Scope.Ports) != 1 {
+		t.Fatalf("approved proposal = %#v, Scope=%#v", approved, updatedProject.Scope)
+	}
+	if _, _, err := service.Approve(createdProject.ID, proposal.ID); !errors.Is(err, scopeexpansion.ErrNotProposed) {
+		t.Fatalf("second approval error = %v", err)
+	}
+}
+
+func TestScopeExpansionRejectsUnprovenRuntimeTrustedOrigin(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))
+	if err != nil {
+		t.Fatalf("open Store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	projects := project.NewService(db)
+	createdProject, _ := projects.CreateWithKind("Engagement", "", project.KindPentest, project.Scope{}, project.Defaults{})
+	service := scopeexpansion.NewService(db, projects)
+
+	_, err = service.Propose(scopeexpansion.ProposeRequest{
+		ProjectID: createdProject.ID, Addition: project.Scope{Domains: []string{"api.example.com"}},
+		DiscoverySource: "Project Fact", Reason: "discovered", Risk: "new host",
+		Origin: scopeexpansion.TrustedOrigin{Kind: scopeexpansion.TrustedOriginRuntime, TaskID: "foreign", ContinuationID: "foreign"},
+	})
+	if !errors.Is(err, scopeexpansion.ErrTrustedOrigin) {
+		t.Fatalf("unproven Trusted Origin error = %v", err)
+	}
+}

--- a/internal/session/blackboard_conclusion.go
+++ b/internal/session/blackboard_conclusion.go
@@ -1,9 +1,7 @@
 package session
 
 import (
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -190,18 +188,18 @@ const sessionConclusionDispatchColumns = `id,obligation_id,kind,continuation_id,
 // Blackboard Conclusion obligation for a completed assisted Work Runtime Turn.
 // Replay returns the original obligation.
 func (s *Service) RecordBlackboardConclusionCheckpoint(sessionID, continuationID, sourceRequestID, sourceSessionID, sourceTurnID string, sourceSelection RuntimeTurnSelection, watermarks SemanticDebtWatermarks) (BlackboardConclusionReceipt, bool, error) {
-	sessionID = strings.TrimSpace(sessionID)
-	continuationID = strings.TrimSpace(continuationID)
-	sourceRequestID = strings.TrimSpace(sourceRequestID)
-	sourceSessionID = strings.TrimSpace(sourceSessionID)
-	sourceTurnID = strings.TrimSpace(sourceTurnID)
-	sourceSelection.ModelProviderID = strings.TrimSpace(sourceSelection.ModelProviderID)
-	sourceSelection.Model = strings.TrimSpace(sourceSelection.Model)
-	sourceSelection.ReasoningEffort = strings.TrimSpace(sourceSelection.ReasoningEffort)
-	if sessionID == "" || continuationID == "" || sourceRequestID == "" || sourceSessionID == "" || sourceTurnID == "" ||
-		sourceSelection.ModelProviderID == "" || sourceSelection.Model == "" || !watermarks.Valid() {
+	checkpoint, valid := (owner.ConclusionCheckpointInput{
+		OwnerID: sessionID, ContinuationID: continuationID, SourceRequestID: sourceRequestID,
+		SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
+		ModelProviderID: sourceSelection.ModelProviderID, Model: sourceSelection.Model,
+		ReasoningEffort: sourceSelection.ReasoningEffort, Watermarks: watermarks,
+	}).Normalize()
+	if !valid {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
+	sessionID, continuationID, sourceRequestID = checkpoint.OwnerID, checkpoint.ContinuationID, checkpoint.SourceRequestID
+	sourceSessionID, sourceTurnID, watermarks = checkpoint.SourceSessionID, checkpoint.SourceTurnID, checkpoint.Watermarks
+	sourceSelection = RuntimeTurnSelection{ModelProviderID: checkpoint.ModelProviderID, Model: checkpoint.Model, ReasoningEffort: checkpoint.ReasoningEffort}
 	found, err := s.Get(sessionID)
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, err
@@ -240,12 +238,7 @@ func (s *Service) RecordBlackboardConclusionCheckpoint(sessionID, continuationID
 	}
 
 	now := time.Now().UTC()
-	obligationState := BlackboardConclusionReceiptPending
-	phase := "pending_detected"
-	if watermarks.SourceWork <= watermarks.SemanticPersistence {
-		obligationState = BlackboardConclusionReceiptClean
-		phase = "persistence_current"
-	}
+	obligationState, phase := owner.InitialConclusionCheckpoint(watermarks)
 	obligation := PendingBlackboardConclusion{
 		ID: newIDMust(), SessionID: sessionID, SourceRequestID: sourceRequestID, SourceRequestCorrelationExact: true,
 		SourceContinuationID: continuationID, SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
@@ -447,8 +440,7 @@ func (s *Service) HandleBlackboardConclusionFailure(dispatchRequestID string, co
 	if obligation.State != BlackboardConclusionReceiptAwaitingResult || dispatch.DeliveryState != ConclusionDispatchAwaitingResult {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
-	if code == BlackboardConclusionErrorInvalidResult && obligation.AutomaticTurnCount < BlackboardConclusionAutomaticTurnLimit &&
-		obligation.RepairCount == 0 && obligation.VersionRegenerationCount == 0 && obligation.ExplicitRetryCount == 0 {
+	if owner.ConclusionRepairAllowed(code, obligation.AutomaticTurnCount, obligation.RepairCount, obligation.VersionRegenerationCount, obligation.ExplicitRetryCount) {
 		repairNumber := obligation.RepairCount + 1
 		requestID := sessionBlackboardConclusionAttemptRequestID("repair", dispatch.ContinuationID, obligation.SourceTurnID, repairNumber, "")
 		nextEligible := now.Add(cooldown)
@@ -498,10 +490,7 @@ func (s *Service) HandleBlackboardConclusionFailure(dispatchRequestID string, co
 		}
 		return view, true, nil
 	}
-	actionCode := code
-	if code == BlackboardConclusionErrorInvalidResult && obligation.RepairCount > 0 && obligation.VersionRegenerationCount == 0 {
-		actionCode = BlackboardConclusionErrorRepairExhausted
-	}
+	actionCode := owner.ConclusionFailureActionCode(code, obligation.RepairCount, obligation.VersionRegenerationCount)
 	nextEligible := now.Add(cooldown)
 	if obligation.NextEligibleAt != nil {
 		nextEligible = obligation.NextEligibleAt.UTC()
@@ -574,7 +563,7 @@ func (s *Service) HandleBlackboardConclusionVersionConflict(dispatchRequestID st
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	nextEligible := now.Add(cooldown)
-	if obligation.VersionRegenerationCount == 0 && obligation.AutomaticTurnCount < BlackboardConclusionAutomaticTurnLimit && obligation.ExplicitRetryCount == 0 {
+	if owner.ConclusionVersionRegenerationAllowed(obligation.VersionRegenerationCount, obligation.AutomaticTurnCount, obligation.ExplicitRetryCount) {
 		requestID := sessionBlackboardConclusionAttemptRequestID("version", dispatch.ContinuationID, obligation.SourceTurnID, 1, fmt.Sprintf("%d", currentRevision))
 		nowDispatch := ConclusionDispatch{
 			ID: newIDMust(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindVersionRegeneration,
@@ -759,13 +748,7 @@ func (s *Service) markSessionConclusionRecoveryActionRequiredTx(tx *sql.Tx, obli
 	if obligation.State == BlackboardConclusionReceiptActionRequired {
 		return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
 	}
-	eligiblePending := obligation.State == BlackboardConclusionReceiptPending
-	eligibleInitial := obligation.State == BlackboardConclusionReceiptDispatchRequested
-	eligibleRepair := obligation.State == BlackboardConclusionReceiptRepairDispatchRequested
-	eligibleVersionSync := obligation.State == BlackboardConclusionReceiptVersionSyncRequested
-	eligibleVersionRegeneration := obligation.State == BlackboardConclusionReceiptVersionRegenerationDispatchRequested
-	eligibleAwaiting := obligation.State == BlackboardConclusionReceiptAwaitingResult
-	if !eligiblePending && !eligibleInitial && !eligibleRepair && !eligibleVersionSync && !eligibleVersionRegeneration && !eligibleAwaiting {
+	if !owner.ConclusionRecoveryEligible(obligation.State) {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	nextEligible := now.Add(cooldown)
@@ -827,12 +810,7 @@ func (s *Service) MarkBlackboardConclusionWorkTurnConflict(dispatchRequestID str
 	if dispatch.DeliveryState != ConclusionDispatchRequested {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
-	errorCode := BlackboardConclusionErrorRuntimeRecoveryRequired
-	reason := "work_turn_conflict"
-	if obligation.ExplicitRetryCount >= BlackboardConclusionWorkTurnConflictLimit {
-		errorCode = BlackboardConclusionErrorWorkTurnNeverSettled
-		reason = "work_turn_never_settled"
-	}
+	errorCode, reason := owner.ConclusionWorkTurnConflictOutcome(obligation.ExplicitRetryCount)
 	nextEligible := now.Add(cooldown)
 	if obligation.NextEligibleAt != nil {
 		nextEligible = obligation.NextEligibleAt.UTC()
@@ -1017,18 +995,12 @@ func retrySessionBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboard
 	if !errors.Is(err, sql.ErrNoRows) {
 		return BlackboardConclusionReceipt{}, false, fmt.Errorf("read Session Blackboard conclusion retry idempotency history: %w", err)
 	}
-	if obligation.State != BlackboardConclusionReceiptActionRequired {
+	switch owner.ConclusionRetryDecisionFor(obligation.State, obligation.ErrorCode, obligation.RecoveryReason, obligation.NextEligibleAt, now) {
+	case owner.ConclusionRetryInvalidState:
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if obligation.ErrorCode == BlackboardConclusionErrorWorkTurnNeverSettled {
+	case owner.ConclusionRetryNeverSettled:
 		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionWorkTurnNeverSettled
-	}
-	if obligation.RecoveryReason == ConclusionRecoveryAcceptanceAmbiguous {
-		// An acceptance-ambiguous provider delivery is never resent: a generic
-		// Retry could duplicate a request the provider already accepted.
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
-	}
-	if obligation.NextEligibleAt == nil || now.Before(*obligation.NextEligibleAt) {
+	case owner.ConclusionRetryAcceptanceAmbiguous, owner.ConclusionRetryCooldown:
 		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
 	}
 	dispatch, err := sessionActiveConclusionDispatchTx(tx, obligation.ID)
@@ -1175,8 +1147,7 @@ func (s *Service) MarkBlackboardConclusionValidated(dispatchRequestID string, ca
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	canonicalResult = append([]byte(nil), canonicalResult...)
-	sum := sha256.Sum256(canonicalResult)
-	hash := hex.EncodeToString(sum[:])
+	hash := owner.CanonicalConclusionSHA256(canonicalResult)
 	return s.advanceSessionObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptAwaitingResult,
 		BlackboardConclusionReceiptValidated,
 		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
@@ -1899,16 +1870,11 @@ func sessionBlackboardConclusionLookupError(err error) error {
 }
 
 func sessionBlackboardConclusionRequestLineage(continuationID, sourceTurnID string) (string, string) {
-	lineage := fmt.Sprintf("%d:%s%d:%s", len(continuationID), continuationID, len(sourceTurnID), sourceTurnID)
-	sum := sha256.Sum256([]byte(lineage))
-	digest := hex.EncodeToString(sum[:])
-	return "conclude:v1:" + digest, "assisted-apply:v1:" + digest
+	return owner.ConclusionRequestLineage(continuationID, sourceTurnID)
 }
 
 func sessionBlackboardConclusionAttemptRequestID(kind, continuationID, sourceTurnID string, number int, key string) string {
-	lineage := fmt.Sprintf("%s:%d:%s:%d:%s:%d:%s", kind, len(continuationID), continuationID, len(sourceTurnID), sourceTurnID, number, key)
-	sum := sha256.Sum256([]byte(lineage))
-	return "conclude-" + kind + ":v1:" + hex.EncodeToString(sum[:])
+	return owner.ConclusionAttemptRequestID(kind, continuationID, sourceTurnID, number, key)
 }
 
 func appendSessionBlackboardConclusionEventTx(tx *sql.Tx, receipt BlackboardConclusionReceipt, payload EventPayload, now time.Time) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -943,8 +943,49 @@ func migrations() []migration {
 		newMigration(56, "challenge_workflow", migration56SQL, migration56Up),
 		newMigration(57, "task_type_snapshot", migration57SQL, migration57Up),
 		newMigration(58, "challenge_operation_recovery_settlement", migration58SQL, migration58Up),
+		newMigration(59, "project_approval_workflows", migration59SQL, migration59Up),
 	}
 }
+
+// migration59SQL stores operator-approved Project workflows. Scope Expansion
+// retains its internal Trusted Origin, and a Reason Task proposal remains
+// separate from Blackboard state until explicit approval.
+const migration59SQL = `
+CREATE TABLE IF NOT EXISTS scope_expansions (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+	addition_json TEXT NOT NULL,
+	discovery_source TEXT NOT NULL,
+	reason TEXT NOT NULL,
+	risk TEXT NOT NULL,
+	status TEXT NOT NULL CHECK (status IN ('proposed','approved','rejected')),
+	origin_kind TEXT NOT NULL CHECK (origin_kind IN ('operator','runtime')),
+	origin_task_id TEXT REFERENCES tasks(id) ON DELETE RESTRICT,
+	origin_continuation_id TEXT REFERENCES task_continuations(id) ON DELETE RESTRICT,
+	created_at TEXT NOT NULL,
+	decided_at TEXT
+);
+CREATE INDEX IF NOT EXISTS scope_expansions_project_status_idx ON scope_expansions(project_id,status,created_at);
+CREATE TABLE IF NOT EXISTS reason_tasks (
+	task_id TEXT PRIMARY KEY REFERENCES tasks(id) ON DELETE RESTRICT,
+	project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+	created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS reason_tasks_project_created_idx ON reason_tasks(project_id,created_at);
+CREATE TABLE IF NOT EXISTS reason_task_proposals (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+	reason_task_id TEXT NOT NULL REFERENCES reason_tasks(task_id) ON DELETE RESTRICT,
+	proposal_json TEXT NOT NULL,
+	change_batch_json TEXT NOT NULL,
+	status TEXT NOT NULL CHECK (status IN ('proposed','approved','rejected')),
+	created_at TEXT NOT NULL,
+	decided_at TEXT
+);
+CREATE INDEX IF NOT EXISTS reason_task_proposals_project_status_idx ON reason_task_proposals(project_id,status,created_at);
+`
+
+func migration59Up(tx *sql.Tx) error { return execStatements(tx, migration59SQL) }
 
 // migration58SQL is the recovery-settlement shape of challenge_operations.
 // Migration 56 created the baseline without action_required or recovery_error;

--- a/internal/store/store_v2_test.go
+++ b/internal/store/store_v2_test.go
@@ -135,7 +135,7 @@ func TestOrdinaryOpenRefusesUnknownEpochWithoutTouchingSQLiteState(t *testing.T)
 			prepare: func(t *testing.T, path string) func() {
 				return holdStoreEpochUpdateInWAL(t, path, "future_v3")
 			},
-			wantMigrationCount: 58,
+			wantMigrationCount: 59,
 			wantSidecars:       true,
 		},
 	}

--- a/internal/task/blackboard_conclusion.go
+++ b/internal/task/blackboard_conclusion.go
@@ -1,9 +1,7 @@
 package task
 
 import (
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -92,18 +90,18 @@ const conclusionDispatchColumns = `id,obligation_id,kind,continuation_id,source_
 // continuation is retained only as correlation for the initial dispatch.
 // Replay returns the original obligation.
 func (s *Service) RecordBlackboardConclusionCheckpoint(taskID, continuationID, sourceRequestID, sourceSessionID, sourceTurnID string, sourceSelection TurnSelection, watermarks SemanticDebtWatermarks) (BlackboardConclusionReceipt, bool, error) {
-	taskID = strings.TrimSpace(taskID)
-	continuationID = strings.TrimSpace(continuationID)
-	sourceRequestID = strings.TrimSpace(sourceRequestID)
-	sourceSessionID = strings.TrimSpace(sourceSessionID)
-	sourceTurnID = strings.TrimSpace(sourceTurnID)
-	sourceSelection.ModelProviderID = strings.TrimSpace(sourceSelection.ModelProviderID)
-	sourceSelection.Model = strings.TrimSpace(sourceSelection.Model)
-	sourceSelection.ReasoningEffort = strings.TrimSpace(sourceSelection.ReasoningEffort)
-	if taskID == "" || continuationID == "" || sourceRequestID == "" || sourceSessionID == "" || sourceTurnID == "" ||
-		sourceSelection.ModelProviderID == "" || sourceSelection.Model == "" || !watermarks.Valid() {
+	checkpoint, valid := (owner.ConclusionCheckpointInput{
+		OwnerID: taskID, ContinuationID: continuationID, SourceRequestID: sourceRequestID,
+		SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
+		ModelProviderID: sourceSelection.ModelProviderID, Model: sourceSelection.Model,
+		ReasoningEffort: sourceSelection.ReasoningEffort, Watermarks: watermarks,
+	}).Normalize()
+	if !valid {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
+	taskID, continuationID, sourceRequestID = checkpoint.OwnerID, checkpoint.ContinuationID, checkpoint.SourceRequestID
+	sourceSessionID, sourceTurnID, watermarks = checkpoint.SourceSessionID, checkpoint.SourceTurnID, checkpoint.Watermarks
+	sourceSelection = TurnSelection{ModelProviderID: checkpoint.ModelProviderID, Model: checkpoint.Model, ReasoningEffort: checkpoint.ReasoningEffort}
 	found, err := s.Get(taskID)
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, err
@@ -117,6 +115,16 @@ func (s *Service) RecordBlackboardConclusionCheckpoint(taskID, continuationID, s
 		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion obligation: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	var continuationTaskID string
+	if err := tx.QueryRow(`SELECT task_id FROM task_continuations WHERE id=?`, continuationID).Scan(&continuationTaskID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return BlackboardConclusionReceipt{}, false, ErrNotFound
+		}
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("load Blackboard conclusion Continuation: %w", err)
+	}
+	if continuationTaskID != taskID {
+		return BlackboardConclusionReceipt{}, false, ErrNotFound
+	}
 
 	prior, err := scanPendingBlackboardConclusion(tx.QueryRow(`SELECT `+pendingBlackboardConclusionColumns+`
 		FROM pending_blackboard_conclusions WHERE task_id=? AND source_session_id=? AND source_turn_id=?`, taskID, sourceSessionID, sourceTurnID))
@@ -132,12 +140,7 @@ func (s *Service) RecordBlackboardConclusionCheckpoint(taskID, continuationID, s
 	}
 
 	now := time.Now().UTC()
-	obligationState := BlackboardConclusionReceiptPending
-	phase := "pending_detected"
-	if watermarks.SourceWork <= watermarks.SemanticPersistence {
-		obligationState = BlackboardConclusionReceiptClean
-		phase = "persistence_current"
-	}
+	obligationState, phase := owner.InitialConclusionCheckpoint(watermarks)
 	obligation := PendingBlackboardConclusion{
 		ID: newID(), TaskID: taskID, SourceRequestID: sourceRequestID, SourceRequestCorrelationExact: true,
 		SourceContinuationID: continuationID, SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
@@ -341,8 +344,7 @@ func (s *Service) HandleBlackboardConclusionFailure(dispatchRequestID string, co
 	if obligation.State != BlackboardConclusionReceiptAwaitingResult || dispatch.DeliveryState != ConclusionDispatchAwaitingResult {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
-	if code == BlackboardConclusionErrorInvalidResult && obligation.AutomaticTurnCount < BlackboardConclusionAutomaticTurnLimit &&
-		obligation.RepairCount == 0 && obligation.VersionRegenerationCount == 0 && obligation.ExplicitRetryCount == 0 {
+	if owner.ConclusionRepairAllowed(code, obligation.AutomaticTurnCount, obligation.RepairCount, obligation.VersionRegenerationCount, obligation.ExplicitRetryCount) {
 		repairNumber := obligation.RepairCount + 1
 		requestID := blackboardConclusionAttemptRequestID("repair", dispatch.ContinuationID, obligation.SourceTurnID, repairNumber, "")
 		nextEligible := now.Add(cooldown)
@@ -392,10 +394,7 @@ func (s *Service) HandleBlackboardConclusionFailure(dispatchRequestID string, co
 		}
 		return view, true, nil
 	}
-	actionCode := code
-	if code == BlackboardConclusionErrorInvalidResult && obligation.RepairCount > 0 && obligation.VersionRegenerationCount == 0 {
-		actionCode = BlackboardConclusionErrorRepairExhausted
-	}
+	actionCode := owner.ConclusionFailureActionCode(code, obligation.RepairCount, obligation.VersionRegenerationCount)
 	nextEligible := now.Add(cooldown)
 	if obligation.NextEligibleAt != nil {
 		nextEligible = obligation.NextEligibleAt.UTC()
@@ -468,7 +467,7 @@ func (s *Service) HandleBlackboardConclusionVersionConflict(dispatchRequestID st
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	nextEligible := now.Add(cooldown)
-	if obligation.VersionRegenerationCount == 0 && obligation.AutomaticTurnCount < BlackboardConclusionAutomaticTurnLimit && obligation.ExplicitRetryCount == 0 {
+	if owner.ConclusionVersionRegenerationAllowed(obligation.VersionRegenerationCount, obligation.AutomaticTurnCount, obligation.ExplicitRetryCount) {
 		requestID := blackboardConclusionAttemptRequestID("version", dispatch.ContinuationID, obligation.SourceTurnID, 1, fmt.Sprintf("%d", currentRevision))
 		nowDispatch := ConclusionDispatch{
 			ID: newID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindVersionRegeneration,
@@ -653,13 +652,7 @@ func (s *Service) markConclusionRecoveryActionRequiredTx(tx *sql.Tx, obligation 
 	if obligation.State == BlackboardConclusionReceiptActionRequired {
 		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
 	}
-	eligiblePending := obligation.State == BlackboardConclusionReceiptPending
-	eligibleInitial := obligation.State == BlackboardConclusionReceiptDispatchRequested
-	eligibleRepair := obligation.State == BlackboardConclusionReceiptRepairDispatchRequested
-	eligibleVersionSync := obligation.State == BlackboardConclusionReceiptVersionSyncRequested
-	eligibleVersionRegeneration := obligation.State == BlackboardConclusionReceiptVersionRegenerationDispatchRequested
-	eligibleAwaiting := obligation.State == BlackboardConclusionReceiptAwaitingResult
-	if !eligiblePending && !eligibleInitial && !eligibleRepair && !eligibleVersionSync && !eligibleVersionRegeneration && !eligibleAwaiting {
+	if !owner.ConclusionRecoveryEligible(obligation.State) {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	nextEligible := now.Add(cooldown)
@@ -722,12 +715,7 @@ func (s *Service) MarkBlackboardConclusionWorkTurnConflict(dispatchRequestID str
 	if !eligible {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
-	errorCode := BlackboardConclusionErrorRuntimeRecoveryRequired
-	reason := "work_turn_conflict"
-	if obligation.ExplicitRetryCount >= BlackboardConclusionWorkTurnConflictLimit {
-		errorCode = BlackboardConclusionErrorWorkTurnNeverSettled
-		reason = "work_turn_never_settled"
-	}
+	errorCode, reason := owner.ConclusionWorkTurnConflictOutcome(obligation.ExplicitRetryCount)
 	nextEligible := now.Add(cooldown)
 	if obligation.NextEligibleAt != nil {
 		nextEligible = obligation.NextEligibleAt.UTC()
@@ -913,18 +901,12 @@ func retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclus
 	if !errors.Is(err, sql.ErrNoRows) {
 		return BlackboardConclusionReceipt{}, false, fmt.Errorf("read Blackboard conclusion retry idempotency history: %w", err)
 	}
-	if obligation.State != BlackboardConclusionReceiptActionRequired {
+	switch owner.ConclusionRetryDecisionFor(obligation.State, obligation.ErrorCode, obligation.RecoveryReason, obligation.NextEligibleAt, now) {
+	case owner.ConclusionRetryInvalidState:
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if obligation.ErrorCode == BlackboardConclusionErrorWorkTurnNeverSettled {
+	case owner.ConclusionRetryNeverSettled:
 		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionWorkTurnNeverSettled
-	}
-	if obligation.RecoveryReason == ConclusionRecoveryAcceptanceAmbiguous {
-		// An acceptance-ambiguous provider delivery is never resent: a generic
-		// Retry could duplicate a request the provider already accepted.
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
-	}
-	if obligation.NextEligibleAt == nil || now.Before(*obligation.NextEligibleAt) {
+	case owner.ConclusionRetryAcceptanceAmbiguous, owner.ConclusionRetryCooldown:
 		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
 	}
 	dispatch, err := activeConclusionDispatchTx(tx, obligation.ID)
@@ -1082,8 +1064,7 @@ func (s *Service) MarkBlackboardConclusionValidated(dispatchRequestID string, ca
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	canonicalResult = append([]byte(nil), canonicalResult...)
-	sum := sha256.Sum256(canonicalResult)
-	hash := hex.EncodeToString(sum[:])
+	hash := owner.CanonicalConclusionSHA256(canonicalResult)
 	return s.advanceObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptAwaitingResult,
 		BlackboardConclusionReceiptValidated,
 		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
@@ -1816,16 +1797,11 @@ func blackboardConclusionLookupError(err error) error {
 }
 
 func blackboardConclusionRequestLineage(continuationID, sourceTurnID string) (string, string) {
-	lineage := fmt.Sprintf("%d:%s%d:%s", len(continuationID), continuationID, len(sourceTurnID), sourceTurnID)
-	sum := sha256.Sum256([]byte(lineage))
-	digest := hex.EncodeToString(sum[:])
-	return "conclude:v1:" + digest, "assisted-apply:v1:" + digest
+	return owner.ConclusionRequestLineage(continuationID, sourceTurnID)
 }
 
 func blackboardConclusionAttemptRequestID(kind, continuationID, sourceTurnID string, number int, key string) string {
-	lineage := fmt.Sprintf("%s:%d:%s:%d:%s:%d:%s", kind, len(continuationID), continuationID, len(sourceTurnID), sourceTurnID, number, key)
-	sum := sha256.Sum256([]byte(lineage))
-	return "conclude-" + kind + ":v1:" + hex.EncodeToString(sum[:])
+	return owner.ConclusionAttemptRequestID(kind, continuationID, sourceTurnID, number, key)
 }
 
 func appendBlackboardConclusionEventTx(tx *sql.Tx, receipt BlackboardConclusionReceipt, payload EventPayload, now time.Time) error {

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -366,6 +366,44 @@ func TestRecordBlackboardConclusionCheckpointPersistsPendingDebtIdempotently(t *
 	}
 }
 
+func TestRecordBlackboardConclusionCheckpointRejectsContinuationOwnedByAnotherTask(t *testing.T) {
+	db := newStore(t)
+	projects := project.NewService(db)
+	svc := task.NewService(db, projects)
+	proj, _ := projects.Create("P", "", project.Scope{}, project.Defaults{})
+	newAssistedTask := func(goal string) task.Task {
+		t.Helper()
+		created, err := svc.Create(task.CreateRequest{
+			ProjectID: proj.ID,
+			Type:      task.TypePentest, Goal: goal, Runner: task.RunnerSandbox,
+			RunControls: task.RunControls{BlackboardConclusionMode: task.BlackboardConclusionModeAssisted},
+		})
+		if err != nil {
+			t.Fatalf("create Task: %v", err)
+		}
+		return created
+	}
+	first := newAssistedTask("first")
+	second := newAssistedTask("second")
+	secondContinuation, err := svc.CreateContinuation(second.ID, "profile", "fake", task.RunnerSandbox)
+	if err != nil {
+		t.Fatalf("create second Task Continuation: %v", err)
+	}
+
+	_, inserted, err := svc.RecordBlackboardConclusionCheckpoint(
+		first.ID, secondContinuation.ID, "work-request-1", "session-1", "turn-1",
+		task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		task.SemanticDebtWatermarks{SourceWork: 2, SemanticPersistence: 1},
+	)
+	if !errors.Is(err, task.ErrNotFound) || inserted {
+		t.Fatalf("cross-Task checkpoint inserted=%v, error=%v", inserted, err)
+	}
+	latest, err := svc.LatestBlackboardConclusion(first.ID)
+	if err != nil || latest != nil {
+		t.Fatalf("first Task conclusion = %#v, error=%v", latest, err)
+	}
+}
+
 // #203 / ADR 0021: after an interrupt_then_replace native steer creates a
 // replacement Continuation, an in-flight assisted-conclusion obligation gets a
 // NEW immutable Conclusion Dispatch bound to the replacement (continuation_id +

--- a/scripts/build-release-binaries.sh
+++ b/scripts/build-release-binaries.sh
@@ -39,28 +39,49 @@ if [ -z "${version}" ]; then
   usage >&2
   exit 2
 fi
+if [[ ! "${version}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "invalid version ${version}: use letters, numbers, dot, underscore, or dash" >&2
+  exit 2
+fi
+
+for target in "${targets[@]}"; do
+  if [[ ! "${target}" =~ ^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*$ ]]; then
+    echo "invalid target ${target}: expected safe GOOS/GOARCH" >&2
+    exit 2
+  fi
+done
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
-dist_dir="${2:-dist/release}"
+dist_arg="${2:-dist/release}"
+case "${dist_arg}" in
+  /*) dist_candidate="${dist_arg}" ;;
+  *) dist_candidate="${repo_root}/${dist_arg}" ;;
+esac
+dist_dir="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${dist_candidate}")"
 case "${dist_dir}" in
-  /*) ;;
-  *) dist_dir="${repo_root}/${dist_dir}" ;;
+  "${repo_root}"|"${repo_root}/")
+    echo "dist-dir must not be the repository root" >&2
+    exit 2
+    ;;
+  "${repo_root}"/*) ;;
+  *)
+    echo "dist-dir must stay inside the repository" >&2
+    exit 2
+    ;;
 esac
 
-rm -rf "${dist_dir}"
 mkdir -p "${dist_dir}"
+staging_root="$(mktemp -d "${dist_dir}/.cyberpenda-release.XXXXXX")"
+release_output="${staging_root}/output"
+mkdir -p "${release_output}"
+cleanup() {
+  rm -rf -- "${staging_root}"
+}
+trap cleanup EXIT
 
 for target in "${targets[@]}"; do
-  case "${target}" in
-    */*) ;;
-    *)
-      echo "invalid target ${target}: expected GOOS/GOARCH" >&2
-      exit 2
-      ;;
-  esac
-
   goos="${target%/*}"
   goarch="${target#*/}"
   exe=""
@@ -71,7 +92,6 @@ for target in "${targets[@]}"; do
   fi
 
   package_name="cyberpenda_${version}_${goos}_${goarch}"
-  staging_root="$(mktemp -d)"
   package_dir="${staging_root}/${package_name}"
   mkdir -p "${package_dir}"
 
@@ -89,19 +109,23 @@ for target in "${targets[@]}"; do
   cp README.md "${package_dir}/"
 
   if [ "${archive_ext}" = "zip" ]; then
-    (cd "${staging_root}" && zip -qr "${dist_dir}/${package_name}.zip" "${package_name}")
+    (cd "${staging_root}" && zip -qr "${release_output}/${package_name}.zip" "${package_name}")
   else
-    tar -C "${staging_root}" -czf "${dist_dir}/${package_name}.tar.gz" "${package_name}"
+    tar -C "${staging_root}" -czf "${release_output}/${package_name}.tar.gz" "${package_name}"
   fi
 
-  rm -rf "${staging_root}"
+  rm -rf -- "${package_dir}"
 done
 
 (
-  cd "${dist_dir}"
+  cd "${release_output}"
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum * > SHA256SUMS
   else
     shasum -a 256 * > SHA256SUMS
   fi
 )
+
+for artifact in "${release_output}"/*; do
+  mv -f -- "${artifact}" "${dist_dir}/"
+done

--- a/scripts/ci_release_workflow_test.go
+++ b/scripts/ci_release_workflow_test.go
@@ -34,6 +34,94 @@ func TestReleaseBinaryTargetsCoverSupportedPlatforms(t *testing.T) {
 	}
 }
 
+func TestReleaseBinaryBuildRejectsOutputOutsideRepositoryWithoutDeletingIt(t *testing.T) {
+	repoRoot := repoRoot(t)
+	script := filepath.Join(repoRoot, "scripts", "build-release-binaries.sh")
+	distDir := filepath.Join(t.TempDir(), "shared-output")
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
+		t.Fatalf("create outside output: %v", err)
+	}
+	marker := filepath.Join(distDir, "keep.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write outside output marker: %v", err)
+	}
+
+	cmd := exec.Command("bash", script, "v1.2.3", distDir)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "PENTEST_RELEASE_TARGETS=linux/amd64")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("build with outside output unexpectedly succeeded:\n%s", out)
+	}
+	if !strings.Contains(string(out), "dist-dir must stay inside the repository") {
+		t.Fatalf("build error = %q, want safe output-path rejection", out)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("outside output marker was changed: %v", err)
+	}
+}
+
+func TestReleaseBinaryBuildRejectsRepositoryRoot(t *testing.T) {
+	repoRoot := repoRoot(t)
+	script := filepath.Join(repoRoot, "scripts", "build-release-binaries.sh")
+
+	cmd := exec.Command("bash", script, "v1.2.3", repoRoot)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "PENTEST_RELEASE_TARGETS=linux/amd64")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("build at repository root unexpectedly succeeded:\n%s", out)
+	}
+	if !strings.Contains(string(out), "dist-dir must not be the repository root") {
+		t.Fatalf("build error = %q, want repository-root rejection", out)
+	}
+}
+
+func TestReleaseBinaryBuildRejectsUnsafePathComponentsBeforeChangingOutput(t *testing.T) {
+	repoRoot := repoRoot(t)
+	script := filepath.Join(repoRoot, "scripts", "build-release-binaries.sh")
+	testRoot, err := os.MkdirTemp(repoRoot, ".release-script-test-")
+	if err != nil {
+		t.Fatalf("create repository test directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(testRoot) })
+	distDir := filepath.Join(testRoot, "output")
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
+		t.Fatalf("create output: %v", err)
+	}
+	marker := filepath.Join(distDir, "keep.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write output marker: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		version string
+		target  string
+		want    string
+	}{
+		{name: "version traversal", version: "v1/../../escape", target: "linux/amd64", want: "invalid version"},
+		{name: "target traversal", version: "v1.2.3", target: "linux/amd64/../../escape", want: "invalid target"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("bash", script, tt.version, distDir)
+			cmd.Dir = repoRoot
+			cmd.Env = append(os.Environ(), "PENTEST_RELEASE_TARGETS="+tt.target)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("unsafe build unexpectedly succeeded:\n%s", out)
+			}
+			if !strings.Contains(string(out), tt.want) {
+				t.Fatalf("build error = %q, want %q", out, tt.want)
+			}
+			if _, err := os.Stat(marker); err != nil {
+				t.Fatalf("output marker was changed: %v", err)
+			}
+		})
+	}
+}
+
 func TestReleaseWorkflowPublishesBinariesAndAppImageWithoutSandboxBuild(t *testing.T) {
 	repoRoot := repoRoot(t)
 	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "release.yml")

--- a/scripts/with-pentestd-live.sh
+++ b/scripts/with-pentestd-live.sh
@@ -13,7 +13,7 @@ if [[ -n "${PENTEST_LISTEN_ADDR:-}" ]]; then
 elif [[ -n "${GITHUB_ACTIONS:-}" ]]; then
   # Sandbox smoke reaches the daemon via host.docker.internal, which cannot
   # connect to a loopback-only listener on Linux CI runners.
-  mcp_port="$(python3 -c "from urllib.parse import urlparse; u=urlparse('${DAEMON_URL}'); print(u.port or 8787)")"
+  mcp_port="$(python3 -c 'import sys; from urllib.parse import urlparse; u=urlparse(sys.argv[1]); print(u.port or 8787)' "${DAEMON_URL}")"
   LISTEN_ADDR="0.0.0.0:${mcp_port}"
 else
   LISTEN_ADDR="127.0.0.1:8787"

--- a/scripts/with_pentestd_live_test.go
+++ b/scripts/with_pentestd_live_test.go
@@ -1,0 +1,45 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWithPentestdLiveDoesNotEvaluateDaemonURLAsPython(t *testing.T) {
+	repoRoot := repoRoot(t)
+	script := filepath.Join(repoRoot, "scripts", "with-pentestd-live.sh")
+	testRoot := t.TempDir()
+	marker := filepath.Join(testRoot, "injected")
+	binDir := filepath.Join(testRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create fake binary directory: %v", err)
+	}
+	fakeGo := filepath.Join(binDir, "go")
+	if err := os.WriteFile(fakeGo, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake go: %v", err)
+	}
+
+	unsafeURL := "http://127.0.0.1:8787'); __import__('pathlib').Path('" + marker + "').write_text('injected'); #"
+	cmd := exec.Command("bash", script, "true")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"GITHUB_ACTIONS=1",
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"PENTEST_DAEMON_URL="+unsafeURL,
+		"PENTEST_DAEMON_WAIT_SECONDS=0",
+		"RUNNER_TEMP="+testRoot,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("invalid daemon URL unexpectedly succeeded:\n%s", out)
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("daemon URL was evaluated as Python source; stat error = %v", statErr)
+	}
+	if strings.Contains(string(out), "injected") {
+		t.Fatalf("daemon URL payload reached command output: %s", out)
+	}
+}

--- a/web/src/App.build.test.ts
+++ b/web/src/App.build.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { build, type Rollup } from "vite";
+
+describe("application build", () => {
+  it("emits route pages as lazy chunks", async () => {
+    const result = await build({
+      root: process.cwd(),
+      logLevel: "silent",
+      build: { write: false },
+    });
+    const outputs = Array.isArray(result) ? result : [result];
+    const chunks = outputs.flatMap((output) =>
+      output.output.filter((item): item is Rollup.OutputChunk => item.type === "chunk"),
+    );
+    const lazyPageChunks = chunks.filter(
+      (chunk) => chunk.isDynamicEntry && /Page-[A-Za-z0-9_-]+\.js$/.test(chunk.fileName),
+    );
+
+    expect(lazyPageChunks.length).toBeGreaterThanOrEqual(10);
+  }, 30_000);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,29 +1,68 @@
 import { Outlet, useRouteError } from "react-router-dom";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { ShieldAlert, Menu, X } from "lucide-react";
-import { ProjectListPage } from "@/pages/ProjectListPage";
-import { ProjectDashboardPage } from "@/pages/ProjectDashboardPage";
-import { ScopeEditorPage } from "@/pages/ScopeEditorPage";
-import { RuntimeProfilesPage } from "@/pages/RuntimeProfilesPage";
-import { ModelProvidersPage } from "@/pages/ModelProvidersPage";
-import { CredentialBindingsPage } from "@/pages/CredentialBindingsPage";
-import { SkillsPage } from "@/pages/SkillsPage";
-import { TaskLaunchPage } from "@/pages/TaskLaunchPage";
-import { TaskDetailPage } from "@/pages/TaskDetailPage";
-import { ChallengeWorkflowPage } from "@/pages/ChallengeWorkflowPage";
-import { FactsPage } from "@/pages/FactsPage";
-import { BlackboardPage } from "@/pages/BlackboardPage";
-import { FindingsPage } from "@/pages/FindingsPage";
-import { EvidencePage } from "@/pages/EvidencePage";
-import { ReportPage } from "@/pages/ReportPage";
-import { SolutionPage } from "@/pages/SolutionPage";
-import { TasksPage } from "@/pages/TasksPage";
-import { SessionHomePage } from "@/pages/SessionHomePage";
-import { SessionDetailPage } from "@/pages/SessionDetailPage";
 import { Logo } from "@/components/Logo";
 import { WorkspaceSidebar } from "@/components/WorkspaceSidebar";
 import { cn } from "@/lib/utils";
+
+const ProjectListPage = lazy(() =>
+  import("@/pages/ProjectListPage").then(({ ProjectListPage }) => ({ default: ProjectListPage })),
+);
+const SessionHomePage = lazy(() =>
+  import("@/pages/SessionHomePage").then(({ SessionHomePage }) => ({ default: SessionHomePage })),
+);
+const SessionDetailPage = lazy(() =>
+  import("@/pages/SessionDetailPage").then(({ SessionDetailPage }) => ({ default: SessionDetailPage })),
+);
+const RuntimeProfilesPage = lazy(() =>
+  import("@/pages/RuntimeProfilesPage").then(({ RuntimeProfilesPage }) => ({ default: RuntimeProfilesPage })),
+);
+const ModelProvidersPage = lazy(() =>
+  import("@/pages/ModelProvidersPage").then(({ ModelProvidersPage }) => ({ default: ModelProvidersPage })),
+);
+const CredentialBindingsPage = lazy(() =>
+  import("@/pages/CredentialBindingsPage").then(({ CredentialBindingsPage }) => ({ default: CredentialBindingsPage })),
+);
+const SkillsPage = lazy(() =>
+  import("@/pages/SkillsPage").then(({ SkillsPage }) => ({ default: SkillsPage })),
+);
+const ProjectDashboardPage = lazy(() =>
+  import("@/pages/ProjectDashboardPage").then(({ ProjectDashboardPage }) => ({ default: ProjectDashboardPage })),
+);
+const ScopeEditorPage = lazy(() =>
+  import("@/pages/ScopeEditorPage").then(({ ScopeEditorPage }) => ({ default: ScopeEditorPage })),
+);
+const TasksPage = lazy(() =>
+  import("@/pages/TasksPage").then(({ TasksPage }) => ({ default: TasksPage })),
+);
+const TaskLaunchPage = lazy(() =>
+  import("@/pages/TaskLaunchPage").then(({ TaskLaunchPage }) => ({ default: TaskLaunchPage })),
+);
+const TaskDetailPage = lazy(() =>
+  import("@/pages/TaskDetailPage").then(({ TaskDetailPage }) => ({ default: TaskDetailPage })),
+);
+const ChallengeWorkflowPage = lazy(() =>
+  import("@/pages/ChallengeWorkflowPage").then(({ ChallengeWorkflowPage }) => ({ default: ChallengeWorkflowPage })),
+);
+const FactsPage = lazy(() =>
+  import("@/pages/FactsPage").then(({ FactsPage }) => ({ default: FactsPage })),
+);
+const BlackboardPage = lazy(() =>
+  import("@/pages/BlackboardPage").then(({ BlackboardPage }) => ({ default: BlackboardPage })),
+);
+const FindingsPage = lazy(() =>
+  import("@/pages/FindingsPage").then(({ FindingsPage }) => ({ default: FindingsPage })),
+);
+const EvidencePage = lazy(() =>
+  import("@/pages/EvidencePage").then(({ EvidencePage }) => ({ default: EvidencePage })),
+);
+const ReportPage = lazy(() =>
+  import("@/pages/ReportPage").then(({ ReportPage }) => ({ default: ReportPage })),
+);
+const SolutionPage = lazy(() =>
+  import("@/pages/SolutionPage").then(({ SolutionPage }) => ({ default: SolutionPage })),
+);
 
 export function ShellErrorBoundary() {
   const err = useRouteError() as Error;
@@ -173,7 +212,9 @@ export function ShellLayout() {
           tabIndex={-1}
           className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-background pt-14 md:pt-0"
         >
-          <Outlet />
+          <Suspense fallback={<div role="status" className="p-6 text-sm text-muted-foreground">Loading…</div>}>
+            <Outlet />
+          </Suspense>
         </main>
       </div>
     </>
@@ -199,7 +240,7 @@ function createAppRouter() {
         { path: "/projects/:projectId/tasks", element: <TasksPage /> },
         { path: "/projects/:projectId/tasks/new", element: <TaskLaunchPage /> },
         { path: "/projects/:projectId/tasks/:taskId", element: <TaskDetailPage /> },
-		{ path: "/projects/:projectId/tasks/:taskId/challenges", element: <ChallengeWorkflowPage /> },
+        { path: "/projects/:projectId/tasks/:taskId/challenges", element: <ChallengeWorkflowPage /> },
         // Legacy Facts bookmark → Blackboard Work filtered to ProjectFact.
         { path: "/projects/:projectId/facts", element: <FactsPage /> },
         { path: "/projects/:projectId/blackboard/*", element: <BlackboardPage /> },

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 
 describe("api client auth", () => {
   it("sends the dashboard URL token as a bearer token", async () => {
-    window.history.replaceState(null, "", "/?token=secret");
+    window.history.replaceState(null, "", "/?view=tasks&token=secret#activity");
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ projects: [] }), {
         status: 200,
@@ -29,5 +29,9 @@ describe("api client auth", () => {
         }),
       }),
     );
+    expect(window.location.pathname + window.location.search + window.location.hash).toBe(
+      "/?view=tasks#activity",
+    );
+    expect(window.sessionStorage.getItem("pentest.authToken")).toBe("secret");
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -73,6 +73,13 @@ function dashboardAuthToken(): string {
   if (token) {
     try {
       window.sessionStorage.setItem(authTokenStorageKey, token);
+      const cleanURL = new URL(window.location.href);
+      cleanURL.searchParams.delete(authTokenParam);
+      window.history.replaceState(
+        window.history.state,
+        "",
+        cleanURL.pathname + cleanURL.search + cleanURL.hash,
+      );
     } catch {
       // Session storage may be disabled; the URL token still works for this request.
     }
@@ -113,7 +120,7 @@ export function apiDelete(path: string) {
 // ---- Domain types ----
 
 export interface Scope {
-	capabilities?: string[];
+  capabilities?: string[];
   domains?: string[];
   ips?: string[];
   cidrs?: string[];
@@ -122,6 +129,33 @@ export interface Scope {
   excluded?: string[];
   testing_limits?: string[];
   notes?: string;
+}
+
+export type ApprovalStatus = "proposed" | "approved" | "rejected";
+
+export interface ScopeExpansion {
+  id: string;
+  project_id: string;
+  addition: Scope;
+  discovery_source: string;
+  reason: string;
+  risk: string;
+  status: ApprovalStatus;
+  created_at: string;
+  decided_at?: string;
+}
+
+export interface ReasonTaskProposal {
+  id: string;
+  project_id: string;
+  reason_task_id: string;
+  next_task_goals: string[];
+  exploration_objective_changes: string[];
+  readiness_judgment: string;
+  changes: unknown[];
+  status: ApprovalStatus;
+  created_at: string;
+  decided_at?: string;
 }
 
 export interface ProjectDefaults {

--- a/web/src/pages/BlackboardPage.test.tsx
+++ b/web/src/pages/BlackboardPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen, within } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   createMemoryRouter,
@@ -303,12 +303,20 @@ function trackFetch(handlers: {
   detail?: unknown;
   history?: (url: string) => unknown;
   project?: unknown;
+  reasonProposals?: unknown;
   errors?: Record<string, { status: number; body: unknown }>;
 }) {
   const requests: string[] = [];
-  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     requests.push(url);
+
+    if (url.includes("/reason-task-proposals/") && (init?.method ?? "GET") === "POST") {
+      return json({ proposal: { id: "reason-proposal-1", status: "approved" }, result: {} });
+    }
+    if (url.includes("/reason-task-proposals")) {
+      return json(handlers.reasonProposals ?? { proposals: [] });
+    }
 
     for (const [match, err] of Object.entries(handlers.errors ?? {})) {
       if (url.includes(match)) {
@@ -401,6 +409,10 @@ describe("Blackboard UI v2 workflows", () => {
     expect(within(health).getByText(/Approval-required Reason Task proposal/i)).toBeInTheDocument();
     expect(within(health).getByText(/consolidation_reason_task/i)).toBeInTheDocument();
     expect(within(health).getByText(/start_reason_task/i)).toBeInTheDocument();
+    expect(within(health).getByRole("link", { name: /Start Reason Task/i })).toHaveAttribute(
+      "href",
+      "/projects/project-1/tasks/new?purpose=reason",
+    );
 
     const status = screen.getByRole("region", { name: /Blackboard status/i });
     expect(within(status).getByText("critical")).toBeInTheDocument();
@@ -417,6 +429,37 @@ describe("Blackboard UI v2 workflows", () => {
     expect(requests.some((url) => url.includes("/api/v2/projects/project-1/blackboard/health"))).toBe(
       true,
     );
+  });
+
+  it("lets the operator approve a pending Reason Task proposal", async () => {
+    const { fetchMock } = trackFetch({
+      health: actionableHealth,
+      reasonProposals: {
+        proposals: [{
+          id: "reason-proposal-1",
+          project_id: "project-1",
+          reason_task_id: "reason-task-1",
+          next_task_goals: ["Confirm the exposed admin route"],
+          exploration_objective_changes: ["Close the broad enumeration objective"],
+          readiness_judgment: "Ready after one targeted confirmation",
+          changes: [{ op: "upsert" }],
+          status: "proposed",
+          created_at: "2026-01-03T00:00:00Z",
+        }],
+      },
+    });
+    renderBlackboard("/projects/project-1/blackboard");
+
+    const region = await screen.findByRole("region", { name: /Reason Task proposals/i });
+    expect(within(region).getByText("Confirm the exposed admin route")).toBeInTheDocument();
+    expect(within(region).getByText(/Ready after one targeted confirmation/i)).toBeInTheDocument();
+    await userEvent.click(within(region).getByRole("button", { name: /Approve/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/reason-task-proposals/reason-proposal-1/approve"),
+      expect.objectContaining({ method: "POST" }),
+    ));
+    expect(within(region).queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
   });
 
   it("keeps dangling anomaly links actionable and wraps long keys", async () => {

--- a/web/src/pages/BlackboardPage.tsx
+++ b/web/src/pages/BlackboardPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, NavLink, useParams } from "react-router-dom";
 import { Compass, History, Layers3, Library, Loader2, Radar } from "lucide-react";
-import { apiGet, type Project } from "@/lib/api";
+import { apiGet, apiPost, type Project, type ReasonTaskProposal } from "@/lib/api";
 import {
   attentionLabel,
   blackboardHref,
@@ -26,7 +26,7 @@ import {
   type SnapshotListEntry,
 } from "@/lib/blackboardv2";
 import { ProjectPageShell } from "@/components/ProjectPageShell";
-import { Badge, Card, CardDescription, CardTitle } from "@/components/ui";
+import { Badge, Button, Card, CardDescription, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 type BlackboardTab = "work" | "knowledge" | "explorer" | "record";
@@ -189,6 +189,7 @@ function BoardPanel({
       ) : (
         <HealthPanel projectId={projectId} health={health} />
       )}
+      <ReasonTaskProposalPanel projectId={projectId} />
       {focus === "work" && (
         <>
           <WorkSection projectId={projectId} entries={workEntries} />
@@ -336,7 +337,7 @@ function HealthPanel({
           aria-label="Health proposals"
         >
           {proposals.map((proposal) => (
-            <HealthProposalRow key={`${proposal.code}:${proposal.required}`} proposal={proposal} />
+            <HealthProposalRow key={`${proposal.code}:${proposal.required}`} projectId={projectId} proposal={proposal} />
           ))}
         </ul>
       )}
@@ -354,7 +355,7 @@ function HealthPanel({
   );
 }
 
-function HealthProposalRow({ proposal }: { proposal: HealthProposal }) {
+function HealthProposalRow({ projectId, proposal }: { projectId: string; proposal: HealthProposal }) {
   return (
     <li className="flex min-w-0 flex-col gap-1 p-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0 space-y-1">
@@ -372,10 +373,73 @@ function HealthProposalRow({ proposal }: { proposal: HealthProposal }) {
           Blackboard or schedule work.
         </p>
       </div>
-      <Badge variant="outline" className="border-warning/25 bg-warning/10">
-        proposal
-      </Badge>
+      <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+        <Badge variant="outline" className="border-warning/25 bg-warning/10">proposal</Badge>
+        <Link
+          to={`/projects/${projectId}/tasks/new?purpose=reason`}
+          className="text-sm font-medium text-signal underline-offset-4 hover:underline"
+        >
+          Start Reason Task
+        </Link>
+      </div>
     </li>
+  );
+}
+
+function ReasonTaskProposalPanel({ projectId }: { projectId: string }) {
+  const [proposals, setProposals] = useState<ReasonTaskProposal[]>([]);
+  const [deciding, setDeciding] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<{ proposals?: ReasonTaskProposal[] }>(`/api/projects/${projectId}/reason-task-proposals`)
+      .then((result) => {
+        if (!cancelled) setProposals((result.proposals ?? []).filter((proposal) => proposal.status === "proposed"));
+      })
+      .catch((cause: Error) => {
+        if (!cancelled) setError(cause.message);
+      });
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  async function decide(proposalId: string, decision: "approve" | "reject") {
+    setDeciding(proposalId);
+    try {
+      await apiPost(`/api/projects/${projectId}/reason-task-proposals/${proposalId}/${decision}`);
+      setProposals((current) => current.filter((proposal) => proposal.id !== proposalId));
+      setError(null);
+    } catch (cause) {
+      setError((cause as Error).message);
+    } finally {
+      setDeciding(null);
+    }
+  }
+
+  if (proposals.length === 0 && !error) return null;
+  return (
+    <section className="space-y-3 border-b border-border p-4" aria-label="Reason Task proposals">
+      <SectionHeading title="Reason Task proposals" detail={`${proposals.length} pending`} />
+      {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+      {proposals.map((proposal) => (
+        <Card key={proposal.id} className="space-y-3">
+          <div>
+            <p className="text-sm font-medium">Readiness judgment</p>
+            <p className="text-sm text-muted-foreground">{proposal.readiness_judgment}</p>
+          </div>
+          <div>
+            <p className="text-sm font-medium">Next Task Goals</p>
+            <ul className="list-disc pl-5 text-sm text-muted-foreground">
+              {proposal.next_task_goals.map((goal) => <li key={goal}>{goal}</li>)}
+            </ul>
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => decide(proposal.id, "approve")} disabled={deciding === proposal.id}>Approve</Button>
+            <Button size="sm" variant="outline" onClick={() => decide(proposal.id, "reject")} disabled={deciding === proposal.id}>Reject</Button>
+          </div>
+        </Card>
+      ))}
+    </section>
   );
 }
 

--- a/web/src/pages/KnowledgeReportingViews.test.tsx
+++ b/web/src/pages/KnowledgeReportingViews.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mockApi } from "@/test/mockApi";
 import { BlackboardPage } from "./BlackboardPage";
 import { EvidencePage } from "./EvidencePage";
@@ -50,6 +51,7 @@ describe("knowledge and reporting views", () => {
   it("renders the Scope editor with Geist hierarchy and explicit safety states", async () => {
     mockApi({
       "/api/projects/project-1": project,
+      "/api/projects/project-1/scope-expansions": { expansions: [] },
       "/api/runtime-profiles": { profiles: [] },
     });
 
@@ -70,6 +72,56 @@ describe("knowledge and reporting views", () => {
       "grid-cols-1",
       "sm:grid-cols-2",
     );
+  });
+
+  it("proposes and approves a Scope Expansion before it changes Project Scope", async () => {
+    const pending = {
+      id: "scope-expansion-1",
+      project_id: "project-1",
+      addition: { domains: ["api.acme.test"] },
+      discovery_source: "Runtime discovery",
+      reason: "A related API host responded",
+      risk: "Low",
+      status: "proposed",
+      created_at: "2026-01-03T00:00:00Z",
+    };
+    let expansions: unknown[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/scope-expansions") && method === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { addition?: { domains?: string[] } };
+        expect(body.addition?.domains).toEqual(["api.acme.test"]);
+        expansions = [pending];
+        return new Response(JSON.stringify(pending), { status: 201, headers: { "Content-Type": "application/json" } });
+      }
+      if (url.endsWith("/scope-expansions") && method === "GET") {
+        return new Response(JSON.stringify({ expansions }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (url.includes("/scope-expansions/scope-expansion-1/approve") && method === "POST") {
+        expansions = [{ ...pending, status: "approved" }];
+        return new Response(JSON.stringify({ expansion: expansions[0], project: { ...project, scope: { ...project.scope, domains: ["acme.test", "api.acme.test"] } } }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (url.includes("/api/runtime-profiles")) {
+        return new Response(JSON.stringify({ profiles: [] }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify(project), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderRoute("/projects/project-1/scope", <ScopeEditorPage />, "/projects/:projectId/scope");
+
+    await userEvent.selectOptions(await screen.findByLabelText("Expansion field"), "domains");
+    await userEvent.type(screen.getByLabelText("Proposed addition"), "api.acme.test");
+    await userEvent.type(screen.getByLabelText("Discovery source"), "Runtime discovery");
+    await userEvent.type(screen.getByLabelText("Expansion reason"), "A related API host responded");
+    await userEvent.type(screen.getByLabelText("Expansion risk"), "Low");
+    await userEvent.click(screen.getByRole("button", { name: /Propose Scope Expansion/i }));
+
+    const queue = await screen.findByRole("region", { name: /Scope Expansion proposals/i });
+    expect(within(queue).getByText(/domains: api\.acme\.test/i)).toBeInTheDocument();
+    expect((screen.getByLabelText("Domains") as HTMLTextAreaElement).value).not.toContain("api.acme.test");
+    await userEvent.click(within(queue).getByRole("button", { name: /Approve/i }));
+    await waitFor(() => expect((screen.getByLabelText("Domains") as HTMLTextAreaElement).value).toContain("api.acme.test"));
   });
 
   it("redirects legacy Facts bookmarks to Blackboard Knowledge", async () => {

--- a/web/src/pages/ScopeEditorPage.tsx
+++ b/web/src/pages/ScopeEditorPage.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { AlertTriangle, Save } from "lucide-react";
-import { apiGet, apiPatch, type Project, type RuntimeProfile, type Scope } from "@/lib/api";
+import { AlertTriangle, Plus, Save } from "lucide-react";
+import { apiGet, apiPatch, apiPost, type Project, type RuntimeProfile, type Scope, type ScopeExpansion } from "@/lib/api";
 import { isManualRuntimeProfile } from "@/pages/runtimeProfileKind";
 import { ProjectPageShell } from "@/components/ProjectPageShell";
-import { Button, Card, CardTitle, CardHeader, Label, Textarea, Badge, Select } from "@/components/ui";
+import { Button, Card, CardTitle, CardHeader, Input, Label, Textarea, Badge, Select } from "@/components/ui";
 import { ErrorState, LoadingState } from "@/components/shared";
 
 // Each list field is edited as newline-separated text.
 type ScopeDraft = {
-	capabilities: string;
+  capabilities: string;
   domains: string;
   ips: string;
   cidrs: string;
@@ -42,7 +42,7 @@ function fromDraft(d: ScopeDraft): Scope {
       .map((x) => x.trim())
       .filter(Boolean);
   return {
-	capabilities: split(d.capabilities),
+    capabilities: split(d.capabilities),
     domains: split(d.domains),
     ips: split(d.ips),
     cidrs: split(d.cidrs),
@@ -64,20 +64,30 @@ export function ScopeEditorPage() {
   const [defaultRunner, setDefaultRunner] = useState("sandbox");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [expansions, setExpansions] = useState<ScopeExpansion[]>([]);
+  const [expansionField, setExpansionField] = useState<Exclude<keyof Scope, "notes">>("domains");
+  const [expansionValue, setExpansionValue] = useState("");
+  const [discoverySource, setDiscoverySource] = useState("");
+  const [expansionReason, setExpansionReason] = useState("");
+  const [expansionRisk, setExpansionRisk] = useState("");
+  const [proposing, setProposing] = useState(false);
+  const [deciding, setDeciding] = useState<string | null>(null);
 
   useEffect(() => {
     if (!projectId) return;
     (async () => {
       try {
-        const [p, profileData] = await Promise.all([
+        const [p, profileData, expansionData] = await Promise.all([
           apiGet<Project>(`/api/projects/${projectId}`),
           apiGet<{ profiles: RuntimeProfile[] }>("/api/runtime-profiles"),
+          apiGet<{ expansions?: ScopeExpansion[] }>(`/api/projects/${projectId}/scope-expansions`),
         ]);
         setProject(p);
         setDraft(toDraft(p.scope));
         setProfiles(profileData.profiles ?? []);
         setDefaultProfile(p.defaults.runtime_profile ?? "");
         setDefaultRunner(p.defaults.runner || "sandbox");
+        setExpansions(expansionData.expansions ?? []);
         setError(null);
       } catch (e) {
         setError((e as Error).message);
@@ -102,6 +112,47 @@ export function ScopeEditorPage() {
       setError((e as Error).message);
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function proposeExpansion() {
+    if (!projectId || !expansionValue.trim() || !discoverySource.trim() || !expansionReason.trim() || !expansionRisk.trim()) return;
+    setProposing(true);
+    try {
+      const proposal = await apiPost<ScopeExpansion>(`/api/projects/${projectId}/scope-expansions`, {
+        addition: { [expansionField]: [expansionValue.trim()] },
+        discovery_source: discoverySource.trim(),
+        reason: expansionReason.trim(),
+        risk: expansionRisk.trim(),
+      });
+      setExpansions((current) => [...current, proposal]);
+      setExpansionValue("");
+      setDiscoverySource("");
+      setExpansionReason("");
+      setExpansionRisk("");
+      setError(null);
+    } catch (cause) {
+      setError((cause as Error).message);
+    } finally {
+      setProposing(false);
+    }
+  }
+
+  async function decideExpansion(expansionId: string, decision: "approve" | "reject") {
+    if (!projectId) return;
+    setDeciding(expansionId);
+    try {
+      const result = await apiPost<{ expansion: ScopeExpansion; project: Project }>(
+        `/api/projects/${projectId}/scope-expansions/${expansionId}/${decision}`,
+      );
+      setExpansions((current) => current.map((item) => item.id === expansionId ? result.expansion : item));
+      setProject(result.project);
+      setDraft(toDraft(result.project.scope));
+      setError(null);
+    } catch (cause) {
+      setError((cause as Error).message);
+    } finally {
+      setDeciding(null);
     }
   }
 
@@ -185,8 +236,74 @@ export function ScopeEditorPage() {
         </div>
       </Card>
 
+      <Card as="section" aria-label="Scope Expansion proposals">
+        <CardHeader>
+          <CardTitle>Scope Expansion proposals</CardTitle>
+        </CardHeader>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Propose a discovered addition. It does not become authorized Scope until an operator approves it.
+        </p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <Label htmlFor="expansion-field">Expansion field</Label>
+            <Select id="expansion-field" value={expansionField} onChange={(event) => setExpansionField(event.target.value as Exclude<keyof Scope, "notes">)}>
+              <option value="capabilities">Authorized capabilities</option>
+              <option value="domains">Domains</option>
+              <option value="ips">IP addresses</option>
+              <option value="cidrs">CIDRs</option>
+              <option value="urls">URLs</option>
+              <option value="ports">Ports</option>
+              <option value="excluded">Exclusions</option>
+              <option value="testing_limits">Testing limits</option>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="expansion-value">Proposed addition</Label>
+            <Input id="expansion-value" value={expansionValue} onChange={(event) => setExpansionValue(event.target.value)} autoComplete="off" />
+          </div>
+          <div>
+            <Label htmlFor="expansion-source">Discovery source</Label>
+            <Input id="expansion-source" value={discoverySource} onChange={(event) => setDiscoverySource(event.target.value)} autoComplete="off" />
+          </div>
+          <div>
+            <Label htmlFor="expansion-risk">Expansion risk</Label>
+            <Input id="expansion-risk" value={expansionRisk} onChange={(event) => setExpansionRisk(event.target.value)} autoComplete="off" />
+          </div>
+          <div className="sm:col-span-2">
+            <Label htmlFor="expansion-reason">Expansion reason</Label>
+            <Textarea id="expansion-reason" value={expansionReason} onChange={(event) => setExpansionReason(event.target.value)} autoComplete="off" />
+          </div>
+        </div>
+        <div className="mt-3 flex justify-end">
+          <Button onClick={proposeExpansion} disabled={proposing || !expansionValue.trim() || !discoverySource.trim() || !expansionReason.trim() || !expansionRisk.trim()}>
+            <Plus className="mr-1 h-4 w-4" /> {proposing ? "Proposing…" : "Propose Scope Expansion"}
+          </Button>
+        </div>
+        {expansions.length > 0 && (
+          <ul className="mt-4 divide-y divide-border border-y border-border">
+            {expansions.map((expansion) => (
+              <li key={expansion.id} className="space-y-2 py-3">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium">{scopeAdditionLabel(expansion.addition)}</p>
+                    <p className="text-xs text-muted-foreground">{expansion.discovery_source} · {expansion.reason} · Risk: {expansion.risk}</p>
+                  </div>
+                  <Badge variant="outline">{expansion.status}</Badge>
+                </div>
+                {expansion.status === "proposed" && (
+                  <div className="flex gap-2">
+                    <Button size="sm" onClick={() => decideExpansion(expansion.id, "approve")} disabled={deciding === expansion.id}>Approve</Button>
+                    <Button size="sm" variant="outline" onClick={() => decideExpansion(expansion.id, "reject")} disabled={deciding === expansion.id}>Reject</Button>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-		{field("capabilities", "Authorized capabilities", "challenge_platform\nnetwork_access")}
+        {field("capabilities", "Authorized capabilities", "challenge_platform\nnetwork_access")}
         {field("domains", "Domains", "example.com\napi.example.com")}
         {field("ips", "IP addresses", "203.0.113.5")}
         {field("cidrs", "CIDRs", "203.0.113.0/24")}
@@ -227,4 +344,11 @@ export function ScopeEditorPage() {
       </section>
     </ProjectPageShell>
   );
+}
+
+function scopeAdditionLabel(addition: Scope): string {
+  const values = Object.entries(addition)
+    .filter(([, value]) => Array.isArray(value))
+    .flatMap(([field, value]) => (value as string[]).map((item) => `${field}: ${item}`));
+  return values.join(", ");
 }

--- a/web/src/pages/TaskLaunchPage.test.tsx
+++ b/web/src/pages/TaskLaunchPage.test.tsx
@@ -63,10 +63,10 @@ const autoResolvedProfile = {
   updated_at: "",
 };
 
-function renderPage() {
+function renderPage(path = "/projects/project-1/tasks/new") {
   return render(
     <StrictMode>
-      <MemoryRouter initialEntries={["/projects/project-1/tasks/new"]}>
+      <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/projects/:projectId/tasks/new" element={<TaskLaunchPage />} />
           <Route path="/projects/:projectId/tasks/:taskId" element={<div>Task detail</div>} />
@@ -81,6 +81,55 @@ async function selectPentestTaskType() {
 }
 
 describe("TaskLaunchPage", () => {
+  it("launches a Reason Task with the server-owned planning goal", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/runtime-plugins")) {
+        return Promise.resolve(new Response(JSON.stringify({ plugins: [codexPlugin] }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url.includes("/api/model-providers")) {
+        return Promise.resolve(new Response(JSON.stringify({ providers: [mimoProvider] }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url.includes("/api/runtime-profiles")) {
+        return Promise.resolve(new Response(JSON.stringify({ profiles: [codexPreset] }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url.includes("/api/skills?")) {
+        return Promise.resolve(new Response(JSON.stringify({ skills: [] }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url.includes("/api/projects/project-1/preflight") && method === "POST") {
+        return Promise.resolve(new Response(JSON.stringify({ pass: true, checks: [] }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url.includes("/api/projects/project-1/reason-tasks") && method === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { goal?: string };
+        expect(body.goal).toMatch(/^Read the complete Runtime Blackboard Snapshot/);
+        expect(body.goal).toMatch(/Do not mutate Blackboard records directly\.$/);
+        return Promise.resolve(new Response(JSON.stringify({ id: "reason-task-1" }), { status: 201, headers: { "Content-Type": "application/json" } }));
+      }
+      if (url.includes("/api/projects/project-1")) {
+        return Promise.resolve(new Response(JSON.stringify({
+          id: "project-1", name: "Acme", description: "", kind: "pentest", scope: {},
+          defaults: { runner: "sandbox", runtime_profile: "codex-preset" }, created_at: "", updated_at: "",
+        }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPage("/projects/project-1/tasks/new?purpose=reason");
+
+    expect(await screen.findByRole("heading", { name: /Launch Reason Task/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Task type")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Reason Task goal")).toHaveAttribute("readonly");
+    await userEvent.click(screen.getByRole("button", { name: /Launch Reason Task/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/projects/project-1/reason-tasks"),
+      expect.objectContaining({ method: "POST" }),
+    ));
+    expect(await screen.findByText("Task detail")).toBeInTheDocument();
+  });
+
   it("launches with an explicit assisted Blackboard conclusion mode", async () => {
     const assistedPlugin = {
       ...codexPlugin,

--- a/web/src/pages/TaskLaunchPage.tsx
+++ b/web/src/pages/TaskLaunchPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Rocket } from "lucide-react";
 import { AttachmentPicker } from "@/components/AttachmentPicker";
 import { RuntimeLaunchControls, useRuntimeLaunchControls } from "@/components/RuntimeLaunchControls";
@@ -7,9 +7,13 @@ import { ProjectPageShell } from "@/components/ProjectPageShell";
 import { Button, Card, CardHeader, CardTitle, Input, Label, Select, Textarea } from "@/components/ui";
 import { apiPost, apiPostForm } from "@/lib/api";
 
+const REASON_TASK_GOAL = "Read the complete Runtime Blackboard Snapshot and prepare an approval-required proposal for next Task Goals, Exploration Objective changes, and a readiness judgment. Do not mutate Blackboard records directly.";
+
 export function TaskLaunchPage() {
   const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const reasonTask = searchParams.get("purpose") === "reason";
   const launchControls = useRuntimeLaunchControls({ projectId });
   const [taskType, setTaskType] = useState("");
   const [goal, setGoal] = useState("");
@@ -23,6 +27,7 @@ export function TaskLaunchPage() {
     maxRatingDrawdown: "0",
     maxNoProgressSeconds: "0",
   });
+  const effectiveGoal = reasonTask ? REASON_TASK_GOAL : goal;
 
   async function launchTask() {
     if (!projectId) return;
@@ -37,8 +42,8 @@ export function TaskLaunchPage() {
       }
       const launch = launchControls.launchPayload(profileId);
       const payload = {
-        type: taskType,
-        goal,
+        type: reasonTask ? projectKind : taskType,
+        goal: effectiveGoal,
         ...launch,
         run_controls: {
           ...launch.run_controls,
@@ -52,14 +57,15 @@ export function TaskLaunchPage() {
           },
         },
       };
+      const taskPath = `/api/projects/${projectId}/${reasonTask ? "reason-tasks" : "tasks"}`;
       let created: { id: string };
       if (attachments.length > 0) {
         const body = new FormData();
         body.append("payload", JSON.stringify(payload));
         for (const file of attachments) body.append("attachments", file);
-        created = await apiPostForm<{ id: string }>(`/api/projects/${projectId}/tasks`, body);
+        created = await apiPostForm<{ id: string }>(taskPath, body);
       } else {
-        created = await apiPost<{ id: string }>(`/api/projects/${projectId}/tasks`, payload);
+        created = await apiPost<{ id: string }>(taskPath, payload);
       }
       navigate(`/projects/${projectId}/tasks/${created.id}`);
     } catch (cause) {
@@ -71,42 +77,48 @@ export function TaskLaunchPage() {
 
   const hostBlocked = launchControls.form.runner === "host" && !launchControls.hostActivated;
   const projectKind = launchControls.project?.kind === "ctf_challenge" ? "ctf_challenge" : "pentest";
-  const taskTypeMatchesProject = taskType !== "" && taskType === projectKind;
+  const taskTypeMatchesProject = reasonTask || (taskType !== "" && taskType === projectKind);
 
   return (
     <ProjectPageShell
       title={
         <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
-          <Rocket className="h-5 w-5 text-signal" /> Launch task
+          <Rocket className="h-5 w-5 text-signal" /> {reasonTask ? "Launch Reason Task" : "Launch task"}
         </h1>
       }
-      description="Define a Task goal, choose a Runtime, and launch a Task-scoped persistent Runtime."
+      description={reasonTask
+        ? "Launch an operator-triggered planning Task. Its Blackboard changes require later approval."
+        : "Define a Task goal, choose a Runtime, and launch a Task-scoped persistent Runtime."}
       bodyClassName="w-full max-w-3xl space-y-4"
     >
+      {!reasonTask && (
+        <div>
+          <Label htmlFor="task-type">Task type</Label>
+          <Select id="task-type" name="task_type" value={taskType} onChange={(event) => setTaskType(event.target.value)}>
+            <option value="" disabled>Select task type…</option>
+            <option value="pentest">Pentest</option>
+            <option value="ctf_challenge">CTF Challenge</option>
+          </Select>
+          <p className="mt-1 text-xs text-muted-foreground">The selected type becomes an immutable Task Type Snapshot.</p>
+          {taskType !== "" && !taskTypeMatchesProject && (
+            <p role="alert" className="mt-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
+              Task Type must match this Project&apos;s kind. <Link className="underline underline-offset-2" to={`/projects/${projectId}`}>Convert the Project first.</Link>
+            </p>
+          )}
+        </div>
+      )}
       <div>
-        <Label htmlFor="task-type">Task type</Label>
-        <Select id="task-type" name="task_type" value={taskType} onChange={(event) => setTaskType(event.target.value)}>
-          <option value="" disabled>Select task type…</option>
-          <option value="pentest">Pentest</option>
-          <option value="ctf_challenge">CTF Challenge</option>
-        </Select>
-        <p className="mt-1 text-xs text-muted-foreground">The selected type becomes an immutable Task Type Snapshot.</p>
-        {taskType !== "" && !taskTypeMatchesProject && (
-          <p role="alert" className="mt-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
-            Task Type must match this Project&apos;s kind. <Link className="underline underline-offset-2" to={`/projects/${projectId}`}>Convert the Project first.</Link>
-          </p>
-        )}
-      </div>
-      <div>
-        <Label htmlFor="goal">Task goal</Label>
+        <Label htmlFor="goal">{reasonTask ? "Reason Task goal" : "Task goal"}</Label>
         <Textarea
           id="goal"
           name="task_goal"
-          value={goal}
+          value={effectiveGoal}
           onChange={(event) => setGoal(event.target.value)}
           placeholder="Enumerate example.com and assess exposure…"
           autoComplete="off"
+          readOnly={reasonTask}
         />
+        {reasonTask && <p className="mt-1 text-xs text-muted-foreground">The daemon owns this planning goal. The Task can only submit an approval-required proposal.</p>}
       </div>
       <AttachmentPicker
         id="attachments"
@@ -116,7 +128,7 @@ export function TaskLaunchPage() {
         ownerLabel="task"
       />
 
-      <RuntimeLaunchControls controller={launchControls} ownerLabel="task" initialInput={goal} />
+      <RuntimeLaunchControls controller={launchControls} ownerLabel="task" initialInput={effectiveGoal} />
 
       <Card as="section" className="border-border/70 bg-muted/10">
         <CardHeader>
@@ -134,8 +146,8 @@ export function TaskLaunchPage() {
       </Card>
 
       <div className="flex justify-end">
-        <Button onClick={launchTask} disabled={!taskTypeMatchesProject || !launchControls.launchReady(goal) || launching || hostBlocked}>
-          <Rocket className="h-4 w-4" /> {launching ? "Launching…" : "Launch"}
+        <Button onClick={launchTask} disabled={!taskTypeMatchesProject || !launchControls.launchReady(effectiveGoal) || launching || hostBlocked}>
+          <Rocket className="h-4 w-4" /> {launching ? "Launching…" : reasonTask ? "Launch Reason Task" : "Launch"}
         </Button>
       </div>
     </ProjectPageShell>


### PR DESCRIPTION
## Summary

- harden release and smoke scripts against destructive paths, traversal, and command injection
- remove URL bearer tokens after bootstrap, classify Podman CLI variants correctly, and split route pages into lazy chunks
- enforce Runtime Continuation ownership and move shared assisted-conclusion rules into the owner kernel
- bound Model Catalog Refresh by request cancellation, timeout, and response size
- enforce Task Policy before Claim, Abandon, and Finalize operations
- allow Project Kind Conversion after interrupted Tasks
- add Scope Expansion proposal, internal Trusted Origin, approval, API, and operator UI
- add operator-triggered Reason Task launch and approval-required Blackboard proposals

## Validation

- go test ./cmd/... ./internal/... ./scripts
- go vet ./cmd/... ./internal/... ./scripts
- npm test -- --run (506 tests)
- npm run lint
- npm run build
- bash -n scripts/build-release-binaries.sh scripts/with-pentestd-live.sh
- git diff --check