### PR TITLE
fix: launch Hermes Sessions and project a readable Transcript

### DIFF
--- a/internal/daemon/production_provider_session_factory.go
+++ b/internal/daemon/production_provider_session_factory.go
@@ -892,9 +892,10 @@ func (f *ProductionProviderSessionFactory) finishHermesBinding(
 	closeBridge func(context.Context),
 	processIdentity string,
 ) (ProviderSessionBinding, error) {
+	// Hermes ACP InitializeRequest requires integer protocolVersion.
 	if _, err := bridge.Send(ctx, runtime.SandboxBridgeRequest{
 		ID: "setup:initialize", Method: "initialize",
-		Params: json.RawMessage(`{"clientInfo":{"name":"cyberpenda","version":"1"}}`),
+		Params: json.RawMessage(`{"protocolVersion":1,"clientInfo":{"name":"cyberpenda","version":"1"}}`),
 	}); err != nil {
 		closeBridge(ctx)
 		return ProviderSessionBinding{}, err
@@ -902,14 +903,14 @@ func (f *ProductionProviderSessionFactory) finishHermesBinding(
 
 	sessionID := strings.TrimSpace(request.Continuation.NativeSessionID)
 	method := "session/new"
-	params, err := json.Marshal(map[string]any{"cwd": workdir})
+	params, err := json.Marshal(map[string]any{"cwd": workdir, "mcpServers": []any{}})
 	if err != nil {
 		closeBridge(ctx)
 		return ProviderSessionBinding{}, err
 	}
 	if sessionID != "" {
 		method = "session/load"
-		params, err = json.Marshal(map[string]any{"sessionId": sessionID, "cwd": workdir})
+		params, err = json.Marshal(map[string]any{"sessionId": sessionID, "cwd": workdir, "mcpServers": []any{}})
 		if err != nil {
 			closeBridge(ctx)
 			return ProviderSessionBinding{}, err

--- a/internal/daemon/production_provider_session_factory_test.go
+++ b/internal/daemon/production_provider_session_factory_test.go
@@ -650,6 +650,125 @@ func TestProductionProviderSessionFactoryOpensHostHermesACP(t *testing.T) {
 	}
 }
 
+func TestProductionProviderSessionFactorySendsHermesACPInitializeProtocolVersion(t *testing.T) {
+	starter := newProductionFactoryHostStarter()
+	factory := NewProductionProviderSessionFactory(ProductionProviderSessionFactoryConfig{HostStarter: starter})
+	legacy := runtime.NewCommandAdapter(runtime.CommandAdapterConfig{
+		Name: "hermes", Program: "/opt/hermes",
+		Args:    []string{"--yolo", "acp"},
+		Workdir: "/tmp/task-workdir",
+		Env:     map[string]string{"HERMES_HOME": "/tmp/hermes-home", "HERMES_YOLO_MODE": "1"},
+	})
+	type captured struct {
+		Method string
+		Params map[string]any
+	}
+	seen := make(chan captured, 2)
+	go func() {
+		scanner := bufio.NewScanner(starter.inputR)
+		for scanner.Scan() {
+			var request runtime.SandboxBridgeRequest
+			_ = json.Unmarshal(scanner.Bytes(), &request)
+			params := map[string]any{}
+			_ = json.Unmarshal(request.Params, &params)
+			select {
+			case seen <- captured{Method: request.Method, Params: params}:
+			default:
+			}
+			result := `{"ok":true}`
+			switch request.Method {
+			case "initialize":
+				result = `{"protocolVersion":1}`
+			case "session/new":
+				result = `{"sessionId":"hermes-acp-1"}`
+			}
+			_, _ = io.WriteString(starter.outputW, `{"jsonrpc":"2.0","id":"`+request.ID+`","result":`+result+"}\n")
+		}
+	}()
+	if _, err := factory.Open(context.Background(), ProviderSessionLaunchRequest{
+		Owner: owner.NewTaskContract("host-hermes-init", "project-test", ""), Continuation: owner.Continuation{ID: "host-hermes-init-c1", OwnerID: "host-hermes-init"},
+		Provider: runtimeprofile.ProviderHermes, Runner: task.RunnerHost, LegacyAdapter: legacy,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-seen:
+		if got.Method != "initialize" {
+			t.Fatalf("first method = %q", got.Method)
+		}
+		if got.Params["protocolVersion"] != float64(1) {
+			t.Fatalf("initialize params = %#v", got.Params)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initialize")
+	}
+}
+
+func TestProductionProviderSessionFactorySendsHermesACPSessionNewMCPServers(t *testing.T) {
+	starter := newProductionFactoryHostStarter()
+	factory := NewProductionProviderSessionFactory(ProductionProviderSessionFactoryConfig{HostStarter: starter})
+	legacy := runtime.NewCommandAdapter(runtime.CommandAdapterConfig{
+		Name: "hermes", Program: "/opt/hermes",
+		Args:    []string{"--yolo", "acp"},
+		Workdir: "/tmp/task-workdir",
+		Env:     map[string]string{"HERMES_HOME": "/tmp/hermes-home", "HERMES_YOLO_MODE": "1"},
+	})
+	type captured struct {
+		Method string
+		Params map[string]any
+	}
+	seen := make(chan captured, 2)
+	go func() {
+		scanner := bufio.NewScanner(starter.inputR)
+		for scanner.Scan() {
+			var request runtime.SandboxBridgeRequest
+			_ = json.Unmarshal(scanner.Bytes(), &request)
+			params := map[string]any{}
+			_ = json.Unmarshal(request.Params, &params)
+			select {
+			case seen <- captured{Method: request.Method, Params: params}:
+			default:
+			}
+			result := `{"ok":true}`
+			switch request.Method {
+			case "initialize":
+				result = `{"protocolVersion":1}`
+			case "session/new":
+				result = `{"sessionId":"hermes-acp-1"}`
+			}
+			_, _ = io.WriteString(starter.outputW, `{"jsonrpc":"2.0","id":"`+request.ID+`","result":`+result+"}\n")
+		}
+	}()
+	if _, err := factory.Open(context.Background(), ProviderSessionLaunchRequest{
+		Owner: owner.NewTaskContract("host-hermes-session", "project-test", ""), Continuation: owner.Continuation{ID: "host-hermes-session-c1", OwnerID: "host-hermes-session"},
+		Provider: runtimeprofile.ProviderHermes, Runner: task.RunnerHost, LegacyAdapter: legacy,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var sessionNew captured
+	deadline := time.After(time.Second)
+	for sessionNew.Method != "session/new" {
+		select {
+		case got := <-seen:
+			if got.Method == "session/new" {
+				sessionNew = got
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for session/new")
+		}
+	}
+	if sessionNew.Params["cwd"] != "/tmp/task-workdir" {
+		t.Fatalf("session/new cwd = %#v", sessionNew.Params["cwd"])
+	}
+	servers, ok := sessionNew.Params["mcpServers"].([]any)
+	if !ok {
+		t.Fatalf("session/new params = %#v", sessionNew.Params)
+	}
+	if len(servers) != 0 {
+		t.Fatalf("session/new mcpServers = %#v", servers)
+	}
+}
+
 func TestProductionProviderSessionFactoryOpensHostClaudeSDKBridge(t *testing.T) {
 	starter := newProductionFactoryHostStarter()
 	factory := NewProductionProviderSessionFactory(ProductionProviderSessionFactoryConfig{
@@ -1284,7 +1403,6 @@ func TestHostCodexReservedConfigOverridesStayRejectedByValidateCustomArgs(t *tes
 		t.Fatalf("ValidateCustomArgs must allow non-conflicting -c foo=bar: %v", err)
 	}
 }
-
 
 // TestProductionProviderSessionFactoryUsesLegacyAdapterContainerCLI proves the
 // sandbox bridge invokes the launch-selected container CLI (podman) rather than

--- a/internal/daemon/session_runtime_handlers.go
+++ b/internal/daemon/session_runtime_handlers.go
@@ -117,6 +117,27 @@ func (server *Server) resolveSessionRuntimeProfile(input sessionRuntimeInput, pr
 		if provider := input.provider(); provider != "" && provider != profile.Provider {
 			return runtimeprofile.Profile{}, fmt.Errorf("runtime profile provider does not match requested provider")
 		}
+		wantProvider := strings.TrimSpace(input.ModelProviderID)
+		if wantProvider != "" && wantProvider != strings.TrimSpace(profile.Fields.ModelProviderID) {
+			// A later Launch Selection may change Model Provider. Reusing the
+			// previous profile then fails preflight when the new model is not
+			// in that profile's catalog.
+			provider := input.provider()
+			if provider == "" {
+				provider = profile.Provider
+			}
+			providerName := wantProvider
+			if found, getErr := server.modelProviders.Get(wantProvider); getErr == nil {
+				providerName = found.Name
+			}
+			resolution, resolveErr := server.profiles.ResolveLaunchProfile(runtimeprofile.LaunchSelection{
+				Provider: provider, ModelProviderID: wantProvider, ModelOverride: input.selectedModel(),
+			}, providerName)
+			if resolveErr != nil {
+				return runtimeprofile.Profile{}, resolveErr
+			}
+			return resolution.Profile, nil
+		}
 		return profile, nil
 	}
 

--- a/internal/daemon/session_runtime_handlers_test.go
+++ b/internal/daemon/session_runtime_handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"pentest/internal/modelprovider"
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeplugin"
 	"pentest/internal/runtimeprofile"
@@ -626,6 +627,68 @@ func TestSessionRestartCarriesNativeProviderIdentityIntoTheNewContinuation(t *te
 	}
 	if requests[0].Continuation.NativeSessionID != previous.NativeSessionID || requests[0].Continuation.NativeSessionPath != previous.NativeSessionPath {
 		t.Fatalf("restart lost native identity: %#v", requests[0].Continuation)
+	}
+}
+
+func TestResolveSessionRuntimeProfileHonorsNewModelProviderAfterPreviousContinuation(t *testing.T) {
+	server, err := NewServer(Config{
+		Version: "test", DBPath: filepath.Join(t.TempDir(), "pentest.db"), RuntimeRoot: t.TempDir(), DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	glm, err := server.modelProviders.Create(modelprovider.CreateRequest{
+		Name: "GLM", BaseURL: "https://glm.example.test/v1",
+		Protocols: []modelprovider.Protocol{modelprovider.ProtocolOpenAIChatCompletions},
+		Catalog:   modelprovider.Catalog{Manual: []string{"glm-5.2"}, DefaultModel: "glm-5.2"},
+	})
+	if err != nil {
+		t.Fatalf("create glm provider: %v", err)
+	}
+	hub, err := server.modelProviders.Create(modelprovider.CreateRequest{
+		Name: "HUB", BaseURL: "https://hub.example.test/v1",
+		Protocols: []modelprovider.Protocol{modelprovider.ProtocolOpenAIChatCompletions},
+		Catalog:   modelprovider.Catalog{Manual: []string{"MiniMax-M3", "deepseek-v4-flash"}, DefaultModel: "deepseek-v4-flash"},
+	})
+	if err != nil {
+		t.Fatalf("create hub provider: %v", err)
+	}
+	t.Setenv(glm.APIKeyEnv, "sk-glm")
+	t.Setenv(hub.APIKeyEnv, "sk-hub")
+
+	glmProfile, err := server.profiles.Create("Hermes · GLM · glm-5.2", runtimeprofile.ProviderHermes, runtimeprofile.Fields{
+		ModelProviderID: glm.ID, ModelOverride: "glm-5.2", DefaultRunner: "sandbox",
+	})
+	if err != nil {
+		t.Fatalf("create glm profile: %v", err)
+	}
+	previous := &session.Continuation{RuntimeProfileID: glmProfile.ID, RuntimeProvider: "hermes", Runner: session.RunnerSandbox}
+
+	resolved, err := server.resolveSessionRuntimeProfile(sessionRuntimeInput{
+		RuntimeProfileID: glmProfile.ID,
+		RuntimeProvider:  "hermes",
+		ModelProviderID:  hub.ID,
+		Model:            "MiniMax-M3",
+	}, previous)
+	if err != nil {
+		t.Fatalf("resolve Session Runtime Profile: %v", err)
+	}
+	if resolved.Fields.ModelProviderID != hub.ID {
+		t.Fatalf("model provider = %q, want %q", resolved.Fields.ModelProviderID, hub.ID)
+	}
+	if resolved.Fields.ModelOverride != "MiniMax-M3" {
+		t.Fatalf("model override = %q, want MiniMax-M3", resolved.Fields.ModelOverride)
+	}
+
+	if _, err := server.prepareSessionRuntime(t.Context(), session.BlackboardConclusionModeInteractive, sessionRuntimeInput{
+		RuntimeProfileID: glmProfile.ID,
+		RuntimeProvider:  "hermes",
+		ModelProviderID:  hub.ID,
+		Model:            "MiniMax-M3",
+	}, previous); err != nil {
+		t.Fatalf("prepare Session Runtime after Model Provider switch: %v", err)
 	}
 }
 

--- a/internal/runner/projection_hermes.go
+++ b/internal/runner/projection_hermes.go
@@ -39,8 +39,8 @@ func projectHermesHome(layout Layout, profile runtimeprofile.Profile, req Projec
 	if err := os.MkdirAll(layout.ProviderHome, 0o700); err != nil {
 		return ConfigProjection{}, fmt.Errorf("prepare hermes home: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Join(layout.ProviderHome, "skills"), 0o700); err != nil {
-		return ConfigProjection{}, fmt.Errorf("prepare hermes skills dir: %w", err)
+	if err := ensureHermesSkillsDir(layout.ProviderHome); err != nil {
+		return ConfigProjection{}, err
 	}
 
 	configPath := filepath.Join(layout.ProviderHome, "config.yaml")
@@ -79,12 +79,39 @@ func projectHermesHome(layout Layout, profile runtimeprofile.Profile, req Projec
 	return ConfigProjection{ConfigPath: configPath, Config: preview}, nil
 }
 
+// ensureHermesSkillsDir leaves a PrepareSandboxSkills symlink in place. MkdirAll
+// follows a broken host-side /task/skills link and then fails with EEXIST.
+func ensureHermesSkillsDir(providerHome string) error {
+	skillsDir := filepath.Join(providerHome, "skills")
+	if _, err := os.Lstat(skillsDir); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("prepare hermes skills dir: %w", err)
+	}
+	if err := os.MkdirAll(skillsDir, 0o700); err != nil {
+		return fmt.Errorf("prepare hermes skills dir: %w", err)
+	}
+	return nil
+}
+
 func buildHermesConfigYAML(profile runtimeprofile.Profile, projected []piProjectedProvider, servers []runtimeprofile.MCPServer) string {
 	var b strings.Builder
 	b.WriteString("approvals:\n")
 	b.WriteString("  mode: off\n")
 	b.WriteString("model:\n")
-	b.WriteString("  provider: custom\n")
+	// Bare provider: custom ignores providers.*.api_key_env and sends
+	// "no-key-required" to non-OpenAI hosts, which returns HTTP 401.
+	providerName := "custom"
+	if selected := hermesSelectedProvider(profile, projected); selected != nil {
+		if id := strings.TrimSpace(selected.Provider.ID); id != "" {
+			if strings.HasPrefix(id, "custom:") {
+				providerName = id
+			} else {
+				providerName = "custom:" + id
+			}
+		}
+	}
+	fmt.Fprintf(&b, "  provider: %s\n", yamlScalar(providerName))
 	if model := strings.TrimSpace(profile.Fields.Model); model != "" {
 		fmt.Fprintf(&b, "  default: %s\n", yamlScalar(model))
 	} else if selected := hermesSelectedProvider(profile, projected); selected != nil && len(selected.Models) > 0 {
@@ -102,7 +129,7 @@ func buildHermesConfigYAML(profile runtimeprofile.Profile, projected []piProject
 			fmt.Fprintf(&b, "  %s:\n", yamlScalar(entry.Provider.ID))
 			fmt.Fprintf(&b, "    base_url: %s\n", yamlScalar(entry.Endpoint.BaseURL))
 			fmt.Fprintf(&b, "    api_mode: %s\n", yamlScalar(hermesAPIMode(entry.Protocol)))
-			fmt.Fprintf(&b, "    api_key_env: %s\n", yamlScalar(entry.Provider.APIKeyEnv))
+			fmt.Fprintf(&b, "    key_env: %s\n", yamlScalar(entry.Provider.APIKeyEnv))
 		}
 	}
 	b.WriteString("terminal:\n")

--- a/internal/runner/projection_hermes_test.go
+++ b/internal/runner/projection_hermes_test.go
@@ -10,6 +10,7 @@ import (
 	"pentest/internal/modelprovider"
 	"pentest/internal/runner"
 	"pentest/internal/runtimeprofile"
+	"pentest/internal/skill"
 	"pentest/internal/store"
 )
 
@@ -119,6 +120,22 @@ func TestProjectHermesHomeIsolatesConfigAndProjectsLaunchReadyProviders(t *testi
 	if !strings.Contains(config, alternate.ID) {
 		t.Fatalf("missing alternate provider in Global Model Projection:\n%s", config)
 	}
+	if !strings.Contains(config, "provider: \"custom:"+primary.ID+"\"\n") {
+		t.Fatalf("expected model.provider custom:%s so Hermes stays on the named endpoint, got:\n%s", primary.ID, config)
+	}
+	if strings.Contains(config, "provider: custom\n") {
+		t.Fatalf("bare custom provider ignores named api_key_env, got:\n%s", config)
+	}
+	foundKeyEnv := false
+	for _, line := range strings.Split(config, "\n") {
+		if strings.TrimSpace(line) == "key_env: "+primary.APIKeyEnv {
+			foundKeyEnv = true
+			break
+		}
+	}
+	if !foundKeyEnv {
+		t.Fatalf("Hermes providers dict reads key_env, not api_key_env, got:\n%s", config)
+	}
 
 	envRaw, err := os.ReadFile(filepath.Join(layout.ProviderHome, ".env"))
 	if err != nil {
@@ -142,5 +159,41 @@ func TestProjectHermesHomeIsolatesConfigAndProjectsLaunchReadyProviders(t *testi
 	if strings.Contains(fmt.Sprint(projection.Config), "sk-primary-secret") ||
 		strings.Contains(fmt.Sprint(projection.Config), "sk-alternate-secret") {
 		t.Fatalf("preview leaked secret: %#v", projection.Config)
+	}
+}
+
+func TestProjectRuntimeConfigKeepsHermesSandboxSkillsLink(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "skill-source")
+	if err := os.MkdirAll(sourceDir, 0o700); err != nil {
+		t.Fatalf("create skill source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte("# Recon"), 0o600); err != nil {
+		t.Fatalf("write skill doc: %v", err)
+	}
+
+	profile := runtimeprofile.Profile{Provider: runtimeprofile.ProviderHermes}
+	layout, err := runner.PrepareTaskLayout(root, "task-hermes-sandbox", profile.Provider)
+	if err != nil {
+		t.Fatalf("prepare layout: %v", err)
+	}
+
+	if _, err := runner.ProjectRuntimeConfig(layout, profile, runner.ProjectionRequest{
+		Sandbox: true,
+		SkillBundles: []skill.Bundle{{
+			ID:   "recon-helper",
+			Name: "Recon Helper",
+			Path: sourceDir,
+		}},
+	}); err != nil {
+		t.Fatalf("project runtime config: %v", err)
+	}
+
+	link := filepath.Join(layout.ProviderHome, "skills")
+	if target, err := os.Readlink(link); err != nil || target != "/task/skills" {
+		t.Fatalf("hermes provider skills link = %q, err = %v", target, err)
+	}
+	if _, err := os.Stat(filepath.Join(layout.ProviderHome, "config.yaml")); err != nil {
+		t.Fatalf("expected hermes config: %v", err)
 	}
 }

--- a/internal/runtime/provider_adapters.go
+++ b/internal/runtime/provider_adapters.go
@@ -940,32 +940,71 @@ type HermesProviderSession struct{ *providerSessionAdapter }
 
 func NewHermesProviderSession(config HermesProviderSessionConfig) *HermesProviderSession {
 	methods := providerWireMethods{
-		send:      "session/prompt",
-		interrupt: "session/cancel",
-		params:    hermesACPParams,
-		turnID:    func(record map[string]any) string { return providerJSONValue(record, "turn_id", "turnId", "id") },
-		sessionID: identitySession,
+		send:        "session/prompt",
+		interrupt:   "session/cancel",
+		params:      hermesACPParams,
+		prepareSend: hermesPrepareSendSelection,
+		turnID:      func(record map[string]any) string { return providerJSONValue(record, "turn_id", "turnId", "id") },
+		sessionID:   identitySession,
 	}
 	return &HermesProviderSession{newProviderSessionAdapter("hermes", config.Transport, config.SessionID, config.ActiveTurnID, providerCapabilities(config.Capabilities), methods)}
 }
 
 func hermesACPParams(sessionID, turnID string, request ProviderSessionRequest) map[string]any {
-	params := map[string]any{
-		"sessionId": sessionID,
+	return map[string]any{
+		"sessionId":  sessionID,
 		"session_id": sessionID,
-		"turn_id":   turnID,
-		"prompt":    []map[string]any{{"type": "text", "text": request.Message}},
+		"turn_id":    turnID,
+		"prompt":     []map[string]any{{"type": "text", "text": request.Message}},
 	}
-	if model := strings.TrimSpace(request.Model); model != "" {
-		params["model"] = model
+}
+
+// hermesPrepareSendSelection applies Runtime Turn Selection through ACP
+// session/set_model. session/prompt has no model field; extra keys are ignored.
+// Named Model Providers use custom:<id>:<model> so Hermes does not auto-switch
+// to a built-in MiniMax/OpenRouter route.
+func hermesPrepareSendSelection(ctx context.Context, transport ProviderSessionTransport, wireBaseID, sessionID, turnID string, request ProviderSessionRequest) error {
+	if transport == nil {
+		return errors.New("provider session transport is required")
 	}
-	if effort := strings.TrimSpace(request.RequestedReasoningEffort); effort != "" {
-		params["requested_reasoning_effort"] = effort
+	modelID := hermesACPModelID(request.ModelProviderID, request.Model)
+	if modelID == "" {
+		return nil
 	}
-	if providerID := strings.TrimSpace(request.ModelProviderID); providerID != "" {
-		params["model_provider_id"] = providerID
+	params := map[string]any{
+		"sessionId":  sessionID,
+		"session_id": sessionID,
+		"modelId":    modelID,
 	}
-	return params
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	response, err := transport.Send(ctx, SandboxBridgeRequest{
+		ID: wireBaseID + ":set_model", Method: "session/set_model", Params: encoded,
+	})
+	if err != nil {
+		return err
+	}
+	if len(response.Error) > 0 && string(response.Error) != "null" {
+		return &SandboxBridgeRPCError{RequestID: wireBaseID + ":set_model"}
+	}
+	return nil
+}
+
+func hermesACPModelID(providerID, model string) string {
+	providerID = strings.TrimSpace(providerID)
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return ""
+	}
+	if providerID == "" || strings.HasPrefix(model, "custom:") {
+		return model
+	}
+	if strings.HasPrefix(providerID, "custom:") {
+		return providerID + ":" + model
+	}
+	return "custom:" + providerID + ":" + model
 }
 
 func NewPiProviderSession(config PiProviderSessionConfig) *PiProviderSession {

--- a/internal/runtime/provider_adapters_test.go
+++ b/internal/runtime/provider_adapters_test.go
@@ -657,6 +657,37 @@ func TestPiProviderSessionMapsPromptAbortAndReplacement(t *testing.T) {
 	}
 }
 
+func TestHermesProviderSessionAppliesSetModelBeforePrompt(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"session/set_model": {Result: json.RawMessage(`{}`)},
+		"session/prompt":    {Result: json.RawMessage(`{"sessionId":"hermes-1","turn_id":"turn-2"}`)},
+	}}
+	session := NewHermesProviderSession(HermesProviderSessionConfig{Transport: transport, SessionID: "hermes-1"})
+	_, err := session.SendTurn(context.Background(), ProviderSessionRequest{
+		RequestID:       "send-selection",
+		Message:         "hi",
+		ModelProviderID: "hub",
+		Model:           "deepseek-v4-flash-free",
+	}, nil)
+	if err != nil {
+		t.Fatalf("send turn: %v", err)
+	}
+	requests := transport.snapshot()
+	if len(requests) < 2 {
+		t.Fatalf("wire requests = %#v", requests)
+	}
+	if requests[0].Method != "session/set_model" || requests[1].Method != "session/prompt" {
+		t.Fatalf("order = %q, %q", requests[0].Method, requests[1].Method)
+	}
+	var setModel map[string]any
+	if err := json.Unmarshal(requests[0].Params, &setModel); err != nil {
+		t.Fatal(err)
+	}
+	if setModel["sessionId"] != "hermes-1" || setModel["modelId"] != "custom:hub:deepseek-v4-flash-free" {
+		t.Fatalf("set_model params = %#v", setModel)
+	}
+}
+
 // TestPiProviderSessionAppliesModelThenEffortThenPrompt proves Pi native
 // controls are issued in mandatory order: set_model → set_thinking_level → prompt.
 func TestPiProviderSessionAppliesModelThenEffortThenPrompt(t *testing.T) {

--- a/internal/runtimeoutput/parse.go
+++ b/internal/runtimeoutput/parse.go
@@ -147,7 +147,7 @@ func parseContentBlocks(content []any, opts ParseOptions, role string, createdAt
 func toolUseTurn(record map[string]any, createdAt time.Time) Turn {
 	input := map[string]any{}
 	details := map[string]any{}
-	for _, key := range []string{"input", "arguments", "parameters"} {
+	for _, key := range []string{"input", "arguments", "parameters", "rawInput", "raw_input"} {
 		if value, ok := record[key]; ok {
 			details[key] = value
 			if typed, ok := value.(map[string]any); ok {
@@ -349,6 +349,19 @@ func parseHermesACPRecord(record map[string]any, opts ParseOptions, createdAt ti
 		} else if input, ok := mapValue(update, "raw_input"); ok {
 			turn.Input = input
 		}
+		if len(turn.Input) == 0 {
+			turn.Input = hermesToolInputFallback(update)
+		}
+		if len(turn.Input) > 0 {
+			details := turn.Details
+			if details == nil {
+				details = map[string]any{}
+			}
+			if _, ok := details["input"]; !ok {
+				details["input"] = turn.Input
+			}
+			turn.Details = details
+		}
 		return []Turn{turn}
 	case "tool_call_update":
 		turn := toolResultTurn(update, createdAt)
@@ -365,6 +378,32 @@ func parseHermesACPRecord(record map[string]any, opts ParseOptions, createdAt ti
 	default:
 		return nil
 	}
+}
+
+func hermesToolInputFallback(update map[string]any) map[string]any {
+	if locs, ok := sliceValue(update, "locations"); ok {
+		paths := make([]string, 0, len(locs))
+		for _, loc := range locs {
+			typed, ok := loc.(map[string]any)
+			if !ok {
+				continue
+			}
+			if path := firstText(typed, "path"); path != "" {
+				paths = append(paths, path)
+			}
+		}
+		if len(paths) == 1 {
+			return map[string]any{"path": paths[0]}
+		}
+		if len(paths) > 1 {
+			return map[string]any{"paths": paths}
+		}
+	}
+	text := strings.TrimSpace(firstText(update, "content", "text"))
+	if strings.HasPrefix(text, "$ ") {
+		return map[string]any{"command": strings.TrimPrefix(text, "$ ")}
+	}
+	return nil
 }
 
 func isTruthy(value any) bool {

--- a/internal/runtimeoutput/parse_test.go
+++ b/internal/runtimeoutput/parse_test.go
@@ -137,6 +137,22 @@ func TestParseRecordHermesACPSessionUpdates(t *testing.T) {
 			callID: "call-1",
 		},
 		{
+			name: "tool describe rawInput",
+			record: map[string]any{
+				"sessionId": "hermes-session",
+				"update": map[string]any{
+					"sessionUpdate": "tool_call",
+					"toolCallId":    "tc-1",
+					"title":         "tool_describe",
+					"kind":          "other",
+					"rawInput":      map[string]any{"name": "mcp__pentest__blackboard_change"},
+				},
+			},
+			kind:   runtimeoutput.KindToolUse,
+			tool:   "tool_describe",
+			callID: "tc-1",
+		},
+		{
 			name: "update-only tool result",
 			record: map[string]any{
 				"sessionUpdate": "tool_call_update",

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -35,6 +35,11 @@ const (
 	// through an adapter whose name ("provider-session:<id>") resolves to no
 	// plugin parser, so the stream identifies the underlying provider instead.
 	PiSessionStream = "pi_session"
+
+	// HermesACPStream marks runtime_output events from the Hermes ACP session
+	// bridge. Each agent_message_chunk is one token, so the transcript joins
+	// adjacent chunks from the same Continuation into one sentence.
+	HermesACPStream = "hermes_acp"
 )
 
 // Entry is one projected transcript row. Truncated marks a bounded preview of
@@ -118,9 +123,31 @@ func BuildWindow(subject Subject, events []Event, context WindowContext) []Entry
 			}
 			continue
 		}
-		entries = append(entries, entriesForEvent(event, continuation, adapter)...)
+		entries = appendOrCoalesceTranscript(entries, entriesForEvent(event, continuation, adapter))
 	}
 	return entries
+}
+
+// appendOrCoalesceTranscript joins adjacent assistant message chunks from one
+// Continuation so a streamed sentence is one row, not one row per token.
+func appendOrCoalesceTranscript(entries, next []Entry) []Entry {
+	for _, entry := range next {
+		if n := len(entries); n > 0 && canMergeAssistantMessage(entries[n-1], entry) {
+			entries[n-1].Text += entry.Text
+			entries[n-1].Seq = entry.Seq
+			entries[n-1].CreatedAt = entry.CreatedAt
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func canMergeAssistantMessage(prev, next Entry) bool {
+	return prev.Kind == KindMessage && next.Kind == KindMessage &&
+		prev.Role == RoleAssistant && next.Role == RoleAssistant &&
+		prev.Continuation == next.Continuation &&
+		prev.Stream == HermesACPStream && next.Stream == HermesACPStream
 }
 
 func lifecycleEntry(event Event, continuation int) (Entry, bool) {
@@ -252,7 +279,7 @@ func entriesForEvent(event Event, continuation int, adapter string) []Entry {
 		parseAdapter := adapter
 		if stream == PiSessionStream {
 			parseAdapter = string(runtimeprofile.ProviderPi)
-		} else if stream == "hermes_acp" {
+		} else if stream == HermesACPStream {
 			parseAdapter = string(runtimeprofile.ProviderHermes)
 		} else if strings.HasPrefix(parseAdapter, "provider-session:") {
 			if provider := stringValue(event.Payload, "provider"); provider != "" {
@@ -319,6 +346,7 @@ func parseRuntimeOutput(event Event, continuation int, adapter, text string) ([]
 		Seq:          event.Seq,
 		Continuation: continuation,
 		CreatedAt:    event.CreatedAt,
+		Stream:       stringValue(event.Payload, "stream"),
 	}
 	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{}, base.CreatedAt)
 	if len(turns) == 0 {
@@ -398,11 +426,23 @@ func messageEntry(base Entry, id, role, text string) Entry {
 		Kind:         KindMessage,
 		Role:         role,
 		Text:         text,
+		Stream:       base.Stream,
 		CreatedAt:    base.CreatedAt,
 	}
 }
 
 func toolCallEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry {
+	details := turn.Details
+	if len(turn.Input) > 0 {
+		cloned := make(map[string]any, len(details)+1)
+		for key, value := range details {
+			cloned[key] = value
+		}
+		if _, ok := cloned["input"]; !ok {
+			cloned["input"] = turn.Input
+		}
+		details = cloned
+	}
 	return Entry{
 		ID:           id,
 		Seq:          base.Seq,
@@ -411,7 +451,7 @@ func toolCallEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry
 		Role:         RoleAssistant,
 		ToolCallID:   turn.ToolCallID,
 		ToolName:     turn.Tool,
-		Details:      turn.Details,
+		Details:      details,
 		Status:       StatusCollapsed,
 		CreatedAt:    base.CreatedAt,
 	}

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -1,6 +1,7 @@
 package transcript_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -321,6 +322,137 @@ func TestBuildParsesHermesACPRuntimeOutputFromPersistentSessionAdapter(t *testin
 	if msg.Text != "Inspecting the app." {
 		t.Fatalf("assistant text = %q in %#v", msg.Text, got)
 	}
+}
+
+func TestBuildProjectsHermesACPToolCallRawInput(t *testing.T) {
+	createdAt := time.Date(2026, 8, 14, 13, 45, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "session-1", Title: "reverse the package", CreatedAt: createdAt}
+	got := transcript.Build(subject, []transcript.Event{{
+		ID: "ev-1", Seq: 1, Kind: "runtime_output",
+		Payload: map[string]any{
+			"provider": "hermes",
+			"stream":   "hermes_acp",
+			"text":     `{"sessionId":"hermes-session","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","title":"tool_describe","kind":"other","rawInput":{"name":"mcp__pentest__blackboard_change"},"locations":[]}}`,
+		},
+		CreatedAt: createdAt,
+	}})
+	call := findEntryByKind(t, got, "tool_call")
+	if call.ToolName != "tool_describe" {
+		t.Fatalf("tool name = %q, want tool_describe", call.ToolName)
+	}
+	input, _ := call.Details["input"].(map[string]any)
+	if input["name"] != "mcp__pentest__blackboard_change" {
+		t.Fatalf("tool_describe details.input = %#v, want name mcp__pentest__blackboard_change", call.Details)
+	}
+}
+
+func TestBuildProjectsHermesACPWriteLocationsAsInput(t *testing.T) {
+	createdAt := time.Date(2026, 8, 14, 13, 45, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "session-1", Title: "reverse the package", CreatedAt: createdAt}
+	got := transcript.Build(subject, []transcript.Event{{
+		ID: "ev-1", Seq: 1, Kind: "runtime_output",
+		Payload: map[string]any{
+			"provider": "hermes",
+			"stream":   "hermes_acp",
+			"text":     `{"sessionId":"hermes-session","update":{"sessionUpdate":"tool_call","toolCallId":"tc-2","title":"write: /task/workdir/tools/split_fat.py","kind":"edit","locations":[{"path":"/task/workdir/tools/split_fat.py"}]}}`,
+		},
+		CreatedAt: createdAt,
+	}})
+	call := findEntryByKind(t, got, "tool_call")
+	input, _ := call.Details["input"].(map[string]any)
+	if input["path"] != "/task/workdir/tools/split_fat.py" {
+		t.Fatalf("write details.input = %#v, want path /task/workdir/tools/split_fat.py", call.Details)
+	}
+}
+
+func TestBuildProjectsHermesACPTerminalContentAsCommand(t *testing.T) {
+	createdAt := time.Date(2026, 8, 14, 13, 45, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "session-1", Title: "reverse the package", CreatedAt: createdAt}
+	got := transcript.Build(subject, []transcript.Event{{
+		ID: "ev-1", Seq: 1, Kind: "runtime_output",
+		Payload: map[string]any{
+			"provider": "hermes",
+			"stream":   "hermes_acp",
+			"text":     `{"sessionId":"hermes-session","update":{"sessionUpdate":"tool_call","toolCallId":"tc-3","title":"terminal: ls -la /task/workdir","kind":"execute","content":[{"type":"content","content":{"type":"text","text":"$ ls -la /task/workdir"}}]}}`,
+		},
+		CreatedAt: createdAt,
+	}})
+	call := findEntryByKind(t, got, "tool_call")
+	input, _ := call.Details["input"].(map[string]any)
+	if input["command"] != "ls -la /task/workdir" {
+		t.Fatalf("terminal details.input = %#v, want command ls -la /task/workdir", call.Details)
+	}
+}
+
+func TestBuildCoalescesAdjacentHermesACPMessageChunks(t *testing.T) {
+	createdAt := time.Date(2026, 8, 14, 13, 8, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "session-1", Title: "just say hi", CreatedAt: createdAt}
+	chunk := func(id string, seq int, text string) transcript.Event {
+		return transcript.Event{
+			ID: id, Seq: seq, Kind: "runtime_output",
+			Payload: map[string]any{
+				"provider": "hermes",
+				"stream":   "hermes_acp",
+				"text":     `{"sessionId":"hermes-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":` + mustJSONString(t, text) + `}}}`,
+			},
+			CreatedAt: createdAt.Add(time.Duration(seq) * time.Second),
+		}
+	}
+	got := transcript.Build(subject, []transcript.Event{
+		{ID: "ev-start", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "provider-session:abc"}, CreatedAt: createdAt},
+		chunk("ev-5", 5, "Hi"),
+		chunk("ev-6", 6, "!"),
+		chunk("ev-7", 7, " "),
+		chunk("ev-8", 8, "👋"),
+	})
+	var assistants []transcript.Entry
+	for _, entry := range got {
+		if entry.Kind == "message" && entry.Role == "assistant" {
+			assistants = append(assistants, entry)
+		}
+	}
+	if len(assistants) != 1 {
+		t.Fatalf("assistant messages = %d, want 1 coalesced sentence: %#v", len(assistants), assistants)
+	}
+	if assistants[0].Text != "Hi! 👋" {
+		t.Fatalf("assistant text = %q, want %q", assistants[0].Text, "Hi! 👋")
+	}
+	if assistants[0].Seq != 8 {
+		t.Fatalf("coalesced seq = %d, want last chunk seq 8", assistants[0].Seq)
+	}
+	if assistants[0].Stream != "hermes_acp" {
+		t.Fatalf("coalesced stream = %q, want hermes_acp", assistants[0].Stream)
+	}
+}
+
+func TestBuildKeepsAdjacentConversationAssistantMessagesSeparate(t *testing.T) {
+	createdAt := time.Date(2026, 8, 14, 13, 20, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "task-1", Title: "history window", CreatedAt: createdAt}
+	got := transcript.Build(subject, []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "conversation", Payload: map[string]any{"role": "assistant", "text": "Message 1"}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-2", Seq: 2, Kind: "conversation", Payload: map[string]any{"role": "assistant", "text": "Message 2"}, CreatedAt: createdAt.Add(2 * time.Second)},
+	})
+	var assistants []transcript.Entry
+	for _, entry := range got {
+		if entry.Kind == "message" && entry.Role == "assistant" {
+			assistants = append(assistants, entry)
+		}
+	}
+	if len(assistants) != 2 {
+		t.Fatalf("conversation assistant messages = %#v, want two separate rows", assistants)
+	}
+	if assistants[0].Text != "Message 1" || assistants[1].Text != "Message 2" {
+		t.Fatalf("conversation assistant texts = %#v", assistants)
+	}
+}
+
+func mustJSONString(t *testing.T, text string) string {
+	t.Helper()
+	raw, err := json.Marshal(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
 }
 
 func TestParseRecordPiSessionLines(t *testing.T) {

--- a/web/src/lib/ownerEvents.test.ts
+++ b/web/src/lib/ownerEvents.test.ts
@@ -49,7 +49,10 @@ describe("mergeTimelineItems", () => {
 
 describe("mergeTranscriptEntries", () => {
   it("returns the delta directly for an empty existing transcript", () => {
-    const delta = [transcriptEntry("a", 1), transcriptEntry("b", 2)];
+    const delta = [
+      { ...transcriptEntry("a", 1), role: "user" as const, text: "hi" },
+      transcriptEntry("b", 2),
+    ];
     expect(mergeTranscriptEntries([], delta)).toEqual(delta);
   });
 
@@ -59,10 +62,32 @@ describe("mergeTranscriptEntries", () => {
   });
 
   it("appends new entries and deduplicates by stable id", () => {
-    const existing = [transcriptEntry("a", 1)];
-    const delta = [transcriptEntry("a", 1), transcriptEntry("b", 2)];
+    const existing = [{ ...transcriptEntry("a", 1), role: "user" as const, text: "hi" }];
+    const delta = [
+      { ...transcriptEntry("a", 1), role: "user" as const, text: "hi" },
+      transcriptEntry("b", 2),
+    ];
     const merged = mergeTranscriptEntries(existing, delta);
     expect(merged.map((entry) => entry.id)).toEqual(["a", "b"]);
+  });
+
+  it("joins later Hermes ACP assistant chunks onto the previous sentence", () => {
+    const existing = [{ ...transcriptEntry("ev-5-message", 5), text: "Hi", stream: "hermes_acp" }];
+    const delta = [
+      { ...transcriptEntry("ev-6-message", 6), text: "!", stream: "hermes_acp" },
+      { ...transcriptEntry("ev-7-message", 7), text: " ", stream: "hermes_acp" },
+      { ...transcriptEntry("ev-8-message", 8), text: "👋", stream: "hermes_acp" },
+    ];
+    const merged = mergeTranscriptEntries(existing, delta);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ id: "ev-5-message", seq: 8, text: "Hi! 👋" });
+  });
+
+  it("keeps complete adjacent assistant messages as separate rows", () => {
+    const existing = [{ ...transcriptEntry("a", 1), text: "Message 1" }];
+    const delta = [{ ...transcriptEntry("b", 2), text: "Message 2" }];
+    const merged = mergeTranscriptEntries(existing, delta);
+    expect(merged.map((entry) => entry.text)).toEqual(["Message 1", "Message 2"]);
   });
 });
 

--- a/web/src/lib/ownerEvents.ts
+++ b/web/src/lib/ownerEvents.ts
@@ -34,7 +34,7 @@ export function mergeTimelineItems(existing: TaskTimelineItem[], delta: TaskTime
 
 /** mergeTranscriptEntries appends an ordered transcript delta without duplicates. */
 export function mergeTranscriptEntries(existing: TaskTranscriptEntry[], delta: TaskTranscriptEntry[]): TaskTranscriptEntry[] {
-  if (existing.length === 0) return delta;
+  if (existing.length === 0) return coalesceAssistantChunks(delta);
   if (delta.length === 0) return existing;
   const maxSeq = Math.max(...existing.map((entry) => entry.seq));
   const appended: TaskTranscriptEntry[] = [];
@@ -45,7 +45,53 @@ export function mergeTranscriptEntries(existing: TaskTranscriptEntry[], delta: T
     appended.push(entry);
   }
   if (appended.length === 0) return existing;
-  return [...existing, ...appended];
+  return appendCoalescedTranscript(existing, appended);
+}
+
+function appendCoalescedTranscript(existing: TaskTranscriptEntry[], delta: TaskTranscriptEntry[]): TaskTranscriptEntry[] {
+  const next = coalesceAssistantChunks(delta);
+  if (next.length === 0) return existing;
+  const last = existing[existing.length - 1]!;
+  if (canMergeAssistantChunk(last, next[0]!)) {
+    const joined: TaskTranscriptEntry = {
+      ...last,
+      text: `${last.text ?? ""}${next[0]!.text ?? ""}`,
+      seq: next[0]!.seq,
+      created_at: next[0]!.created_at ?? last.created_at,
+    };
+    return [...existing.slice(0, -1), joined, ...next.slice(1)];
+  }
+  return [...existing, ...next];
+}
+
+function coalesceAssistantChunks(entries: TaskTranscriptEntry[]): TaskTranscriptEntry[] {
+  const out: TaskTranscriptEntry[] = [];
+  for (const entry of entries) {
+    const prev = out[out.length - 1];
+    if (prev && canMergeAssistantChunk(prev, entry)) {
+      out[out.length - 1] = {
+        ...prev,
+        text: `${prev.text ?? ""}${entry.text ?? ""}`,
+        seq: entry.seq,
+        created_at: entry.created_at ?? prev.created_at,
+      };
+      continue;
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+function canMergeAssistantChunk(prev: TaskTranscriptEntry, next: TaskTranscriptEntry): boolean {
+  return (
+    prev.kind === "message" &&
+    next.kind === "message" &&
+    prev.role === "assistant" &&
+    next.role === "assistant" &&
+    prev.continuation === next.continuation &&
+    prev.stream === "hermes_acp" &&
+    next.stream === "hermes_acp"
+  );
 }
 
 /**

--- a/web/src/pages/taskDetailView.test.ts
+++ b/web/src/pages/taskDetailView.test.ts
@@ -17,6 +17,20 @@ describe("collapsedTranscriptTitle", () => {
     expect(collapsedTranscriptTitle(entry)).toBe("Bash · curl http://localhost:3000");
   });
 
+  it("previews a Hermes tool_describe name argument", () => {
+    const entry: TaskTranscriptEntry = {
+      id: "x",
+      seq: 1,
+      continuation: 1,
+      kind: "tool_call",
+      role: "assistant",
+      tool_name: "tool_describe",
+      details: { input: { name: "mcp__pentest__blackboard_change" } },
+      created_at: "",
+    };
+    expect(collapsedTranscriptTitle(entry)).toBe("tool_describe · mcp__pentest__blackboard_change");
+  });
+
   it("summarizes tool results without exposing transport call ids", () => {
     const entry: TaskTranscriptEntry = {
       id: "x",

--- a/web/src/pages/taskDetailView.ts
+++ b/web/src/pages/taskDetailView.ts
@@ -21,7 +21,7 @@ export function collapsedTranscriptTitle(entry: TaskTranscriptEntry): string {
 function toolInputPreview(entry: TaskTranscriptEntry): string {
   const input = asRecord(asRecord(entry.details)?.input);
   if (!input) return "";
-  for (const key of ["command", "file_path", "path", "query", "url", "pattern"]) {
+  for (const key of ["command", "file_path", "path", "query", "url", "pattern", "name"]) {
     const value = stringValue(input[key]);
     if (value) return firstLine(value);
   }


### PR DESCRIPTION
## Summary

Hermes Non-Project Sessions failed to launch, then showed a broken conversation view after a turn succeeded.

- Complete the Hermes ACP handshake: integer `protocolVersion` on `initialize`, and `mcpServers: []` on `session/new` / `session/load`.
- Write Config Projection as `model.provider: custom:<id>` and `key_env` so named Model Provider keys (for example `HUB_API_KEY`) are used.
- Apply Runtime Turn Selection with `session/set_model` (`custom:<provider>:<model>`) before `session/prompt`. Hermes ignores extra `model` keys on prompt.
- Resolve a new Launch Profile when Launch Selection changes Model Provider, instead of reusing the previous profile catalog.
- Join adjacent `hermes_acp` `agent_message_chunk` tokens into one Transcript sentence. Keep complete conversation messages as separate rows.
- Project Hermes tool `rawInput`, write `locations`, and terminal `$` content into `details.input` so the conversation view shows arguments instead of "No arguments."

## Test plan

- [x] `go test ./internal/transcript ./internal/runtimeoutput ./internal/runner ./internal/runtime ./internal/daemon -count=1`
- [x] `npx vitest run src/lib/ownerEvents.test.ts src/pages/taskDetailView.test.ts` (in `web/`)
- [x] Reload Session `just say hi`: `Hi! 👋` is one assistant line
- [x] Reload the same Session: `tool_describe` shows `name`, `write` shows `path`, `blackboard_change` shows `changes`