### PR TITLE
fix (security): Prohibits casting operator tokens and desensitizing d…

### DIFF
--- a/.github/workflows/build-tsecbench-hosted.yml
+++ b/.github/workflows/build-tsecbench-hosted.yml
@@ -8,23 +8,23 @@ on:
         required: true
         default: manual
         type: string
-  pull_request:
-    branches: [main]
-    paths:
-      - .github/workflows/build-tsecbench-hosted.yml
-      - cmd/pentest-claude-sdk-bridge/**
-      - cmd/pentest-provider-bridge/**
-      - cmd/pentest-tsecbench-hosted/**
-      - docker/tsecbench-hosted/**
-      - docs/tsecbench/**
-      - internal/hostedcontroller/**
-      - internal/runner/**
-      - scripts/build-tsecbench-hosted-bundle.sh
-      - scripts/tsecbench_hosted_*.go
-      - web/**
-      - go.mod
-      - go.sum
-      - Makefile
+  # pull_request:
+  #   branches: [main]
+  #   paths:
+  #     - .github/workflows/build-tsecbench-hosted.yml
+  #     - cmd/pentest-claude-sdk-bridge/**
+  #     - cmd/pentest-provider-bridge/**
+  #     - cmd/pentest-tsecbench-hosted/**
+  #     - docker/tsecbench-hosted/**
+  #     - docs/tsecbench/**
+  #     - internal/hostedcontroller/**
+  #     - internal/runner/**
+  #     - scripts/build-tsecbench-hosted-bundle.sh
+  #     - scripts/tsecbench_hosted_*.go
+  #     - web/**
+  #     - go.mod
+  #     - go.sum
+  #     - Makefile
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint
         working-directory: web
         run: npm run lint
+      - name: Unit tests
+        working-directory: web
+        run: npm run test
       - name: Install browser
         working-directory: web
         run: npx playwright install --with-deps chromium

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Always read CONTEXT.md, unconditionally.
 Use TDD
 
 Update `CONTEXT.md` when the user explicitly resolves a domain ambiguity.
-Always talk in ASD-STE100 Simplified Technical English. Always read CONTEXT.md files, and use their ubiquitous language.
+Always talk in ASD-STE100 Simplified Technical English(or Chines if user talks in Chinese). Always read CONTEXT.md files, and use their ubiquitous language.
 ## Agent skills
 
 ### Issue tracker

--- a/cmd/pentestd/main.go
+++ b/cmd/pentestd/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"pentest/internal/adapters"
 	"pentest/internal/challengeworkflow"
 	"pentest/internal/daemon"
 	"pentest/internal/runtime"
@@ -57,12 +58,17 @@ func main() {
 		}
 	}
 
+	// Seed the redactor with the one long-lived secret the daemon knows at
+	// startup: the operator token, which otherwise has no recognizable shape.
+	// Model API keys are masked by the shape patterns.
+	diagnosticsRedactor := adapters.NewRedactor([]string{authToken})
 	providerSessions := daemon.NewProductionProviderSessionFactory(daemon.ProductionProviderSessionFactoryConfig{
 		Docker: runtime.DockerCLISandboxBridgeDocker{ContainerCLI: containerCLI},
 		Diagnostics: func(line string) {
-			// Bridge stderr / docker diagnostics. Keep operator-visible but do not
-			// persist into Task Event payloads (credentials may appear).
-			log.Printf("provider-bridge: %s", line)
+			// Bridge stderr / docker diagnostics, redacted so operator logs
+			// never persist credential values that leaked into provider or
+			// container diagnostics output.
+			log.Printf("provider-bridge: %s", diagnosticsRedactor.RedactString(line))
 		},
 	})
 	app, err := daemon.NewServer(daemon.Config{

--- a/internal/adapters/adapters.go
+++ b/internal/adapters/adapters.go
@@ -390,6 +390,13 @@ func (r *Redactor) redactString(s string) string {
 	return s
 }
 
+// RedactString applies the same known-value and secret-shape masking as Redact
+// to a plain string, for non-payload channels such as bridge stderr or docker
+// diagnostics where credentials may appear in free-form text.
+func (r *Redactor) RedactString(s string) string {
+	return r.redactString(s)
+}
+
 // Redact returns a copy of payload with secret-shaped values replaced by a
 // placeholder using the shape-based patterns only. Callers that know the resolved
 // secret values should prefer NewRedactor(...).Redact so opaque tokens without a

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -687,3 +687,25 @@ func TestBuildNativeResumeArgsPreservesNonConflictingCustomArgsOrder(t *testing.
 		t.Fatalf("custom args order not preserved on resume:\nargs=%#v\nwant contiguous %#v", args, custom)
 	}
 }
+
+// TestRedactStringMasksSecretShapesInPlainDiagnostics covers plain-string
+// redaction for non-payload channels such as provider-bridge stderr, where a
+// credential may appear inside free-form diagnostics text.
+func TestRedactStringMasksSecretShapesInPlainDiagnostics(t *testing.T) {
+	redactor := adapters.NewRedactor([]string{"opaque-runtime-token-value"})
+
+	redacted := redactor.RedactString("bridge failed: ANTHROPIC_API_KEY=sk-ant-api03-abcdef123456789012345678 and opaque-runtime-token-value rejected")
+
+	if strings.Contains(redacted, "sk-ant-api03-abcdef123456789012345678") {
+		t.Fatalf("expected API key shape redacted, got %q", redacted)
+	}
+	if strings.Contains(redacted, "opaque-runtime-token-value") {
+		t.Fatalf("expected known opaque secret redacted, got %q", redacted)
+	}
+	if !strings.Contains(redacted, "ANTHROPIC_API_KEY=") {
+		t.Fatalf("expected variable name retained for context, got %q", redacted)
+	}
+	if !strings.Contains(redacted, "bridge failed") {
+		t.Fatalf("expected ordinary diagnostics retained, got %q", redacted)
+	}
+}

--- a/internal/daemon/operator_token_projection_test.go
+++ b/internal/daemon/operator_token_projection_test.go
@@ -1,0 +1,82 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pentest/internal/project"
+	"pentest/internal/runtimeprofile"
+	"pentest/internal/task"
+)
+
+// The daemon operator token authorizes the full HTTP API, including Host
+// Runner launch. A Runtime environment is not trusted with that authority, so
+// the operator token must never reach a launch plan, a projected config file,
+// or a Runtime process environment. Only a Continuation Interface Grant may
+// authenticate Runtime traffic.
+func TestLegacyLaunchPlanNeverProjectsOperatorToken(t *testing.T) {
+	const operatorToken = "operator-secret-must-never-project"
+	root := t.TempDir()
+	runtimeRoot := filepath.Join(root, "runs")
+	server, err := NewServer(Config{
+		DBPath:               filepath.Join(root, "db.sqlite"),
+		RuntimeRoot:          runtimeRoot,
+		AuthToken:            operatorToken,
+		DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	proj, err := server.projects.CreateWithKind("Token boundary", "", project.KindPentest, project.Scope{}, project.Defaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, err := server.profiles.Create("Claude legacy boundary", runtimeprofile.ProviderClaudeCode, runtimeprofile.Fields{Model: "test-model"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := server.tasks.Create(task.CreateRequest{
+		ProjectID: proj.ID, Type: task.TypePentest, Goal: "inspect boundary",
+		RuntimeProfileID: profile.ID, Runner: task.RunnerHost,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A nil binding forces the legacy non-v2 projection branch, the one path
+	// that historically read the daemon operator token.
+	plan, err := server.buildTaskLaunchPlanWithBinding(created, "inspect boundary", "", "", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if raw, err := json.Marshal(plan.RuntimeConfig); err == nil && strings.Contains(string(raw), operatorToken) {
+		t.Fatalf("launch plan runtime config leaked operator token: %s", raw)
+	}
+	if raw, err := json.Marshal(plan.CapturedRuntimeConfig); err == nil && strings.Contains(string(raw), operatorToken) {
+		t.Fatalf("captured runtime config leaked operator token: %s", raw)
+	}
+
+	layoutRoot := filepath.Join(runtimeRoot, created.ID)
+	walkErr := filepath.WalkDir(layoutRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(content), operatorToken) {
+			t.Errorf("projected file %s leaked the daemon operator token", path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("scan projected layout: %v", walkErr)
+	}
+}

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -783,16 +783,20 @@ func (server *Server) buildTaskLaunchPlanWithBinding(created task.Task, goal str
 		return taskLaunchPlan{}, err
 	}
 
-	authToken := server.authToken
+	// The daemon operator token authorizes the full API, including Host Runner
+	// launch. Runtime environments are not trusted with it: only a Continuation
+	// Interface Grant may authenticate Runtime traffic. The legacy non-v2 branch
+	// projects no token at all, so when a daemon token is configured its trusted
+	// MCP calls cannot authenticate — the denial happens at the daemon, never
+	// through leaked authority.
+	authToken := ""
 	projectionProfile := profile
 	if v2 {
 		if profile.Provider == runtimeprofile.ProviderCodex {
 			// Codex v2 stays networkless for Project Interface writes.
 			projectionProfile = codexV2ProjectionProfile(profile)
-			authToken = ""
 		} else if runner.BlackboardV2UsesTrustedMCP(profile.Provider) {
 			// Claude/Pi use the Continuation grant, never the operator token.
-			authToken = ""
 			if binding != nil {
 				authToken = binding.InterfaceToken
 			}

--- a/internal/owner/conclusion/conclusion.go
+++ b/internal/owner/conclusion/conclusion.go
@@ -1,0 +1,2033 @@
+package conclusion
+
+import (
+	"database/sql"
+
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"pentest/internal/owner"
+)
+
+// Dialect names the owner-specific storage and wording one Engine instance
+// persists against. All identifiers are package constants, never user input,
+// so interpolated SQL stays a fixed statement shape.
+type Dialect struct {
+	// Subject prefixes error strings, e.g. "Blackboard conclusion dispatch".
+	Subject string
+	// ObligationsTable stores Pending Blackboard Conclusion rows.
+	ObligationsTable string
+	// DispatchesTable stores immutable Conclusion Dispatch rows.
+	DispatchesTable string
+	// OwnerColumn is the owner identity column of ObligationsTable.
+	OwnerColumn string
+	// ContinuationsTable maps a Continuation id to its owning owner id.
+	ContinuationsTable string
+	// ContinuationOwnerColumn is the owner identity column of ContinuationsTable.
+	ContinuationOwnerColumn string
+	// EventKind is the event kind string used for conclusion events.
+	EventKind string
+	// ReconcilePendingObligations makes daemon-restart reconciliation treat a
+	// never-dispatched pending obligation as stranded. Non-Project Sessions
+	// need this because a stopped Session cannot resume its dispatch loop.
+	ReconcilePendingObligations bool
+	// AppendEvent stores one owner-local event inside the caller's transaction.
+	// ownerID identifies the owner, continuationID may be empty for owners
+	// whose event rows carry no continuation column.
+	AppendEvent func(tx *sql.Tx, ownerID, continuationID, kind string, payload map[string]any, now time.Time) error
+	// RetryKeysTable stores operator retry idempotency keys.
+	RetryKeysTable string
+	// RetryKeysOwnerColumn is the owner identity column of RetryKeysTable.
+	RetryKeysOwnerColumn string
+	// RetryKeysReceiptColumn names the obligation column of RetryKeysTable.
+	RetryKeysReceiptColumn string
+	// NewID mints row identifiers.
+	NewID func() string
+}
+
+// Engine is the owner-agnostic Pending Blackboard Conclusion state machine
+// shared by Task and Session owners. It owns obligation identity, dispatch
+// lifecycle, watermarks, and recovery settlement; owner eligibility checks
+// (assisted mode, owner existence) stay with the owning package.
+type Engine struct {
+	DB      *sql.DB
+	Dialect Dialect
+}
+
+// Selection is the owner-neutral Runtime Turn Selection snapshot retained on
+// an obligation.
+type Selection struct {
+	ModelProviderID string
+	Model           string
+	ReasoningEffort string
+}
+
+// SemanticDebtWatermarks compare terminal Work Tool Results with the latest
+// successful semantic persistence that covers them.
+type SemanticDebtWatermarks = owner.SemanticDebtWatermarks
+type ConclusionValidationDetail = owner.ConclusionValidationDetail
+
+type (
+	BlackboardConclusionReceiptState = owner.BlackboardConclusionReceiptState
+	BlackboardConclusionErrorCode    = owner.BlackboardConclusionErrorCode
+	ConclusionDispatchKind           = owner.ConclusionDispatchKind
+	ConclusionDispatchState          = owner.ConclusionDispatchState
+	ConclusionRecoveryReason         = owner.ConclusionRecoveryReason
+)
+
+const (
+	BlackboardConclusionAutomaticTurnLimit                          = owner.BlackboardConclusionAutomaticTurnLimit
+	BlackboardConclusionErrorInvalidResult                          = owner.BlackboardConclusionErrorInvalidResult
+	BlackboardConclusionErrorRepairExhausted                        = owner.BlackboardConclusionErrorRepairExhausted
+	BlackboardConclusionErrorRuntimeRecoveryRequired                = owner.BlackboardConclusionErrorRuntimeRecoveryRequired
+	BlackboardConclusionErrorToolUseForbidden                       = owner.BlackboardConclusionErrorToolUseForbidden
+	BlackboardConclusionErrorVersionConflict                        = owner.BlackboardConclusionErrorVersionConflict
+	BlackboardConclusionErrorWorkTurnNeverSettled                   = owner.BlackboardConclusionErrorWorkTurnNeverSettled
+	BlackboardConclusionReceiptActionRequired                       = owner.BlackboardConclusionReceiptActionRequired
+	BlackboardConclusionReceiptApplied                              = owner.BlackboardConclusionReceiptApplied
+	BlackboardConclusionReceiptAwaitingResult                       = owner.BlackboardConclusionReceiptAwaitingResult
+	BlackboardConclusionReceiptClean                                = owner.BlackboardConclusionReceiptClean
+	BlackboardConclusionReceiptDispatchRequested                    = owner.BlackboardConclusionReceiptDispatchRequested
+	BlackboardConclusionReceiptPending                              = owner.BlackboardConclusionReceiptPending
+	BlackboardConclusionReceiptRepairDispatchRequested              = owner.BlackboardConclusionReceiptRepairDispatchRequested
+	BlackboardConclusionReceiptValidated                            = owner.BlackboardConclusionReceiptValidated
+	BlackboardConclusionReceiptVersionRegenerationDispatchRequested = owner.BlackboardConclusionReceiptVersionRegenerationDispatchRequested
+	BlackboardConclusionReceiptVersionSyncRequested                 = owner.BlackboardConclusionReceiptVersionSyncRequested
+	BlackboardConclusionWorkTurnConflictLimit                       = owner.BlackboardConclusionWorkTurnConflictLimit
+	ConclusionDispatchActionRequired                                = owner.ConclusionDispatchActionRequired
+	ConclusionDispatchApplied                                       = owner.ConclusionDispatchApplied
+	ConclusionDispatchAwaitingResult                                = owner.ConclusionDispatchAwaitingResult
+	ConclusionDispatchKindInitial                                   = owner.ConclusionDispatchKindInitial
+	ConclusionDispatchKindRecovery                                  = owner.ConclusionDispatchKindRecovery
+	ConclusionDispatchKindRepair                                    = owner.ConclusionDispatchKindRepair
+	ConclusionDispatchKindRetry                                     = owner.ConclusionDispatchKindRetry
+	ConclusionDispatchKindVersionRegeneration                       = owner.ConclusionDispatchKindVersionRegeneration
+	ConclusionDispatchLateTerminal                                  = owner.ConclusionDispatchLateTerminal
+	ConclusionDispatchRequested                                     = owner.ConclusionDispatchRequested
+	ConclusionDispatchSuperseded                                    = owner.ConclusionDispatchSuperseded
+	ConclusionDispatchValidated                                     = owner.ConclusionDispatchValidated
+	ConclusionRecoveryAcceptanceAmbiguous                           = owner.ConclusionRecoveryAcceptanceAmbiguous
+	ConclusionRecoveryDispatchFailed                                = owner.ConclusionRecoveryDispatchFailed
+	ConclusionRecoveryLegacyCorrelationUnproven                     = owner.ConclusionRecoveryLegacyCorrelationUnproven
+	ConclusionRecoveryRuntimeOwnershipNotProven                     = owner.ConclusionRecoveryRuntimeOwnershipNotProven
+	ConclusionRecoveryWritableReplacementUnavailable                = owner.ConclusionRecoveryWritableReplacementUnavailable
+)
+
+var (
+	ErrInvalidBlackboardConclusionReceipt       = errors.New("invalid Blackboard conclusion checkpoint receipt")
+	ErrBlackboardConclusionRetryCooldown        = errors.New("Blackboard conclusion retry is not yet eligible")
+	ErrBlackboardConclusionWorkTurnNeverSettled = errors.New("Blackboard conclusion work turn never settled")
+	// ErrBlackboardConclusionDispatchInactive reports a callback correlation
+	// that resolved to a superseded or late Conclusion Dispatch. Only the
+	// ACTIVE dispatch of an obligation may validate or apply a provider result,
+	// so a late or duplicate result from an obsolete dispatch can never settle
+	// or corrupt the obligation (ADR 0021).
+	ErrBlackboardConclusionDispatchInactive = errors.New("Blackboard conclusion dispatch is not the active delivery")
+	// ErrOwnerNotFound reports that the owning owner or Continuation does not
+	// exist; callers map it to their owner-specific not-found error.
+	ErrOwnerNotFound = errors.New("Blackboard conclusion owner not found")
+)
+
+// PendingBlackboardConclusion is the durable obligation row. It is keyed by
+// (owner, source session, source turn) and independent of any Runtime
+// Continuation; every delivery attempt is an immutable Conclusion Dispatch
+// child row.
+type PendingBlackboardConclusion struct {
+	ID                            string
+	OwnerID                       string
+	SourceRequestID               string
+	SourceRequestCorrelationExact bool
+	SourceContinuationID          string
+	SourceSessionID               string
+	SourceTurnID                  string
+	State                         BlackboardConclusionReceiptState
+	SourceWorkWatermark           int
+	SemanticPersistenceWatermark  int
+	SourceSelection               Selection
+	CanonicalResultJSON           []byte
+	CanonicalResultSHA256         string
+	ApplyIdempotencyKey           string
+	AppliedRevision               *int
+	BaseRevision                  *int
+	AutomaticTurnCount            int
+	RepairCount                   int
+	VersionRegenerationCount      int
+	ExplicitRetryCount            int
+	OperatorRetryKey              string
+	NextEligibleAt                *time.Time
+	ErrorCode                     BlackboardConclusionErrorCode
+	RecoveryReason                ConclusionRecoveryReason
+	ValidationReason              string
+	ValidationFieldPath           string
+	ValidationExpected            string
+	CreatedAt                     time.Time
+	UpdatedAt                     time.Time
+}
+
+// ConclusionDispatch is one immutable delivery attempt for an obligation. Its
+// continuation and source session are written once at creation and never
+// updated; recovery creates a new dispatch instead of rewriting an old one.
+type ConclusionDispatch struct {
+	ID                   string
+	ObligationID         string
+	Kind                 ConclusionDispatchKind
+	ContinuationID       string
+	SourceSessionID      string
+	DispatchRequestID    string
+	ControlTurnID        string
+	BaseRevision         *int
+	SynchronizedRevision *int
+	DeliveryState        ConclusionDispatchState
+	SendAttemptCount     int
+	SendStartedAt        *time.Time
+	TerminalOutcome      string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+// BlackboardConclusionReceipt is the owner-neutral coordinator projection of
+// an obligation and its active dispatch. Owning packages map OwnerID onto
+// their Task or Session identity and own the API-facing projection.
+type BlackboardConclusionReceipt struct {
+	ID                            string
+	OwnerID                       string
+	ContinuationID                string
+	SourceRequestID               string
+	SourceRequestCorrelationExact bool
+	SourceSessionID               string
+	SourceTurnID                  string
+	InternalState                 BlackboardConclusionReceiptState
+	SourceWorkWatermark           int
+	SemanticPersistenceWatermark  int
+	DispatchRequestID             string
+	ControlTurnID                 string
+	BaseRevision                  *int
+	SynchronizedRevision          *int
+	SourceSelection               Selection
+	CanonicalResultJSON           []byte
+	CanonicalResultSHA256         string
+	ApplyIdempotencyKey           string
+	AppliedRevision               *int
+	AutomaticTurnCount            int
+	RepairCount                   int
+	VersionRegenerationCount      int
+	ExplicitRetryCount            int
+	OperatorRetryKey              string
+	SendAttemptCount              int
+	SendStartedAt                 *time.Time
+	NextEligibleAt                *time.Time
+	ErrorCode                     BlackboardConclusionErrorCode
+	RecoveryReason                string
+	ActiveDispatchID              string
+	DispatchKind                  ConclusionDispatchKind
+	ValidationReason              string
+	ValidationFieldPath           string
+	ValidationExpected            string
+	CreatedAt                     time.Time
+	UpdatedAt                     time.Time
+}
+
+// obligationColumns returns the fixed obligation column list with the owner
+// column in owner-identity position.
+func (e *Engine) obligationColumns() string {
+	return `id,` + e.Dialect.OwnerColumn + `,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,state,
+		source_work_watermark,semantic_persistence_watermark,source_model_provider_id,source_model,source_reasoning_effort,
+		canonical_result_json,canonical_result_sha256,apply_idempotency_key,applied_revision,base_revision,automatic_turn_count,
+		repair_count,version_regeneration_count,explicit_retry_count,operator_retry_key,next_eligible_at,error_code,recovery_reason,
+		validation_reason,validation_field_path,validation_expected,created_at,updated_at`
+}
+
+const conclusionDispatchColumns = `id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,control_turn_id,base_revision,
+	synchronized_revision,delivery_state,send_attempt_count,send_started_at,terminal_outcome,created_at,updated_at`
+
+// RecordBlackboardConclusionCheckpoint creates the one durable Pending
+// Blackboard Conclusion obligation for a completed assisted Work Runtime Turn.
+// The obligation is independent of any Runtime Continuation: the source
+// continuation is retained only as correlation for the initial dispatch.
+// Replay returns the original obligation.
+func (e *Engine) RecordBlackboardConclusionCheckpoint(ownerID, continuationID, sourceRequestID, sourceSessionID, sourceTurnID string, sourceSelection Selection, watermarks SemanticDebtWatermarks) (BlackboardConclusionReceipt, bool, error) {
+	checkpoint, valid := (owner.ConclusionCheckpointInput{
+		OwnerID: ownerID, ContinuationID: continuationID, SourceRequestID: sourceRequestID,
+		SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
+		ModelProviderID: sourceSelection.ModelProviderID, Model: sourceSelection.Model,
+		ReasoningEffort: sourceSelection.ReasoningEffort, Watermarks: watermarks,
+	}).Normalize()
+	if !valid {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	ownerID, continuationID, sourceRequestID = checkpoint.OwnerID, checkpoint.ContinuationID, checkpoint.SourceRequestID
+	sourceSessionID, sourceTurnID, watermarks = checkpoint.SourceSessionID, checkpoint.SourceTurnID, checkpoint.Watermarks
+	sourceSelection = Selection{ModelProviderID: checkpoint.ModelProviderID, Model: checkpoint.Model, ReasoningEffort: checkpoint.ReasoningEffort}
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" obligation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var continuationOwnerID string
+	if err := tx.QueryRow(`SELECT `+e.Dialect.ContinuationOwnerColumn+` FROM `+e.Dialect.ContinuationsTable+` WHERE id=?`, continuationID).Scan(&continuationOwnerID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return BlackboardConclusionReceipt{}, false, ErrOwnerNotFound
+		}
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("load "+e.Dialect.Subject+" Continuation: %w", err)
+	}
+	if continuationOwnerID != ownerID {
+		return BlackboardConclusionReceipt{}, false, ErrOwnerNotFound
+	}
+
+	prior, err := e.scanPendingBlackboardConclusion(tx.QueryRow(`SELECT `+e.obligationColumns()+`
+		FROM `+e.Dialect.ObligationsTable+` WHERE `+e.Dialect.OwnerColumn+`=? AND source_session_id=? AND source_turn_id=?`, ownerID, sourceSessionID, sourceTurnID))
+	if err == nil {
+		view, scanErr := e.combinedConclusionView(tx, prior)
+		if scanErr != nil {
+			return BlackboardConclusionReceipt{}, false, scanErr
+		}
+		return view, false, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("load "+e.Dialect.Subject+" obligation: %w", err)
+	}
+
+	now := time.Now().UTC()
+	obligationState, phase := owner.InitialConclusionCheckpoint(watermarks)
+	obligation := PendingBlackboardConclusion{
+		ID: e.Dialect.NewID(), OwnerID: ownerID, SourceRequestID: sourceRequestID, SourceRequestCorrelationExact: true,
+		SourceContinuationID: continuationID, SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
+		State: obligationState, SourceWorkWatermark: watermarks.SourceWork,
+		SemanticPersistenceWatermark: watermarks.SemanticPersistence,
+		SourceSelection:              sourceSelection, CreatedAt: now, UpdatedAt: now,
+	}
+	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.ObligationsTable+`
+		(id,`+e.Dialect.OwnerColumn+`,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,state,source_work_watermark,semantic_persistence_watermark,
+		 source_model_provider_id,source_model,source_reasoning_effort,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, obligation.ID, obligation.OwnerID, obligation.SourceRequestID,
+		obligation.SourceRequestCorrelationExact, obligation.SourceContinuationID, obligation.SourceSessionID, obligation.SourceTurnID,
+		string(obligation.State), obligation.SourceWorkWatermark, obligation.SemanticPersistenceWatermark,
+		obligation.SourceSelection.ModelProviderID, obligation.SourceSelection.Model, obligation.SourceSelection.ReasoningEffort,
+		obligation.CreatedAt.Format(time.RFC3339Nano), obligation.UpdatedAt.Format(time.RFC3339Nano)); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store "+e.Dialect.Subject+" obligation: %w", err)
+	}
+
+	view := obligationView(obligation)
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+		"phase": phase, "receipt_id": obligation.ID, "source_turn_id": obligation.SourceTurnID,
+		"source_work_watermark": obligation.SourceWorkWatermark, "semantic_persistence_watermark": obligation.SemanticPersistenceWatermark,
+	}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit "+e.Dialect.Subject+" obligation: %w", err)
+	}
+	return view, true, nil
+}
+
+// ClaimBlackboardConclusionDispatch creates the initial Conclusion Dispatch
+// for a pending obligation, bound immutably to the source continuation and
+// source session of the completed Work Runtime Turn. Replaying the same claim
+// returns the existing active dispatch unchanged.
+func (e *Engine) ClaimBlackboardConclusionDispatch(obligationID string, baseRevision int) (BlackboardConclusionReceipt, bool, error) {
+	obligationID = strings.TrimSpace(obligationID)
+	if obligationID == "" || baseRevision < 0 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" dispatch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, err := e.loadPendingBlackboardConclusionByID(tx, obligationID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if obligation.State != BlackboardConclusionReceiptPending {
+		if obligation.State == BlackboardConclusionReceiptClean {
+			view, viewErr := e.combinedConclusionView(tx, obligation)
+			return view, false, viewErr
+		}
+		// Replay: the obligation already claimed the deterministic initial
+		// dispatch. Return the existing ACTIVE dispatch unchanged when its
+		// request lineage and base revision match this replay.
+		dispatchID, _ := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
+		existing, err := e.activeConclusionDispatchTx(tx, obligation.ID)
+		if err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		if existing != nil && existing.DispatchRequestID == dispatchID && existing.BaseRevision != nil && *existing.BaseRevision == baseRevision {
+			view, viewErr := e.combinedConclusionView(tx, obligation)
+			return view, false, viewErr
+		}
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	dispatchID, applyKey := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
+	now := time.Now().UTC()
+	dispatch := ConclusionDispatch{
+		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindInitial,
+		ContinuationID: obligation.SourceContinuationID, SourceSessionID: obligation.SourceSessionID,
+		DispatchRequestID: dispatchID, BaseRevision: intPointer(baseRevision),
+		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
+	}
+	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
+		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)`, dispatch.ID, dispatch.ObligationID, string(dispatch.Kind), dispatch.ContinuationID,
+		dispatch.SourceSessionID, dispatch.DispatchRequestID, baseRevision, string(dispatch.DeliveryState),
+		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store initial Conclusion Dispatch: %w", err)
+	}
+	obligation.State = BlackboardConclusionReceiptDispatchRequested
+	obligation.ApplyIdempotencyKey = applyKey
+	obligation.AutomaticTurnCount = 1
+	obligation.BaseRevision = intPointer(baseRevision)
+	obligation.UpdatedAt = now
+	if _, err := tx.Exec(`UPDATE `+e.Dialect.ObligationsTable+`
+		SET state=?,apply_idempotency_key=?,automatic_turn_count=?,base_revision=?,updated_at=? WHERE id=?`,
+		string(obligation.State), applyKey, obligation.AutomaticTurnCount, baseRevision, now.Format(time.RFC3339Nano), obligation.ID); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("advance "+e.Dialect.Subject+" obligation: %w", err)
+	}
+	view := obligationView(obligation)
+	view.ActiveDispatchID = dispatch.ID
+	view.DispatchKind = dispatch.Kind
+	view.DispatchRequestID = dispatch.DispatchRequestID
+	view.ContinuationID = dispatch.ContinuationID
+	view.SourceSessionID = dispatch.SourceSessionID
+	view.BaseRevision = dispatch.BaseRevision
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+		"phase": "dispatch_requested", "receipt_id": obligation.ID, "source_turn_id": obligation.SourceTurnID,
+		"request_id": dispatchID, "base_revision": baseRevision, "turn_kind": "control",
+	}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit "+e.Dialect.Subject+" dispatch: %w", err)
+	}
+	return view, true, nil
+}
+
+// MarkBlackboardConclusionSendStarted closes the provider-acceptance ambiguity
+// window on the ACTIVE dispatch before SendTurn. Only the active dispatch may
+// claim the fence; replay observes the original timestamp.
+func (e *Engine) MarkBlackboardConclusionSendStarted(dispatchRequestID string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || now.IsZero() {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.Exec(`UPDATE `+e.Dialect.DispatchesTable+` SET send_attempt_count=1,send_started_at=?,updated_at=?
+		WHERE dispatch_request_id=? AND delivery_state=? AND send_attempt_count=0 AND send_started_at IS NULL`,
+		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano), dispatchRequestID, string(ConclusionDispatchRequested))
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	changed, _ := result.RowsAffected()
+	view, err := e.conclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if changed == 0 {
+		return view, false, nil
+	}
+	if changed != 1 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return view, true, nil
+}
+
+// MarkBlackboardConclusionAwaiting records provider acceptance of the Conclude
+// Turn on the ACTIVE dispatch. Replaying the same correlation is idempotent.
+func (e *Engine) MarkBlackboardConclusionAwaiting(dispatchRequestID, controlTurnID string) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID, controlTurnID = strings.TrimSpace(dispatchRequestID), strings.TrimSpace(controlTurnID)
+	if dispatchRequestID == "" || controlTurnID == "" {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	return e.advanceActiveConclusionDispatch(dispatchRequestID, ConclusionDispatchRequested, ConclusionDispatchAwaitingResult,
+		BlackboardConclusionReceiptAwaitingResult,
+		func(receipt BlackboardConclusionReceipt) bool { return receipt.ControlTurnID == controlTurnID },
+		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, dispatch *ConclusionDispatch, now time.Time) error {
+			dispatch.DeliveryState = ConclusionDispatchAwaitingResult
+			dispatch.ControlTurnID = controlTurnID
+			if _, err := tx.Exec(`UPDATE `+e.Dialect.DispatchesTable+` SET delivery_state=?,control_turn_id=?,updated_at=? WHERE id=?`,
+				string(dispatch.DeliveryState), controlTurnID, now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
+				return err
+			}
+			return e.appendBlackboardConclusionEventTx(tx, blackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation), map[string]any{
+				"phase": "awaiting_result", "receipt_id": dispatch.ObligationID, "request_id": dispatchRequestID,
+				"source_turn_id": obligation.SourceTurnID, "control_turn_id": controlTurnID, "turn_kind": "control",
+			}, now)
+		})
+}
+
+// HandleBlackboardConclusionFailure durably resolves a failed Conclude Turn.
+// One invalid initial result may claim a single automatic repair, which
+// supersedes the failed dispatch and creates a NEW repair dispatch on the same
+// immutable continuation and source session. Forbidden tool use, runtime
+// failures, and later invalid results become stable operator-actionable states.
+func (e *Engine) HandleBlackboardConclusionFailure(dispatchRequestID string, code BlackboardConclusionErrorCode, detail ConclusionValidationDetail, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || cooldown < 0 ||
+		(code != BlackboardConclusionErrorInvalidResult && code != BlackboardConclusionErrorToolUseForbidden && code != BlackboardConclusionErrorRuntimeRecoveryRequired) {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	if detail.Valid() && code != BlackboardConclusionErrorInvalidResult {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" failure: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, dispatch, err := e.loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if obligation.State == BlackboardConclusionReceiptActionRequired {
+		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
+	}
+	if obligation.State != BlackboardConclusionReceiptAwaitingResult || dispatch.DeliveryState != ConclusionDispatchAwaitingResult {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	if owner.ConclusionRepairAllowed(code, obligation.AutomaticTurnCount, obligation.RepairCount, obligation.VersionRegenerationCount, obligation.ExplicitRetryCount) {
+		repairNumber := obligation.RepairCount + 1
+		requestID := blackboardConclusionAttemptRequestID("repair", dispatch.ContinuationID, obligation.SourceTurnID, repairNumber, "")
+		nextEligible := now.Add(cooldown)
+		nowDispatch := ConclusionDispatch{
+			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRepair,
+			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
+			DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
+			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
+		}
+		if err := e.supersedeActiveDispatchTx(tx, dispatch, "superseded_by_repair", now); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
+			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
+			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store repair Conclusion Dispatch: %w", err)
+		}
+		obligation.State = BlackboardConclusionReceiptRepairDispatchRequested
+		obligation.AutomaticTurnCount++
+		obligation.RepairCount++
+		obligation.ErrorCode = code
+		obligation.NextEligibleAt = &nextEligible
+		obligation.ValidationReason = detail.Reason
+		obligation.ValidationFieldPath = detail.FieldPath
+		obligation.ValidationExpected = detail.Expected
+		obligation.UpdatedAt = now
+		if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		view := obligationView(obligation)
+		view.ActiveDispatchID = nowDispatch.ID
+		view.DispatchKind = nowDispatch.Kind
+		view.DispatchRequestID = nowDispatch.DispatchRequestID
+		view.ContinuationID = nowDispatch.ContinuationID
+		view.SourceSessionID = nowDispatch.SourceSessionID
+		view.BaseRevision = nowDispatch.BaseRevision
+		payload := map[string]any{"phase": "repair_requested", "receipt_id": obligation.ID, "request_id": requestID,
+			"error_code": string(code), "automatic_turn_count": obligation.AutomaticTurnCount, "repair_count": obligation.RepairCount, "turn_kind": "control"}
+		owner.AppendConclusionValidationEventPayload(payload, detail)
+		if err := e.appendBlackboardConclusionEventTx(tx, view, payload, now); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		return view, true, nil
+	}
+	actionCode := owner.ConclusionFailureActionCode(code, obligation.RepairCount, obligation.VersionRegenerationCount)
+	nextEligible := now.Add(cooldown)
+	if obligation.NextEligibleAt != nil {
+		nextEligible = obligation.NextEligibleAt.UTC()
+	}
+	var failErr error
+	obligation, failErr = e.failActiveDispatchTx(tx, obligation, dispatch, actionCode, nextEligible, detail, now)
+	if failErr != nil {
+		return BlackboardConclusionReceipt{}, false, failErr
+	}
+	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
+	payload := map[string]any{"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
+		"error_code": string(actionCode), "next_eligible_at": nextEligible.Format(time.RFC3339Nano)}
+	owner.AppendConclusionValidationEventPayload(payload, detail)
+	if err := e.appendBlackboardConclusionEventTx(tx, view, payload, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return view, true, nil
+}
+
+// ClaimBlackboardConclusionVersionSync records the intent to synchronize the
+// active dispatch's continuation before version regeneration can be claimed.
+func (e *Engine) ClaimBlackboardConclusionVersionSync(dispatchRequestID string) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	return e.advanceObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptValidated,
+		BlackboardConclusionReceiptVersionSyncRequested,
+		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
+			obligation.State = BlackboardConclusionReceiptVersionSyncRequested
+			obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
+			obligation.UpdatedAt = now
+			if _, err := tx.Exec(`UPDATE `+e.Dialect.ObligationsTable+` SET state=?,error_code=?,updated_at=? WHERE id=?`,
+				string(obligation.State), string(obligation.ErrorCode), now.Format(time.RFC3339Nano), obligation.ID); err != nil {
+				return err
+			}
+			return e.appendBlackboardConclusionEventTx(tx, obligationView(*obligation), map[string]any{
+				"phase": "version_sync_requested", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
+				"turn_kind": "control",
+			}, now)
+		})
+}
+
+// HandleBlackboardConclusionVersionConflict discards a validated result whose
+// revision guard lost a real race and claims one fresh semantic generation.
+// The old validated dispatch is superseded and a NEW version_regeneration
+// dispatch is created; budgets belong to the obligation and never reset.
+func (e *Engine) HandleBlackboardConclusionVersionConflict(dispatchRequestID string, currentRevision int, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || currentRevision < 0 || cooldown < 0 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" version conflict: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, dispatch, err := e.loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if obligation.State == BlackboardConclusionReceiptActionRequired && obligation.ErrorCode == BlackboardConclusionErrorVersionConflict {
+		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
+	}
+	if obligation.State != BlackboardConclusionReceiptVersionSyncRequested || dispatch.BaseRevision == nil || currentRevision <= *dispatch.BaseRevision {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	nextEligible := now.Add(cooldown)
+	if owner.ConclusionVersionRegenerationAllowed(obligation.VersionRegenerationCount, obligation.AutomaticTurnCount, obligation.ExplicitRetryCount) {
+		requestID := blackboardConclusionAttemptRequestID("version", dispatch.ContinuationID, obligation.SourceTurnID, 1, fmt.Sprintf("%d", currentRevision))
+		nowDispatch := ConclusionDispatch{
+			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindVersionRegeneration,
+			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
+			DispatchRequestID: requestID, BaseRevision: intPointer(currentRevision),
+			SynchronizedRevision: intPointer(currentRevision), DeliveryState: ConclusionDispatchRequested,
+			CreatedAt: now, UpdatedAt: now,
+		}
+		if err := e.supersedeActiveDispatchTx(tx, dispatch, "superseded_by_version_regeneration", now); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
+			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,synchronized_revision,delivery_state,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, currentRevision, currentRevision, string(nowDispatch.DeliveryState),
+			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store version regeneration Conclusion Dispatch: %w", err)
+		}
+		obligation.State = BlackboardConclusionReceiptVersionRegenerationDispatchRequested
+		obligation.VersionRegenerationCount = 1
+		obligation.AutomaticTurnCount++
+		obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
+		obligation.NextEligibleAt = &nextEligible
+		obligation.CanonicalResultJSON = nil
+		obligation.CanonicalResultSHA256 = ""
+		obligation.UpdatedAt = now
+		if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		view := obligationView(obligation)
+		view.ActiveDispatchID = nowDispatch.ID
+		view.DispatchKind = nowDispatch.Kind
+		view.DispatchRequestID = nowDispatch.DispatchRequestID
+		view.ContinuationID = nowDispatch.ContinuationID
+		view.SourceSessionID = nowDispatch.SourceSessionID
+		view.BaseRevision = nowDispatch.BaseRevision
+		view.SynchronizedRevision = nowDispatch.SynchronizedRevision
+		if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+			"phase": "version_regeneration_requested", "receipt_id": obligation.ID, "request_id": requestID,
+			"base_revision": currentRevision, "error_code": string(BlackboardConclusionErrorVersionConflict),
+			"automatic_turn_count": obligation.AutomaticTurnCount, "version_regeneration_count": obligation.VersionRegenerationCount,
+			"turn_kind": "control",
+		}, now); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		return view, true, nil
+	}
+
+	obligation.State = BlackboardConclusionReceiptActionRequired
+	obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
+	obligation.NextEligibleAt = &nextEligible
+	obligation.BaseRevision = intPointer(currentRevision)
+	obligation.CanonicalResultJSON = nil
+	obligation.CanonicalResultSHA256 = ""
+	obligation.UpdatedAt = now
+	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := e.supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
+		"base_revision": currentRevision, "error_code": string(BlackboardConclusionErrorVersionConflict),
+		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "version_regeneration_exhausted",
+	}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return view, true, nil
+}
+
+// MarkBlackboardConclusionVersionConflictActionRequired rejects a validated
+// result whose record or change versions are semantically incompatible with
+// the apply contract and requires operator action immediately.
+func (e *Engine) MarkBlackboardConclusionVersionConflictActionRequired(dispatchRequestID string, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	return e.MarkBlackboardConclusionApplyActionRequired(dispatchRequestID, BlackboardConclusionErrorVersionConflict, now, cooldown)
+}
+
+// MarkBlackboardConclusionApplyActionRequired fails closed when a validated
+// result cannot be applied or its pre-regeneration synchronization fails.
+func (e *Engine) MarkBlackboardConclusionApplyActionRequired(dispatchRequestID string, code BlackboardConclusionErrorCode, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || cooldown < 0 || !validBlackboardConclusionErrorCode(code) {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin incompatible "+e.Dialect.Subject+" version: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, dispatch, err := e.loadConclusionByDispatchRequestID(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if obligation.State == BlackboardConclusionReceiptActionRequired && obligation.ErrorCode == code {
+		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
+	}
+	if obligation.State != BlackboardConclusionReceiptValidated && obligation.State != BlackboardConclusionReceiptVersionSyncRequested {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	nextEligible := now.Add(cooldown)
+	obligation.State = BlackboardConclusionReceiptActionRequired
+	obligation.ErrorCode = code
+	obligation.NextEligibleAt = &nextEligible
+	obligation.CanonicalResultJSON = nil
+	obligation.CanonicalResultSHA256 = ""
+	obligation.UpdatedAt = now
+	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := e.supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
+		"base_revision": intPointerValue(dispatch.BaseRevision), "error_code": string(code),
+		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "apply_failed",
+	}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return view, true, nil
+}
+
+// MarkBlackboardConclusionRecoveryActionRequired closes crash windows after a
+// repair, version sync/regeneration, or operator-authorized retry was durably
+// claimed but could not finish. The reason is a closed operator-visible token.
+func (e *Engine) MarkBlackboardConclusionRecoveryActionRequired(dispatchRequestID string, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || !owner.ValidConclusionRecoveryReason(reason) || cooldown < 0 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, dispatch, err := e.loadConclusionByDispatchRequestID(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	return e.markConclusionRecoveryActionRequiredTx(tx, obligation, dispatch, reason, now, cooldown)
+}
+
+// MarkBlackboardConclusionRecoveryActionRequiredByReceiptID resolves any
+// restart-stranded pre-apply obligation, including pending obligations that do
+// not yet have a dispatch. Replays preserve the original cooldown and counters.
+func (e *Engine) MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligationID string, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	obligationID = strings.TrimSpace(obligationID)
+	if obligationID == "" || !owner.ValidConclusionRecoveryReason(reason) || cooldown < 0 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" dispatch recovery: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, err := e.loadPendingBlackboardConclusionByID(tx, obligationID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	dispatch, err := e.activeConclusionDispatchTx(tx, obligation.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return e.markConclusionRecoveryActionRequiredTx(tx, obligation, dispatch, reason, now, cooldown)
+}
+
+func (e *Engine) markConclusionRecoveryActionRequiredTx(tx *sql.Tx, obligation PendingBlackboardConclusion, dispatch *ConclusionDispatch, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	if obligation.State == BlackboardConclusionReceiptActionRequired {
+		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
+	}
+	if !owner.ConclusionRecoveryEligible(obligation.State) {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	nextEligible := now.Add(cooldown)
+	if obligation.NextEligibleAt != nil {
+		nextEligible = obligation.NextEligibleAt.UTC()
+	}
+	obligation.State = BlackboardConclusionReceiptActionRequired
+	obligation.ErrorCode = BlackboardConclusionErrorRuntimeRecoveryRequired
+	obligation.RecoveryReason = reason
+	obligation.NextEligibleAt = &nextEligible
+	obligation.UpdatedAt = now
+	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	// Supersede ANY active dispatch so a later provider callback resolves to a
+	// terminal delivery and is recorded as a late outcome instead of being
+	// silently dropped while the obligation is already action_required.
+	if dispatch != nil && owner.ConclusionDispatchActive(dispatch.DeliveryState) {
+		if err := e.supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+	}
+	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+		"phase": "action_required", "receipt_id": obligation.ID, "request_id": obligationDispatchRequestID(dispatch),
+		"error_code": string(obligation.ErrorCode), "recovery_reason": string(reason),
+		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "dispatch_recovery",
+	}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return view, true, nil
+}
+
+// MarkBlackboardConclusionWorkTurnConflict resolves a conclusion dispatch that
+// a non-yielding provider work turn refused. Within the bounded conflict
+// budget it stays operator-retryable; once exhausted it becomes the distinct,
+// non-retryable never-settled terminal.
+func (e *Engine) MarkBlackboardConclusionWorkTurnConflict(dispatchRequestID string, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || cooldown < 0 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" work turn conflict: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, dispatch, err := e.loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if obligation.State == BlackboardConclusionReceiptActionRequired {
+		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
+	}
+	eligible := dispatch.DeliveryState == ConclusionDispatchRequested
+	if !eligible {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	errorCode, reason := owner.ConclusionWorkTurnConflictOutcome(obligation.ExplicitRetryCount)
+	nextEligible := now.Add(cooldown)
+	if obligation.NextEligibleAt != nil {
+		nextEligible = obligation.NextEligibleAt.UTC()
+	}
+	obligation.State = BlackboardConclusionReceiptActionRequired
+	obligation.ErrorCode = errorCode
+	obligation.NextEligibleAt = &nextEligible
+	obligation.UpdatedAt = now
+	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := e.supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
+		"error_code": string(errorCode), "next_eligible_at": nextEligible.Format(time.RFC3339Nano),
+		"reason": reason, "explicit_retry_count": obligation.ExplicitRetryCount,
+	}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return view, true, nil
+}
+
+// BlackboardConclusionRecoveryCandidates lists obligations in pre-apply states
+// for an ownership-aware daemon coordinator. It never mutates state.
+func (e *Engine) BlackboardConclusionRecoveryCandidates() ([]BlackboardConclusionReceipt, error) {
+	rows, err := e.DB.Query(`SELECT `+e.obligationColumns()+` FROM `+e.Dialect.ObligationsTable+`
+		WHERE state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
+		string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
+		string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
+		string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
+	if err != nil {
+		return nil, fmt.Errorf("list "+e.Dialect.Subject+" recovery candidates: %w", err)
+	}
+	var obligations []PendingBlackboardConclusion
+	for rows.Next() {
+		obligation, scanErr := e.scanPendingBlackboardConclusion(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan "+e.Dialect.Subject+" recovery candidate: %w", scanErr)
+		}
+		obligations = append(obligations, obligation)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate "+e.Dialect.Subject+" recovery candidates: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close "+e.Dialect.Subject+" recovery candidates: %w", err)
+	}
+	views := make([]BlackboardConclusionReceipt, 0, len(obligations))
+	for _, obligation := range obligations {
+		view, viewErr := e.combinedConclusionView(e.DB, obligation)
+		if viewErr != nil {
+			return nil, fmt.Errorf("scan "+e.Dialect.Subject+" recovery candidate view: %w", viewErr)
+		}
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+// ReconcileStrandedBlackboardConclusionRecoveries makes durably claimed
+// repair, version sync/regeneration, and explicit retry work
+// operator-actionable after daemon restart. It excludes indistinguishable
+// initial dispatch claims (their independent recovery policy cannot be
+// inferred) unless an explicit retry was already recorded.
+func (e *Engine) ReconcileStrandedBlackboardConclusionRecoveries(now time.Time, cooldown time.Duration) ([]BlackboardConclusionReceipt, error) {
+	if cooldown < 0 {
+		return nil, ErrInvalidBlackboardConclusionReceipt
+	}
+	// Task reconciliation only strands obligations that claimed dispatch work;
+	// Non-Project Session reconciliation also strands never-dispatched pending
+	// obligations, because a stopped Session cannot resume its dispatch loop.
+	var rows *sql.Rows
+	var err error
+	if e.Dialect.ReconcilePendingObligations {
+		rows, err = e.DB.Query(`SELECT `+e.obligationColumns()+` FROM `+e.Dialect.ObligationsTable+`
+			WHERE state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
+			string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
+			string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
+			string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
+	} else {
+		rows, err = e.DB.Query(`SELECT `+e.obligationColumns()+` FROM `+e.Dialect.ObligationsTable+`
+			WHERE state IN (?,?,?) OR (state=? AND explicit_retry_count>0) OR (state=? AND (repair_count>0 OR version_regeneration_count>0 OR explicit_retry_count>0))
+			ORDER BY created_at,id`, string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested), string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptDispatchRequested),
+			string(BlackboardConclusionReceiptAwaitingResult))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list stranded "+e.Dialect.Subject+" recoveries: %w", err)
+	}
+	var obligations []PendingBlackboardConclusion
+	for rows.Next() {
+		obligation, scanErr := e.scanPendingBlackboardConclusion(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan stranded "+e.Dialect.Subject+" recovery: %w", scanErr)
+		}
+		obligations = append(obligations, obligation)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate stranded "+e.Dialect.Subject+" recoveries: %w", err)
+	}
+	_ = rows.Close()
+	reconciled := make([]BlackboardConclusionReceipt, 0, len(obligations))
+	for _, obligation := range obligations {
+		receipt, changed, err := e.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligation.ID, ConclusionRecoveryDispatchFailed, now, cooldown)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			reconciled = append(reconciled, receipt)
+		}
+	}
+	return reconciled, nil
+}
+
+// RetryBlackboardConclusion atomically claims one operator-authorized retry for
+// an action_required obligation. The retry supersedes the failed dispatch and
+// creates a NEW retry dispatch bound to the same immutable continuation and
+// source session. A never-dispatched obligation is re-armed to pending so the
+// initial dispatch claim runs on the live runtime.
+func (e *Engine) RetryBlackboardConclusion(obligationID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	obligationID, idempotencyKey = strings.TrimSpace(obligationID), strings.TrimSpace(idempotencyKey)
+	if obligationID == "" || idempotencyKey == "" {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, err := e.loadPendingBlackboardConclusionByID(tx, obligationID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	receipt, won, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
+	if err != nil || !won {
+		return receipt, won, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return receipt, true, nil
+}
+
+// RetryLatestBlackboardConclusion atomically applies a Task-scoped operator
+// retry key to the latest durable conclusion obligation.
+func (e *Engine) RetryLatestBlackboardConclusion(ownerID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	ownerID, idempotencyKey = strings.TrimSpace(ownerID), strings.TrimSpace(idempotencyKey)
+	if ownerID == "" || idempotencyKey == "" {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, err := e.scanPendingBlackboardConclusion(tx.QueryRow(`SELECT `+e.obligationColumns()+`
+		FROM `+e.Dialect.ObligationsTable+` WHERE `+e.Dialect.OwnerColumn+`=? ORDER BY created_at DESC,id DESC LIMIT 1`, ownerID))
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	receipt, won, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
+	if err != nil || !won {
+		return receipt, won, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return receipt, true, nil
+}
+
+func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	var priorObligationID string
+	err := tx.QueryRow(`SELECT `+e.Dialect.RetryKeysReceiptColumn+` FROM `+e.Dialect.RetryKeysTable+`
+		WHERE `+e.Dialect.RetryKeysOwnerColumn+`=? AND idempotency_key=?`, obligation.OwnerID, idempotencyKey).Scan(&priorObligationID)
+	if err == nil {
+		prior, loadErr := e.loadPendingBlackboardConclusionByID(tx, priorObligationID)
+		if loadErr != nil {
+			return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(loadErr)
+		}
+		view, viewErr := e.combinedConclusionView(tx, prior)
+		if viewErr != nil {
+			return BlackboardConclusionReceipt{}, false, viewErr
+		}
+		return view, false, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("read "+e.Dialect.Subject+" retry idempotency history: %w", err)
+	}
+	switch owner.ConclusionRetryDecisionFor(obligation.State, obligation.ErrorCode, obligation.RecoveryReason, obligation.NextEligibleAt, now) {
+	case owner.ConclusionRetryInvalidState:
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	case owner.ConclusionRetryNeverSettled:
+		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionWorkTurnNeverSettled
+	case owner.ConclusionRetryAcceptanceAmbiguous, owner.ConclusionRetryCooldown:
+		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
+	}
+	dispatch, err := e.activeConclusionDispatchTx(tx, obligation.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if dispatch == nil {
+		// No active dispatch (for example the failed repair was superseded).
+		// Bind the retry to the LATEST dispatch's immutable binding, which is
+		// either the live replacement (after a steer recovery) or the original
+		// source binding of the completed Work Turn.
+		dispatch, err = e.latestConclusionDispatchTx(tx, obligation.ID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+	}
+	retryNumber := obligation.ExplicitRetryCount + 1
+	if dispatch == nil {
+		// Never-dispatched obligation: re-arm to pending so the initial claim
+		// runs on the live runtime. The retry history records the deterministic
+		// initial request lineage.
+		initialRequestID, _ := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
+		obligation.State = BlackboardConclusionReceiptPending
+		obligation.ExplicitRetryCount++
+		obligation.OperatorRetryKey = idempotencyKey
+		obligation.ErrorCode = ""
+		obligation.NextEligibleAt = nil
+		obligation.UpdatedAt = now
+		if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.RetryKeysTable+`
+			(`+e.Dialect.RetryKeysOwnerColumn+`,`+e.Dialect.RetryKeysReceiptColumn+`,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
+			obligation.OwnerID, obligation.ID, idempotencyKey, initialRequestID, now.Format(time.RFC3339Nano)); err != nil {
+			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store pending "+e.Dialect.Subject+" retry history: %w", err)
+		}
+		if err := e.appendBlackboardConclusionEventTx(tx, obligationView(obligation), map[string]any{
+			"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": initialRequestID,
+			"explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control",
+		}, now); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+		return obligationView(obligation), true, nil
+	}
+	requestID := blackboardConclusionAttemptRequestID("retry", dispatch.ContinuationID, obligation.SourceTurnID, retryNumber, idempotencyKey)
+	nowDispatch := ConclusionDispatch{
+		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRetry,
+		ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
+		DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
+		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := e.supersedeActiveDispatchTx(tx, dispatch, "superseded_by_retry", now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
+		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
+		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store retry Conclusion Dispatch: %w", err)
+	}
+	obligation.State = BlackboardConclusionReceiptDispatchRequested
+	obligation.ExplicitRetryCount++
+	obligation.OperatorRetryKey = idempotencyKey
+	obligation.ErrorCode = ""
+	obligation.NextEligibleAt = nil
+	// The operator retry starts a fresh generation: the previous validated
+	// result and its bounded rejection detail are no longer current.
+	obligation.CanonicalResultJSON = nil
+	obligation.CanonicalResultSHA256 = ""
+	obligation.ValidationReason = ""
+	obligation.ValidationFieldPath = ""
+	obligation.ValidationExpected = ""
+	obligation.UpdatedAt = now
+	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.RetryKeysTable+`
+		(`+e.Dialect.RetryKeysOwnerColumn+`,`+e.Dialect.RetryKeysReceiptColumn+`,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
+		obligation.OwnerID, obligation.ID, idempotencyKey, requestID, now.Format(time.RFC3339Nano)); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store "+e.Dialect.Subject+" retry idempotency history: %w", err)
+	}
+	view := obligationView(obligation)
+	view.ActiveDispatchID = nowDispatch.ID
+	view.DispatchKind = nowDispatch.Kind
+	view.DispatchRequestID = nowDispatch.DispatchRequestID
+	view.ContinuationID = nowDispatch.ContinuationID
+	view.SourceSessionID = nowDispatch.SourceSessionID
+	view.BaseRevision = nowDispatch.BaseRevision
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": requestID, "explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control"}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	return view, true, nil
+}
+
+// BlackboardConclusionByDispatchRequestID resolves the obligation whose ACTIVE
+// dispatch owns the provider request correlation. Only the ACTIVE dispatch may
+// validate or apply a result: a callback that resolves to a superseded or late
+// dispatch is durably recorded as a late terminal delivery outcome and returns
+// ErrBlackboardConclusionDispatchInactive so the coordinator drops it. It can
+// never mutate the obligation or Blackboard (ADR 0021).
+func (e *Engine) BlackboardConclusionByDispatchRequestID(dispatchRequestID string) (BlackboardConclusionReceipt, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" {
+		return BlackboardConclusionReceipt{}, ErrInvalidBlackboardConclusionReceipt
+	}
+	dispatch, err := e.scanConclusionDispatch(e.DB.QueryRow(`SELECT `+conclusionDispatchColumns+`
+		FROM `+e.Dialect.DispatchesTable+` WHERE dispatch_request_id=?`, dispatchRequestID))
+	if err != nil {
+		return BlackboardConclusionReceipt{}, e.blackboardConclusionLookupError(err)
+	}
+	obligation, err := e.loadPendingBlackboardConclusionByID(e.DB, dispatch.ObligationID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, e.blackboardConclusionLookupError(err)
+	}
+	if !e.conclusionDispatchIsActive(dispatch.DeliveryState) {
+		// A late or duplicate result for an obsolete dispatch. Record the
+		// bounded late outcome on this dispatch (idempotent) and reject the
+		// callback so it cannot settle or corrupt the current obligation.
+		if dispatch.DeliveryState == ConclusionDispatchSuperseded {
+			_, _ = e.DB.Exec(`UPDATE `+e.Dialect.DispatchesTable+` SET delivery_state=?,terminal_outcome=?,updated_at=?
+				WHERE dispatch_request_id=? AND delivery_state=?`,
+				string(ConclusionDispatchLateTerminal), "late_result", time.Now().UTC().Format(time.RFC3339Nano),
+				dispatchRequestID, string(ConclusionDispatchSuperseded))
+		}
+		return BlackboardConclusionReceipt{}, ErrBlackboardConclusionDispatchInactive
+	}
+	return blackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
+}
+
+// RecordLateConclusionDispatchOutcome durably records a callback that resolved
+// to a superseded dispatch: the dispatch becomes late_terminal and can never
+// advance the obligation. It is idempotent.
+func (e *Engine) RecordLateConclusionDispatchOutcome(dispatchRequestID string) error {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" {
+		return ErrInvalidBlackboardConclusionReceipt
+	}
+	_, err := e.DB.Exec(`UPDATE `+e.Dialect.DispatchesTable+` SET delivery_state=?,terminal_outcome=?,updated_at=?
+		WHERE dispatch_request_id=? AND delivery_state=?`,
+		string(ConclusionDispatchLateTerminal), "late_result", time.Now().UTC().Format(time.RFC3339Nano),
+		dispatchRequestID, string(ConclusionDispatchSuperseded))
+	return err
+}
+
+func (e *Engine) conclusionDispatchIsActive(state ConclusionDispatchState) bool {
+	return owner.ConclusionDispatchActive(state)
+}
+
+// MarkBlackboardConclusionValidated persists canonical closed result bytes on
+// the obligation before Blackboard application.
+func (e *Engine) MarkBlackboardConclusionValidated(dispatchRequestID string, canonicalResult []byte) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || len(canonicalResult) == 0 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	canonicalResult = append([]byte(nil), canonicalResult...)
+	hash := owner.CanonicalConclusionSHA256(canonicalResult)
+	return e.advanceObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptAwaitingResult,
+		BlackboardConclusionReceiptValidated,
+		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
+			obligation.State = BlackboardConclusionReceiptValidated
+			obligation.CanonicalResultJSON = canonicalResult
+			obligation.CanonicalResultSHA256 = hash
+			obligation.ErrorCode = ""
+			obligation.NextEligibleAt = nil
+			obligation.UpdatedAt = now
+			if _, err := tx.Exec(`UPDATE `+e.Dialect.ObligationsTable+`
+				SET state=?,canonical_result_json=?,canonical_result_sha256=?,error_code=NULL,next_eligible_at=NULL,updated_at=? WHERE id=?`,
+				string(obligation.State), canonicalResult, hash, now.Format(time.RFC3339Nano), obligation.ID); err != nil {
+				return err
+			}
+			dispatch, err := e.activeConclusionDispatchTx(tx, obligation.ID)
+			if err != nil {
+				return err
+			}
+			if dispatch == nil {
+				return ErrInvalidBlackboardConclusionReceipt
+			}
+			dispatch.DeliveryState = ConclusionDispatchValidated
+			if _, err := tx.Exec(`UPDATE `+e.Dialect.DispatchesTable+` SET delivery_state=?,updated_at=? WHERE id=?`,
+				string(dispatch.DeliveryState), now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
+				return err
+			}
+			view := blackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation)
+			return e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+				"phase": "result_validated", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
+				"source_turn_id": obligation.SourceTurnID, "control_turn_id": dispatch.ControlTurnID, "result_hash": hash,
+			}, now)
+		})
+}
+
+// MarkBlackboardConclusionApplied completes the obligation with the exact
+// Blackboard revision returned by ApplyForContinuation.
+func (e *Engine) MarkBlackboardConclusionApplied(dispatchRequestID string, appliedRevision int) (BlackboardConclusionReceipt, bool, error) {
+	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
+	if dispatchRequestID == "" || appliedRevision < 0 {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	return e.advanceObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptValidated,
+		BlackboardConclusionReceiptApplied,
+		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
+			obligation.State = BlackboardConclusionReceiptApplied
+			obligation.AppliedRevision = intPointer(appliedRevision)
+			obligation.UpdatedAt = now
+			if _, err := tx.Exec(`UPDATE `+e.Dialect.ObligationsTable+` SET state=?,applied_revision=?,updated_at=? WHERE id=?`,
+				string(obligation.State), appliedRevision, now.Format(time.RFC3339Nano), obligation.ID); err != nil {
+				return err
+			}
+			dispatch, err := e.activeConclusionDispatchTx(tx, obligation.ID)
+			if err != nil {
+				return err
+			}
+			if dispatch == nil {
+				return ErrInvalidBlackboardConclusionReceipt
+			}
+			dispatch.DeliveryState = ConclusionDispatchApplied
+			dispatch.TerminalOutcome = "applied"
+			if _, err := tx.Exec(`UPDATE `+e.Dialect.DispatchesTable+` SET delivery_state=?,terminal_outcome=?,updated_at=? WHERE id=?`,
+				string(dispatch.DeliveryState), dispatch.TerminalOutcome, now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
+				return err
+			}
+			view := blackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation)
+			return e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+				"phase": "applied", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
+				"source_turn_id": obligation.SourceTurnID, "control_turn_id": dispatch.ControlTurnID, "applied_revision": appliedRevision,
+			}, now)
+		})
+}
+
+// LatestBlackboardConclusion returns the newest durable obligation for a Task
+// together with its ACTIVE dispatch.
+func (e *Engine) LatestBlackboardConclusion(ownerID string) (*BlackboardConclusionReceipt, error) {
+	obligation, err := e.scanPendingBlackboardConclusion(e.DB.QueryRow(`
+		SELECT `+e.obligationColumns()+`
+		FROM `+e.Dialect.ObligationsTable+` WHERE `+e.Dialect.OwnerColumn+`=? ORDER BY created_at DESC,id DESC LIMIT 1`, ownerID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load latest "+e.Dialect.Subject+" obligation: %w", err)
+	}
+	view, err := e.combinedConclusionView(e.DB, obligation)
+	if err != nil {
+		return nil, err
+	}
+	return &view, nil
+}
+
+// ValidatedBlackboardConclusions returns durable apply intents for daemon
+// startup replay. It is read-only and preserves canonical and idempotency
+// lineage exactly as stored.
+func (e *Engine) ValidatedBlackboardConclusions() ([]BlackboardConclusionReceipt, error) {
+	rows, err := e.DB.Query(`SELECT `+e.obligationColumns()+`
+		FROM `+e.Dialect.ObligationsTable+` WHERE state=? ORDER BY created_at,id`, string(BlackboardConclusionReceiptValidated))
+	if err != nil {
+		return nil, fmt.Errorf("list validated "+e.Dialect.Subject+"s: %w", err)
+	}
+	var obligations []PendingBlackboardConclusion
+	for rows.Next() {
+		obligation, scanErr := e.scanPendingBlackboardConclusion(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan validated "+e.Dialect.Subject+": %w", scanErr)
+		}
+		obligations = append(obligations, obligation)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate validated "+e.Dialect.Subject+"s: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close validated "+e.Dialect.Subject+"s: %w", err)
+	}
+	views := make([]BlackboardConclusionReceipt, 0, len(obligations))
+	for _, obligation := range obligations {
+		view, viewErr := e.combinedConclusionView(e.DB, obligation)
+		if viewErr != nil {
+			return nil, fmt.Errorf("scan validated "+e.Dialect.Subject+" view: %w", viewErr)
+		}
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+// ConclusionDispatches returns the immutable dispatch history for an
+// obligation, newest first. The obligation row itself is not projected.
+func (e *Engine) ConclusionDispatches(obligationID string) ([]ConclusionDispatch, error) {
+	obligationID = strings.TrimSpace(obligationID)
+	if obligationID == "" {
+		return nil, ErrInvalidBlackboardConclusionReceipt
+	}
+	rows, err := e.DB.Query(`SELECT `+conclusionDispatchColumns+` FROM `+e.Dialect.DispatchesTable+`
+		WHERE obligation_id=? ORDER BY rowid DESC`, obligationID)
+	if err != nil {
+		return nil, fmt.Errorf("list Conclusion Dispatches: %w", err)
+	}
+	defer rows.Close()
+	var dispatches []ConclusionDispatch
+	for rows.Next() {
+		dispatch, scanErr := e.scanConclusionDispatch(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan Conclusion Dispatch: %w", scanErr)
+		}
+		dispatches = append(dispatches, dispatch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate Conclusion Dispatches: %w", err)
+	}
+	return dispatches, nil
+}
+
+// CreateRecoveryConclusionDispatches supersedes every in-flight Conclusion
+// Dispatch of a Task that is bound to the old Continuation and creates a NEW
+// recovery dispatch bound immutably to the replacement Continuation and
+// session. This replaces the old mutable receipt rebinding (#197): historical
+// dispatch identity is never rewritten. The obligation state is re-armed to the
+// matching pre-send protocol state so the daemon can re-dispatch.
+func (e *Engine) CreateRecoveryConclusionDispatches(taskID, oldContinuationID, replacementContinuationID, replacementSessionID string) ([]BlackboardConclusionReceipt, error) {
+	taskID, oldContinuationID, replacementContinuationID, replacementSessionID =
+		strings.TrimSpace(taskID), strings.TrimSpace(oldContinuationID), strings.TrimSpace(replacementContinuationID), strings.TrimSpace(replacementSessionID)
+	if taskID == "" || oldContinuationID == "" || replacementContinuationID == "" || replacementSessionID == "" || oldContinuationID == replacementContinuationID {
+		return nil, ErrInvalidBlackboardConclusionReceipt
+	}
+	now := time.Now().UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin recovery Conclusion Dispatch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.Query(`SELECT `+e.obligationColumns()+` FROM `+e.Dialect.ObligationsTable+`
+		WHERE `+e.Dialect.OwnerColumn+`=? AND state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
+		taskID, string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
+		string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
+		string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
+	if err != nil {
+		return nil, fmt.Errorf("list recovery Conclusion Dispatches: %w", err)
+	}
+	var obligations []PendingBlackboardConclusion
+	for rows.Next() {
+		obligation, scanErr := e.scanPendingBlackboardConclusion(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan recovery Conclusion Dispatch obligation: %w", scanErr)
+		}
+		obligations = append(obligations, obligation)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate recovery Conclusion Dispatch obligations: %w", err)
+	}
+	_ = rows.Close()
+
+	var views []BlackboardConclusionReceipt
+	for _, obligation := range obligations {
+		dispatch, dispatchErr := e.activeConclusionDispatchTx(tx, obligation.ID)
+		if dispatchErr != nil && !errors.Is(dispatchErr, sql.ErrNoRows) {
+			return nil, dispatchErr
+		}
+		boundToOld := dispatch != nil && dispatch.ContinuationID == oldContinuationID
+		boundToReplacement := dispatch != nil && dispatch.ContinuationID == replacementContinuationID
+		pendingBoundToOld := dispatch == nil && obligation.State == BlackboardConclusionReceiptPending && obligation.SourceContinuationID == oldContinuationID
+		if !boundToOld && !pendingBoundToOld {
+			if boundToReplacement {
+				view, viewErr := e.combinedConclusionView(tx, obligation)
+				if viewErr != nil {
+					return nil, viewErr
+				}
+				views = append(views, view)
+			}
+			continue
+		}
+		if dispatch != nil {
+			if err := e.supersedeActiveDispatchTx(tx, dispatch, "superseded_by_recovery", now); err != nil {
+				return nil, err
+			}
+		}
+		number := e.conclusionDispatchSequence(tx, obligation.ID) + 1
+		requestID := blackboardConclusionAttemptRequestID("recovery", replacementContinuationID, obligation.SourceTurnID, number, "")
+		nowDispatch := ConclusionDispatch{
+			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
+			ContinuationID: replacementContinuationID, SourceSessionID: replacementSessionID,
+			DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
+			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
+		}
+		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
+			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
+			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+			return nil, fmt.Errorf("store recovery Conclusion Dispatch: %w", err)
+		}
+		switch obligation.State {
+		case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptAwaitingResult:
+			obligation.State = BlackboardConclusionReceiptDispatchRequested
+		}
+		obligation.UpdatedAt = now
+		if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+			return nil, err
+		}
+		view := obligationView(obligation)
+		view.ActiveDispatchID = nowDispatch.ID
+		view.DispatchKind = nowDispatch.Kind
+		view.DispatchRequestID = nowDispatch.DispatchRequestID
+		view.ContinuationID = nowDispatch.ContinuationID
+		view.SourceSessionID = nowDispatch.SourceSessionID
+		view.BaseRevision = nowDispatch.BaseRevision
+		if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+			"phase": "recovery_dispatch_created", "receipt_id": obligation.ID, "request_id": requestID,
+			"replacement_continuation_id": replacementContinuationID, "replacement_session_id": replacementSessionID,
+			"turn_kind": "control",
+		}, now); err != nil {
+			return nil, err
+		}
+		views = append(views, view)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit recovery Conclusion Dispatches: %w", err)
+	}
+	return views, nil
+}
+
+// CreateRecoveryConclusionDispatch supersedes the active dispatch (if any) of
+// one obligation and creates a NEW recovery dispatch bound immutably to the
+// proven-live replacement continuation + session. It is the single-obligation
+// form used by restart recovery when the active dispatch is bound to a dead
+// continuation; the old dispatch identity is never rewritten. Won is false when
+// the obligation is already bound to the target continuation or is terminal.
+func (e *Engine) CreateRecoveryConclusionDispatch(obligationID, continuationID, sessionID string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	obligationID, continuationID, sessionID = strings.TrimSpace(obligationID), strings.TrimSpace(continuationID), strings.TrimSpace(sessionID)
+	if obligationID == "" || continuationID == "" || sessionID == "" {
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now = now.UTC()
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin recovery Conclusion Dispatch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, err := e.loadPendingBlackboardConclusionByID(tx, obligationID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	dispatch, err := e.activeConclusionDispatchTx(tx, obligation.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if dispatch != nil && dispatch.ContinuationID == continuationID && dispatch.SourceSessionID == sessionID {
+		view, viewErr := e.combinedConclusionView(tx, obligation)
+		if viewErr != nil {
+			return BlackboardConclusionReceipt{}, false, viewErr
+		}
+		return view, false, nil
+	}
+	if obligation.State == BlackboardConclusionReceiptApplied || obligation.State == BlackboardConclusionReceiptClean {
+		view, viewErr := e.combinedConclusionView(tx, obligation)
+		if viewErr != nil {
+			return BlackboardConclusionReceipt{}, false, viewErr
+		}
+		return view, false, nil
+	}
+	if dispatch != nil {
+		if err := e.supersedeActiveDispatchTx(tx, dispatch, "superseded_by_recovery", now); err != nil {
+			return BlackboardConclusionReceipt{}, false, err
+		}
+	}
+	number := e.conclusionDispatchSequence(tx, obligation.ID) + 1
+	requestID := blackboardConclusionAttemptRequestID("recovery", continuationID, obligation.SourceTurnID, number, "")
+	nowDispatch := ConclusionDispatch{
+		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
+		ContinuationID: continuationID, SourceSessionID: sessionID,
+		DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
+		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
+	}
+	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
+		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
+		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store recovery Conclusion Dispatch: %w", err)
+	}
+	switch obligation.State {
+	case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptAwaitingResult:
+		obligation.State = BlackboardConclusionReceiptDispatchRequested
+	}
+	obligation.UpdatedAt = now
+	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	view := obligationView(obligation)
+	view.ActiveDispatchID = nowDispatch.ID
+	view.DispatchKind = nowDispatch.Kind
+	view.DispatchRequestID = nowDispatch.DispatchRequestID
+	view.ContinuationID = nowDispatch.ContinuationID
+	view.SourceSessionID = nowDispatch.SourceSessionID
+	view.BaseRevision = nowDispatch.BaseRevision
+	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+		"phase": "recovery_dispatch_created", "receipt_id": obligation.ID, "request_id": requestID,
+		"replacement_continuation_id": continuationID, "replacement_session_id": sessionID,
+		"turn_kind": "control",
+	}, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit recovery Conclusion Dispatch: %w", err)
+	}
+	return view, true, nil
+}
+
+// --- internal helpers ---
+
+func obligationView(obligation PendingBlackboardConclusion) BlackboardConclusionReceipt {
+	view := BlackboardConclusionReceipt{
+		ID: obligation.ID, OwnerID: obligation.OwnerID,
+		ContinuationID:  obligation.SourceContinuationID,
+		SourceRequestID: obligation.SourceRequestID, SourceRequestCorrelationExact: obligation.SourceRequestCorrelationExact,
+		SourceSessionID: obligation.SourceSessionID, SourceTurnID: obligation.SourceTurnID,
+		InternalState: obligation.State, SourceWorkWatermark: obligation.SourceWorkWatermark,
+		SemanticPersistenceWatermark: obligation.SemanticPersistenceWatermark,
+		SourceSelection:              obligation.SourceSelection, CanonicalResultJSON: obligation.CanonicalResultJSON,
+		CanonicalResultSHA256: obligation.CanonicalResultSHA256, ApplyIdempotencyKey: obligation.ApplyIdempotencyKey,
+		AppliedRevision: obligation.AppliedRevision, BaseRevision: obligation.BaseRevision, AutomaticTurnCount: obligation.AutomaticTurnCount,
+		RepairCount: obligation.RepairCount, VersionRegenerationCount: obligation.VersionRegenerationCount,
+		ExplicitRetryCount: obligation.ExplicitRetryCount, OperatorRetryKey: obligation.OperatorRetryKey,
+		NextEligibleAt: obligation.NextEligibleAt, ErrorCode: obligation.ErrorCode,
+		RecoveryReason: string(obligation.RecoveryReason), ValidationReason: obligation.ValidationReason,
+		ValidationFieldPath: obligation.ValidationFieldPath, ValidationExpected: obligation.ValidationExpected,
+		CreatedAt: obligation.CreatedAt, UpdatedAt: obligation.UpdatedAt,
+	}
+	return view
+}
+
+func blackboardConclusionReceiptFromObligationDispatch(dispatch *ConclusionDispatch, obligation PendingBlackboardConclusion) BlackboardConclusionReceipt {
+	view := obligationView(obligation)
+	if dispatch == nil {
+		return view
+	}
+	view.ContinuationID = dispatch.ContinuationID
+	view.SourceSessionID = dispatch.SourceSessionID
+	view.DispatchRequestID = dispatch.DispatchRequestID
+	view.ControlTurnID = dispatch.ControlTurnID
+	// The dispatch carries its own immutable base revision. For an active
+	// dispatch it is the current protocol base; for a superseded or terminal
+	// dispatch the obligation's latest claimed base revision is authoritative
+	// (for example the exhausted version-regeneration action_required state).
+	if owner.ConclusionDispatchActive(dispatch.DeliveryState) {
+		view.BaseRevision = dispatch.BaseRevision
+	}
+	if view.BaseRevision == nil {
+		view.BaseRevision = obligation.BaseRevision
+	}
+	view.SynchronizedRevision = dispatch.SynchronizedRevision
+	view.SendAttemptCount = dispatch.SendAttemptCount
+	view.SendStartedAt = dispatch.SendStartedAt
+	view.ActiveDispatchID = dispatch.ID
+	view.DispatchKind = dispatch.Kind
+	return view
+}
+
+func (e *Engine) combinedConclusionView(queryer interface {
+	QueryRow(string, ...any) *sql.Row
+}, obligation PendingBlackboardConclusion) (BlackboardConclusionReceipt, error) {
+	dispatch, err := e.scanConclusionDispatch(queryer.QueryRow(`SELECT `+conclusionDispatchColumns+`
+		FROM `+e.Dialect.DispatchesTable+` WHERE obligation_id=? AND delivery_state IN (?,?,?)
+		ORDER BY created_at DESC,id DESC LIMIT 1`, obligation.ID,
+		string(ConclusionDispatchRequested), string(ConclusionDispatchAwaitingResult), string(ConclusionDispatchValidated)))
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return BlackboardConclusionReceipt{}, fmt.Errorf("load active Conclusion Dispatch: %w", err)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		// Terminal obligations (applied / action_required) keep their last
+		// dispatch as the visible delivery lineage.
+		latest, latestErr := e.scanConclusionDispatch(queryer.QueryRow(`SELECT `+conclusionDispatchColumns+`
+			FROM `+e.Dialect.DispatchesTable+` WHERE obligation_id=? ORDER BY rowid DESC LIMIT 1`, obligation.ID))
+		if latestErr != nil && !errors.Is(latestErr, sql.ErrNoRows) {
+			return BlackboardConclusionReceipt{}, fmt.Errorf("load latest Conclusion Dispatch: %w", latestErr)
+		}
+		if latestErr == nil {
+			return blackboardConclusionReceiptFromObligationDispatch(&latest, obligation), nil
+		}
+		return blackboardConclusionReceiptFromObligationDispatch(nil, obligation), nil
+	}
+	return blackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
+}
+
+type obligationQueryer interface {
+	QueryRow(string, ...any) *sql.Row
+}
+
+func (e *Engine) loadPendingBlackboardConclusionByID(queryer obligationQueryer, obligationID string) (PendingBlackboardConclusion, error) {
+	return e.scanPendingBlackboardConclusion(queryer.QueryRow(`SELECT `+e.obligationColumns()+`
+		FROM `+e.Dialect.ObligationsTable+` WHERE id=?`, obligationID))
+}
+
+// loadConclusionByDispatchRequestID resolves the obligation for any dispatch
+// request id, active or terminal. Callers that advance the protocol must gate
+// on the active dispatch themselves; this loader is used for idempotent replay
+// of terminal states (for example applied).
+func (e *Engine) loadConclusionByDispatchRequestID(tx *sql.Tx, dispatchRequestID string) (PendingBlackboardConclusion, *ConclusionDispatch, error) {
+	dispatch, err := e.scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
+		FROM `+e.Dialect.DispatchesTable+` WHERE dispatch_request_id=?`, dispatchRequestID))
+	if err != nil {
+		return PendingBlackboardConclusion{}, nil, err
+	}
+	obligation, err := e.loadPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
+	if err != nil {
+		return PendingBlackboardConclusion{}, nil, err
+	}
+	return obligation, &dispatch, nil
+}
+
+func (e *Engine) loadActiveConclusionByDispatchRequestID(tx *sql.Tx, dispatchRequestID string) (PendingBlackboardConclusion, *ConclusionDispatch, error) {
+	dispatch, err := e.scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
+		FROM `+e.Dialect.DispatchesTable+` WHERE dispatch_request_id=?`, dispatchRequestID))
+	if err != nil {
+		return PendingBlackboardConclusion{}, nil, err
+	}
+	if !owner.ConclusionDispatchActive(dispatch.DeliveryState) {
+		// A callback for a superseded or late dispatch is obsolete: it must
+		// fail closed (ErrOwnerNotFound) and can never advance the obligation.
+		return PendingBlackboardConclusion{}, nil, sql.ErrNoRows
+	}
+	obligation, err := e.loadPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
+	if err != nil {
+		return PendingBlackboardConclusion{}, nil, err
+	}
+	return obligation, &dispatch, nil
+}
+
+func (e *Engine) conclusionViewByDispatchRequestIDTx(tx *sql.Tx, dispatchRequestID string) (BlackboardConclusionReceipt, error) {
+	dispatch, err := e.scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
+		FROM `+e.Dialect.DispatchesTable+` WHERE dispatch_request_id=?`, dispatchRequestID))
+	if err != nil {
+		return BlackboardConclusionReceipt{}, err
+	}
+	obligation, err := e.loadPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, err
+	}
+	return blackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
+}
+
+func (e *Engine) latestConclusionDispatchTx(tx *sql.Tx, obligationID string) (*ConclusionDispatch, error) {
+	dispatch, err := e.scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
+		FROM `+e.Dialect.DispatchesTable+` WHERE obligation_id=? ORDER BY rowid DESC LIMIT 1`, obligationID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &dispatch, nil
+}
+
+func (e *Engine) activeConclusionDispatchTx(tx *sql.Tx, obligationID string) (*ConclusionDispatch, error) {
+	dispatch, err := e.scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
+		FROM `+e.Dialect.DispatchesTable+` WHERE obligation_id=? AND delivery_state IN (?,?,?)
+		ORDER BY created_at DESC,id DESC LIMIT 1`, obligationID,
+		string(ConclusionDispatchRequested), string(ConclusionDispatchAwaitingResult), string(ConclusionDispatchValidated)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &dispatch, nil
+}
+
+func (e *Engine) supersedeActiveDispatchTx(tx *sql.Tx, dispatch *ConclusionDispatch, outcome string, now time.Time) error {
+	dispatch.DeliveryState = ConclusionDispatchSuperseded
+	dispatch.TerminalOutcome = outcome
+	dispatch.UpdatedAt = now
+	if _, err := tx.Exec(`UPDATE `+e.Dialect.DispatchesTable+` SET delivery_state=?,terminal_outcome=?,updated_at=? WHERE id=?`,
+		string(dispatch.DeliveryState), outcome, now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
+		return fmt.Errorf("supersede Conclusion Dispatch: %w", err)
+	}
+	return nil
+}
+
+func (e *Engine) failActiveDispatchTx(tx *sql.Tx, obligation PendingBlackboardConclusion, dispatch *ConclusionDispatch, code BlackboardConclusionErrorCode, nextEligible time.Time, detail ConclusionValidationDetail, now time.Time) (PendingBlackboardConclusion, error) {
+	obligation.State = BlackboardConclusionReceiptActionRequired
+	obligation.ErrorCode = code
+	obligation.NextEligibleAt = &nextEligible
+	obligation.ValidationReason = detail.Reason
+	obligation.ValidationFieldPath = detail.FieldPath
+	obligation.ValidationExpected = detail.Expected
+	obligation.UpdatedAt = now
+	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+		return PendingBlackboardConclusion{}, err
+	}
+	if dispatch != nil {
+		if err := e.supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
+			return PendingBlackboardConclusion{}, err
+		}
+	}
+	return obligation, nil
+}
+
+func (e *Engine) updateObligationProtocolTx(tx *sql.Tx, obligation PendingBlackboardConclusion) error {
+	if _, err := tx.Exec(`UPDATE `+e.Dialect.ObligationsTable+`
+		SET state=?,canonical_result_json=?,canonical_result_sha256=?,applied_revision=?,base_revision=?,automatic_turn_count=?,repair_count=?,
+		version_regeneration_count=?,explicit_retry_count=?,operator_retry_key=?,error_code=?,recovery_reason=?,next_eligible_at=?,
+		validation_reason=?,validation_field_path=?,validation_expected=?,updated_at=? WHERE id=?`,
+		string(obligation.State), obligation.CanonicalResultJSON, obligation.CanonicalResultSHA256,
+		intPointerValue(obligation.AppliedRevision), intPointerValue(obligation.BaseRevision), obligation.AutomaticTurnCount, obligation.RepairCount,
+		obligation.VersionRegenerationCount, obligation.ExplicitRetryCount, obligation.OperatorRetryKey,
+		string(obligation.ErrorCode), string(obligation.RecoveryReason),
+		formatTimePtr(obligation.NextEligibleAt), obligation.ValidationReason, obligation.ValidationFieldPath,
+		obligation.ValidationExpected, obligation.UpdatedAt.Format(time.RFC3339Nano), obligation.ID); err != nil {
+		return fmt.Errorf("update "+e.Dialect.Subject+" obligation: %w", err)
+	}
+	return nil
+}
+
+// advanceObligationStateByDispatchRequest transitions the obligation's protocol
+// state, verifying the request id still resolves to the ACTIVE dispatch.
+func (e *Engine) advanceObligationStateByDispatchRequest(dispatchRequestID string, from, to BlackboardConclusionReceiptState, advance func(*sql.Tx, *PendingBlackboardConclusion, time.Time) error) (BlackboardConclusionReceipt, bool, error) {
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" %s: %w", to, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, dispatch, err := e.loadConclusionByDispatchRequestID(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if obligation.State != from {
+		if obligation.State == to {
+			return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
+		}
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now := time.Now().UTC()
+	if err := advance(tx, &obligation, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("mark "+e.Dialect.Subject+" %s: %w", to, err)
+	}
+	view, err := e.conclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit "+e.Dialect.Subject+" %s: %w", to, err)
+	}
+	return view, true, nil
+}
+
+// advanceActiveConclusionDispatch transitions the ACTIVE dispatch's delivery
+// state together with the obligation protocol state. Only the active dispatch
+// may advance.
+func (e *Engine) advanceActiveConclusionDispatch(dispatchRequestID string, fromDispatch, toDispatch ConclusionDispatchState, toObligation BlackboardConclusionReceiptState,
+	replayMatches func(BlackboardConclusionReceipt) bool,
+	advance func(*sql.Tx, *PendingBlackboardConclusion, *ConclusionDispatch, time.Time) error,
+) (BlackboardConclusionReceipt, bool, error) {
+	tx, err := e.DB.Begin()
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin "+e.Dialect.Subject+" %s: %w", toDispatch, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	obligation, dispatch, err := e.loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+	}
+	if dispatch == nil || dispatch.DeliveryState != fromDispatch {
+		if dispatch != nil && dispatch.DeliveryState == toDispatch && replayMatches(blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)) {
+			return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
+		}
+		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	now := time.Now().UTC()
+	if err := advance(tx, &obligation, dispatch, now); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("mark "+e.Dialect.Subject+" %s: %w", toDispatch, err)
+	}
+	obligation.State = toObligation
+	obligation.UpdatedAt = now
+	if _, err := tx.Exec(`UPDATE `+e.Dialect.ObligationsTable+` SET state=?,updated_at=? WHERE id=?`,
+		string(obligation.State), now.Format(time.RFC3339Nano), obligation.ID); err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	view, err := e.conclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit "+e.Dialect.Subject+" %s: %w", toDispatch, err)
+	}
+	return view, true, nil
+}
+
+func (e *Engine) scanPendingBlackboardConclusion(row interface{ Scan(...any) error }) (PendingBlackboardConclusion, error) {
+	var obligation PendingBlackboardConclusion
+	var state, createdAt, updatedAt string
+	var nextEligibleAt, errorCode, recoveryReason, validationReason, validationFieldPath, validationExpected, applyKey, resultHash, operatorRetryKey sql.NullString
+	var appliedRevision, baseRevision sql.NullInt64
+	var canonicalResult []byte
+	if err := row.Scan(&obligation.ID, &obligation.OwnerID, &obligation.SourceRequestID, &obligation.SourceRequestCorrelationExact,
+		&obligation.SourceContinuationID, &obligation.SourceSessionID, &obligation.SourceTurnID, &state,
+		&obligation.SourceWorkWatermark, &obligation.SemanticPersistenceWatermark,
+		&obligation.SourceSelection.ModelProviderID, &obligation.SourceSelection.Model, &obligation.SourceSelection.ReasoningEffort,
+		&canonicalResult, &resultHash, &applyKey, &appliedRevision, &baseRevision, &obligation.AutomaticTurnCount,
+		&obligation.RepairCount, &obligation.VersionRegenerationCount, &obligation.ExplicitRetryCount,
+		&operatorRetryKey, &nextEligibleAt, &errorCode, &recoveryReason,
+		&validationReason, &validationFieldPath, &validationExpected, &createdAt, &updatedAt); err != nil {
+		return PendingBlackboardConclusion{}, err
+	}
+	obligation.State = BlackboardConclusionReceiptState(state)
+	obligation.CanonicalResultJSON = append([]byte(nil), canonicalResult...)
+	obligation.CanonicalResultSHA256 = resultHash.String
+	obligation.ApplyIdempotencyKey = applyKey.String
+	obligation.OperatorRetryKey = operatorRetryKey.String
+	obligation.ErrorCode = BlackboardConclusionErrorCode(errorCode.String)
+	obligation.RecoveryReason = ConclusionRecoveryReason(recoveryReason.String)
+	obligation.ValidationReason = validationReason.String
+	obligation.ValidationFieldPath = validationFieldPath.String
+	obligation.ValidationExpected = validationExpected.String
+	if appliedRevision.Valid {
+		obligation.AppliedRevision = intPointer(int(appliedRevision.Int64))
+	}
+	if baseRevision.Valid {
+		obligation.BaseRevision = intPointer(int(baseRevision.Int64))
+	}
+	if nextEligibleAt.Valid {
+		parsed, err := time.Parse(time.RFC3339Nano, nextEligibleAt.String)
+		if err != nil {
+			return PendingBlackboardConclusion{}, fmt.Errorf("parse "+e.Dialect.Subject+" next_eligible_at: %w", err)
+		}
+		obligation.NextEligibleAt = &parsed
+	}
+	var err error
+	if obligation.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
+		return PendingBlackboardConclusion{}, fmt.Errorf("parse "+e.Dialect.Subject+" created_at: %w", err)
+	}
+	if obligation.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt); err != nil {
+		return PendingBlackboardConclusion{}, fmt.Errorf("parse "+e.Dialect.Subject+" updated_at: %w", err)
+	}
+	return obligation, nil
+}
+
+func (e *Engine) scanConclusionDispatch(row interface{ Scan(...any) error }) (ConclusionDispatch, error) {
+	var dispatch ConclusionDispatch
+	var kind, deliveryState, createdAt, updatedAt string
+	var dispatchRequestID, controlTurnID, sendStartedAt, terminalOutcome sql.NullString
+	var baseRevision, synchronizedRevision sql.NullInt64
+	if err := row.Scan(&dispatch.ID, &dispatch.ObligationID, &kind, &dispatch.ContinuationID, &dispatch.SourceSessionID,
+		&dispatchRequestID, &controlTurnID, &baseRevision, &synchronizedRevision, &deliveryState,
+		&dispatch.SendAttemptCount, &sendStartedAt, &terminalOutcome, &createdAt, &updatedAt); err != nil {
+		return ConclusionDispatch{}, err
+	}
+	dispatch.Kind = ConclusionDispatchKind(kind)
+	dispatch.DeliveryState = ConclusionDispatchState(deliveryState)
+	dispatch.DispatchRequestID = dispatchRequestID.String
+	dispatch.ControlTurnID = controlTurnID.String
+	dispatch.TerminalOutcome = terminalOutcome.String
+	if baseRevision.Valid {
+		dispatch.BaseRevision = intPointer(int(baseRevision.Int64))
+	}
+	if synchronizedRevision.Valid {
+		dispatch.SynchronizedRevision = intPointer(int(synchronizedRevision.Int64))
+	}
+	if sendStartedAt.Valid {
+		parsed, err := time.Parse(time.RFC3339Nano, sendStartedAt.String)
+		if err != nil {
+			return ConclusionDispatch{}, fmt.Errorf("parse Conclusion Dispatch send_started_at: %w", err)
+		}
+		dispatch.SendStartedAt = &parsed
+	}
+	var err error
+	if dispatch.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
+		return ConclusionDispatch{}, fmt.Errorf("parse Conclusion Dispatch created_at: %w", err)
+	}
+	if dispatch.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt); err != nil {
+		return ConclusionDispatch{}, fmt.Errorf("parse Conclusion Dispatch updated_at: %w", err)
+	}
+	return dispatch, nil
+}
+
+func validBlackboardConclusionErrorCode(code BlackboardConclusionErrorCode) bool {
+	return owner.ValidBlackboardConclusionErrorCode(code)
+}
+
+func (e *Engine) blackboardConclusionLookupError(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrOwnerNotFound
+	}
+	return fmt.Errorf("load "+e.Dialect.Subject+" obligation: %w", err)
+}
+
+func blackboardConclusionRequestLineage(continuationID, sourceTurnID string) (string, string) {
+	return owner.ConclusionRequestLineage(continuationID, sourceTurnID)
+}
+
+func blackboardConclusionAttemptRequestID(kind, continuationID, sourceTurnID string, number int, key string) string {
+	return owner.ConclusionAttemptRequestID(kind, continuationID, sourceTurnID, number, key)
+}
+
+func (e *Engine) appendBlackboardConclusionEventTx(tx *sql.Tx, receipt BlackboardConclusionReceipt, payload map[string]any, now time.Time) error {
+	if err := e.Dialect.AppendEvent(tx, receipt.OwnerID, receipt.ContinuationID, e.Dialect.EventKind, payload, now); err != nil {
+		return fmt.Errorf("store "+e.Dialect.Subject+" Event: %w", err)
+	}
+	return nil
+}
+
+func (e *Engine) conclusionDispatchSequence(tx *sql.Tx, obligationID string) int {
+	var count int
+	_ = tx.QueryRow(`SELECT COUNT(*) FROM `+e.Dialect.DispatchesTable+` WHERE obligation_id=?`, obligationID).Scan(&count)
+	return count
+}
+
+func dispatchBaseRevision(dispatch *ConclusionDispatch) *int {
+	if dispatch == nil {
+		return nil
+	}
+	return dispatch.BaseRevision
+}
+
+func obligationDispatchRequestID(dispatch *ConclusionDispatch) string {
+	if dispatch == nil {
+		return ""
+	}
+	return dispatch.DispatchRequestID
+}
+
+func intPointerValue(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func formatTimePtr(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func intPointer(value int) *int { return &value }
+
+// MapSentinels returns err unchanged unless one of the engine sentinels
+// matches; then it returns an error that carries the original message and
+// chain while satisfying errors.Is for the owner-package counterpart. Pairs
+// alternate from, to.
+func MapSentinels(err error, pairs ...error) error {
+	if err == nil || len(pairs) < 2 {
+		return err
+	}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		if errors.Is(err, pairs[i]) {
+			return mappedSentinelError{err: err, to: pairs[i+1]}
+		}
+	}
+	return err
+}
+
+type mappedSentinelError struct {
+	err error
+	to  error
+}
+
+func (m mappedSentinelError) Error() string        { return m.err.Error() }
+func (m mappedSentinelError) Unwrap() error        { return m.err }
+func (m mappedSentinelError) Is(target error) bool { return target == m.to }

--- a/internal/owner/conclusion/conclusion_test.go
+++ b/internal/owner/conclusion/conclusion_test.go
@@ -1,0 +1,36 @@
+package conclusion
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestMapSentinelsPreservesMessageAndChain(t *testing.T) {
+	engineSentinel := ErrOwnerNotFound
+	ownerSentinel := errors.New("owner not found")
+
+	original := fmt.Errorf("load continuation: %w", engineSentinel)
+	mapped := MapSentinels(original, engineSentinel, ownerSentinel)
+
+	if !errors.Is(mapped, ownerSentinel) {
+		t.Fatalf("mapped error must satisfy errors.Is for the owner sentinel, got %v", mapped)
+	}
+	if !errors.Is(mapped, engineSentinel) {
+		t.Fatalf("mapped error must keep the engine sentinel in its chain, got %v", mapped)
+	}
+	if mapped.Error() != original.Error() {
+		t.Fatalf("mapped message changed: %q != %q", mapped.Error(), original.Error())
+	}
+}
+
+func TestMapSentinelsLeavesUnrelatedErrorsAlone(t *testing.T) {
+	unrelated := fmt.Errorf("ordinary failure: %w", ErrOwnerNotFound)
+	same := MapSentinels(unrelated, ErrInvalidBlackboardConclusionReceipt, ErrOwnerNotFound)
+	if same != unrelated {
+		t.Fatalf("unrelated error must pass through unchanged, got %v", same)
+	}
+	if MapSentinels(nil, ErrOwnerNotFound, ErrOwnerNotFound) != nil {
+		t.Fatalf("nil must stay nil")
+	}
+}

--- a/internal/runner/mcp.go
+++ b/internal/runner/mcp.go
@@ -25,7 +25,6 @@ type RuntimeOwnerContext struct {
 	Owner          owner.Contract
 	MCPURL         string
 	APIURL         string
-	AuthToken      string
 	InterfaceToken string
 	Provider       runtimeprofile.Provider
 	Sandbox        bool
@@ -36,7 +35,6 @@ func taskContextFromProjection(req ProjectionRequest, provider runtimeprofile.Pr
 	ctx := RuntimeOwnerContext{
 		Owner:         req.Owner,
 		MCPURL:        mcpURL,
-		AuthToken:     req.AuthToken,
 		Provider:      provider,
 		Sandbox:       req.Sandbox,
 		ScopeSnapshot: req.ScopeSnapshot,

--- a/internal/runner/projection.go
+++ b/internal/runner/projection.go
@@ -1452,9 +1452,9 @@ func launchProcessEnv(layout Layout, profile runtimeprofile.Profile, sandbox boo
 	if ctx.MCPURL != "" {
 		env["PENTEST_MCP_URL"] = ctx.MCPURL
 	}
-	if ctx.AuthToken != "" {
-		env["PENTEST_AUTH_TOKEN"] = ctx.AuthToken
-	}
+	// PENTEST_AUTH_TOKEN is deliberately never projected: the daemon operator
+	// token authorizes the full API and must stay outside Runtime boundaries.
+	// Runtime traffic authenticates with the narrower PENTEST_INTERFACE_TOKEN.
 	if ctx.InterfaceToken != "" {
 		env["PENTEST_INTERFACE_TOKEN"] = ctx.InterfaceToken
 	}

--- a/internal/session/blackboard_conclusion.go
+++ b/internal/session/blackboard_conclusion.go
@@ -5,15 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
-	"pentest/internal/owner"
+	"pentest/internal/owner/conclusion"
 )
 
 // SemanticDebtWatermarks compare terminal Work Tool Results with the latest
 // successful semantic persistence that covers them.
-type SemanticDebtWatermarks = owner.SemanticDebtWatermarks
+type SemanticDebtWatermarks = conclusion.SemanticDebtWatermarks
 
 // BlackboardConclusionReceipt is the owner-local durable coordinator record.
 // Canonical result bytes never appear in the Session API projection.
@@ -119,87 +118,136 @@ var (
 	ErrBlackboardConclusionDispatchInactive = errors.New("Session Blackboard conclusion dispatch is not the active delivery")
 )
 
+// The Pending Blackboard Conclusion state machine is shared with Project Tasks
+// through internal/owner/conclusion. This file keeps the Session-facing API:
+// owner eligibility checks, the Session receipt projection, and error
+// translation. Storage rules, dispatch lifecycle, and recovery settlement
+// belong to the shared engine.
+
 // PendingBlackboardConclusion is the durable obligation row, keyed by
 // (session, source session, source turn) and independent of any Runtime
-// Continuation.
-type PendingBlackboardConclusion struct {
-	ID                            string
-	SessionID                     string
-	SourceRequestID               string
-	SourceRequestCorrelationExact bool
-	SourceContinuationID          string
-	SourceSessionID               string
-	SourceTurnID                  string
-	State                         BlackboardConclusionReceiptState
-	SourceWorkWatermark           int
-	SemanticPersistenceWatermark  int
-	SourceSelection               RuntimeTurnSelection
-	CanonicalResultJSON           []byte
-	CanonicalResultSHA256         string
-	ApplyIdempotencyKey           string
-	AppliedRevision               *int
-	BaseRevision                  *int
-	AutomaticTurnCount            int
-	RepairCount                   int
-	VersionRegenerationCount      int
-	ExplicitRetryCount            int
-	OperatorRetryKey              string
-	NextEligibleAt                *time.Time
-	ErrorCode                     BlackboardConclusionErrorCode
-	RecoveryReason                ConclusionRecoveryReason
-	ValidationReason              string
-	ValidationFieldPath           string
-	ValidationExpected            string
-	CreatedAt                     time.Time
-	UpdatedAt                     time.Time
-}
+// Continuation. The shared engine names the owner identity OwnerID.
+type PendingBlackboardConclusion = conclusion.PendingBlackboardConclusion
 
 // ConclusionDispatch is one immutable delivery attempt for an obligation. Its
 // continuation and source session are written once at creation and never
 // updated; recovery creates a new dispatch instead of rewriting an old one.
-type ConclusionDispatch struct {
-	ID                   string
-	ObligationID         string
-	Kind                 ConclusionDispatchKind
-	ContinuationID       string
-	SourceSessionID      string
-	DispatchRequestID    string
-	ControlTurnID        string
-	BaseRevision         *int
-	SynchronizedRevision *int
-	DeliveryState        ConclusionDispatchState
-	SendAttemptCount     int
-	SendStartedAt        *time.Time
-	TerminalOutcome      string
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
+type ConclusionDispatch = conclusion.ConclusionDispatch
+
+// sessionConclusionDialect stores conclusion state against the Session tables.
+func sessionConclusionDialect() conclusion.Dialect {
+	return conclusion.Dialect{
+		Subject:                     "Session Blackboard conclusion",
+		ObligationsTable:            "session_pending_blackboard_conclusions",
+		DispatchesTable:             "session_conclusion_dispatches",
+		OwnerColumn:                 "session_id",
+		ContinuationsTable:          "session_continuations",
+		ContinuationOwnerColumn:     "session_id",
+		EventKind:                   string(EventKindBlackboardConclusion),
+		ReconcilePendingObligations: true,
+		AppendEvent:                 appendSessionConclusionEventTx,
+		RetryKeysTable:              "session_assisted_conclusion_retry_keys",
+		RetryKeysOwnerColumn:        "session_id",
+		RetryKeysReceiptColumn:      "obligation_id",
+		NewID:                       newIDMust,
+	}
 }
 
-const sessionPendingBlackboardConclusionColumns = `id,session_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,state,
-	source_work_watermark,semantic_persistence_watermark,source_model_provider_id,source_model,source_reasoning_effort,
-	canonical_result_json,canonical_result_sha256,apply_idempotency_key,applied_revision,base_revision,automatic_turn_count,
-	repair_count,version_regeneration_count,explicit_retry_count,operator_retry_key,next_eligible_at,error_code,recovery_reason,
-	validation_reason,validation_field_path,validation_expected,created_at,updated_at`
+func appendSessionConclusionEventTx(tx *sql.Tx, ownerID, _ string, kind string, payload map[string]any, now time.Time) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode Session Blackboard conclusion Event: %w", err)
+	}
+	var maxSeq sql.NullInt64
+	if err := tx.QueryRow(`SELECT MAX(seq) FROM session_events WHERE session_id=?`, ownerID).Scan(&maxSeq); err != nil {
+		return fmt.Errorf("read Session Blackboard conclusion Event sequence: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO session_events (id,session_id,seq,kind,payload_json,created_at)
+		VALUES (?,?,?,?,?,?)`, newIDMust(), ownerID, int(maxSeq.Int64)+1, kind, string(payloadJSON), formatTime(now)); err != nil {
+		return fmt.Errorf("store Session Blackboard conclusion Event: %w", err)
+	}
+	return nil
+}
 
-const sessionConclusionDispatchColumns = `id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,control_turn_id,base_revision,
-	synchronized_revision,delivery_state,send_attempt_count,send_started_at,terminal_outcome,created_at,updated_at`
+// conclusions returns the shared conclusion engine bound to the Session tables.
+func (s *Service) conclusions() *conclusion.Engine {
+	return &conclusion.Engine{DB: s.db.DB, Dialect: sessionConclusionDialect()}
+}
+
+func intPointer(value int) *int { return &value }
+
+// mapConclusionError restamps engine sentinels as the Session-package
+// sentinels callers already match with errors.Is, preserving message and chain.
+func mapConclusionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return conclusion.MapSentinels(err,
+		conclusion.ErrOwnerNotFound, ErrNotFound,
+		conclusion.ErrInvalidBlackboardConclusionReceipt, ErrInvalidBlackboardConclusionReceipt,
+		conclusion.ErrBlackboardConclusionRetryCooldown, ErrBlackboardConclusionRetryCooldown,
+		conclusion.ErrBlackboardConclusionWorkTurnNeverSettled, ErrBlackboardConclusionWorkTurnNeverSettled,
+		conclusion.ErrBlackboardConclusionDispatchInactive, ErrBlackboardConclusionDispatchInactive,
+	)
+}
+
+func receiptFromConclusion(rec conclusion.BlackboardConclusionReceipt) BlackboardConclusionReceipt {
+	return BlackboardConclusionReceipt{
+		ID:                            rec.ID,
+		SessionID:                     rec.OwnerID,
+		ContinuationID:                rec.ContinuationID,
+		SourceRequestID:               rec.SourceRequestID,
+		SourceRequestCorrelationExact: rec.SourceRequestCorrelationExact,
+		SourceSessionID:               rec.SourceSessionID,
+		SourceTurnID:                  rec.SourceTurnID,
+		InternalState:                 rec.InternalState,
+		SourceWorkWatermark:           rec.SourceWorkWatermark,
+		SemanticPersistenceWatermark:  rec.SemanticPersistenceWatermark,
+		DispatchRequestID:             rec.DispatchRequestID,
+		ControlTurnID:                 rec.ControlTurnID,
+		BaseRevision:                  rec.BaseRevision,
+		SynchronizedRevision:          rec.SynchronizedRevision,
+		SourceSelection: RuntimeTurnSelection{
+			ModelProviderID: rec.SourceSelection.ModelProviderID,
+			Model:           rec.SourceSelection.Model,
+			ReasoningEffort: rec.SourceSelection.ReasoningEffort,
+		},
+		CanonicalResultJSON:      rec.CanonicalResultJSON,
+		CanonicalResultSHA256:    rec.CanonicalResultSHA256,
+		ApplyIdempotencyKey:      rec.ApplyIdempotencyKey,
+		AppliedRevision:          rec.AppliedRevision,
+		AutomaticTurnCount:       rec.AutomaticTurnCount,
+		RepairCount:              rec.RepairCount,
+		VersionRegenerationCount: rec.VersionRegenerationCount,
+		ExplicitRetryCount:       rec.ExplicitRetryCount,
+		OperatorRetryKey:         rec.OperatorRetryKey,
+		SendAttemptCount:         rec.SendAttemptCount,
+		SendStartedAt:            rec.SendStartedAt,
+		NextEligibleAt:           rec.NextEligibleAt,
+		ErrorCode:                rec.ErrorCode,
+		RecoveryReason:           rec.RecoveryReason,
+		ActiveDispatchID:         rec.ActiveDispatchID,
+		DispatchKind:             rec.DispatchKind,
+		ValidationReason:         rec.ValidationReason,
+		ValidationFieldPath:      rec.ValidationFieldPath,
+		ValidationExpected:       rec.ValidationExpected,
+		CreatedAt:                rec.CreatedAt,
+		UpdatedAt:                rec.UpdatedAt,
+	}
+}
+
+func receiptsFromConclusion(recs []conclusion.BlackboardConclusionReceipt) []BlackboardConclusionReceipt {
+	out := make([]BlackboardConclusionReceipt, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, receiptFromConclusion(rec))
+	}
+	return out
+}
 
 // RecordBlackboardConclusionCheckpoint creates the one durable Pending
 // Blackboard Conclusion obligation for a completed assisted Work Runtime Turn.
 // Replay returns the original obligation.
 func (s *Service) RecordBlackboardConclusionCheckpoint(sessionID, continuationID, sourceRequestID, sourceSessionID, sourceTurnID string, sourceSelection RuntimeTurnSelection, watermarks SemanticDebtWatermarks) (BlackboardConclusionReceipt, bool, error) {
-	checkpoint, valid := (owner.ConclusionCheckpointInput{
-		OwnerID: sessionID, ContinuationID: continuationID, SourceRequestID: sourceRequestID,
-		SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
-		ModelProviderID: sourceSelection.ModelProviderID, Model: sourceSelection.Model,
-		ReasoningEffort: sourceSelection.ReasoningEffort, Watermarks: watermarks,
-	}).Normalize()
-	if !valid {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	sessionID, continuationID, sourceRequestID = checkpoint.OwnerID, checkpoint.ContinuationID, checkpoint.SourceRequestID
-	sourceSessionID, sourceTurnID, watermarks = checkpoint.SourceSessionID, checkpoint.SourceTurnID, checkpoint.Watermarks
-	sourceSelection = RuntimeTurnSelection{ModelProviderID: checkpoint.ModelProviderID, Model: checkpoint.Model, ReasoningEffort: checkpoint.ReasoningEffort}
 	found, err := s.Get(sessionID)
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, err
@@ -207,1726 +255,205 @@ func (s *Service) RecordBlackboardConclusionCheckpoint(sessionID, continuationID
 	if found.RunControls.BlackboardConclusionMode != BlackboardConclusionModeAssisted {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
-
-	tx, err := s.db.Begin()
+	rec, created, err := s.conclusions().RecordBlackboardConclusionCheckpoint(sessionID, continuationID, sourceRequestID, sourceSessionID, sourceTurnID,
+		conclusion.Selection{ModelProviderID: sourceSelection.ModelProviderID, Model: sourceSelection.Model, ReasoningEffort: sourceSelection.ReasoningEffort}, watermarks)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion obligation: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	var ownerSessionID string
-	if err := tx.QueryRow(`SELECT session_id FROM session_continuations WHERE id=?`, continuationID).Scan(&ownerSessionID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return BlackboardConclusionReceipt{}, false, ErrNotFound
-		}
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("load Session Blackboard conclusion Continuation: %w", err)
-	}
-	if ownerSessionID != sessionID {
-		return BlackboardConclusionReceipt{}, false, ErrNotFound
-	}
-
-	prior, err := scanSessionPendingBlackboardConclusion(tx.QueryRow(`SELECT `+sessionPendingBlackboardConclusionColumns+`
-		FROM session_pending_blackboard_conclusions WHERE session_id=? AND source_session_id=? AND source_turn_id=?`, sessionID, sourceSessionID, sourceTurnID))
-	if err == nil {
-		view, scanErr := sessionCombinedConclusionView(tx, prior)
-		if scanErr != nil {
-			return BlackboardConclusionReceipt{}, false, scanErr
-		}
-		return view, false, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("load Session Blackboard conclusion obligation: %w", err)
-	}
-
-	now := time.Now().UTC()
-	obligationState, phase := owner.InitialConclusionCheckpoint(watermarks)
-	obligation := PendingBlackboardConclusion{
-		ID: newIDMust(), SessionID: sessionID, SourceRequestID: sourceRequestID, SourceRequestCorrelationExact: true,
-		SourceContinuationID: continuationID, SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
-		State: obligationState, SourceWorkWatermark: watermarks.SourceWork,
-		SemanticPersistenceWatermark: watermarks.SemanticPersistence,
-		SourceSelection:              sourceSelection, CreatedAt: now, UpdatedAt: now,
-	}
-	if _, err := tx.Exec(`INSERT INTO session_pending_blackboard_conclusions
-		(id,session_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,state,source_work_watermark,semantic_persistence_watermark,
-		 source_model_provider_id,source_model,source_reasoning_effort,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, obligation.ID, obligation.SessionID, obligation.SourceRequestID,
-		obligation.SourceRequestCorrelationExact, obligation.SourceContinuationID, obligation.SourceSessionID, obligation.SourceTurnID,
-		string(obligation.State), obligation.SourceWorkWatermark, obligation.SemanticPersistenceWatermark,
-		obligation.SourceSelection.ModelProviderID, obligation.SourceSelection.Model, obligation.SourceSelection.ReasoningEffort,
-		formatTime(obligation.CreatedAt), formatTime(obligation.UpdatedAt)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session Blackboard conclusion obligation: %w", err)
-	}
-
-	view := sessionObligationView(obligation)
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": phase, "receipt_id": obligation.ID, "source_turn_id": obligation.SourceTurnID,
-		"source_work_watermark": obligation.SourceWorkWatermark, "semantic_persistence_watermark": obligation.SemanticPersistenceWatermark,
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Session Blackboard conclusion obligation: %w", err)
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), created, nil
 }
 
-// ClaimBlackboardConclusionDispatch creates the initial Conclusion Dispatch
-// for a pending obligation, bound immutably to the source continuation and
-// source session of the completed Work Runtime Turn.
 func (s *Service) ClaimBlackboardConclusionDispatch(obligationID string, baseRevision int) (BlackboardConclusionReceipt, bool, error) {
-	obligationID = strings.TrimSpace(obligationID)
-	if obligationID == "" || baseRevision < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	tx, err := s.db.Begin()
+	rec, created, err := s.conclusions().ClaimBlackboardConclusionDispatch(obligationID, baseRevision)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion dispatch: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadSessionPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if obligation.State != BlackboardConclusionReceiptPending {
-		if obligation.State == BlackboardConclusionReceiptClean {
-			view, viewErr := sessionCombinedConclusionView(tx, obligation)
-			return view, false, viewErr
-		}
-		// Replay: the obligation already claimed the deterministic initial
-		// dispatch. Return the existing ACTIVE dispatch unchanged when its
-		// request lineage and base revision match this replay.
-		dispatchID, _ := sessionBlackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
-		existing, err := sessionActiveConclusionDispatchTx(tx, obligation.ID)
-		if err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if existing != nil && existing.DispatchRequestID == dispatchID && existing.BaseRevision != nil && *existing.BaseRevision == baseRevision {
-			view, viewErr := sessionCombinedConclusionView(tx, obligation)
-			return view, false, viewErr
-		}
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	dispatchID, applyKey := sessionBlackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
-	now := time.Now().UTC()
-	dispatch := ConclusionDispatch{
-		ID: newIDMust(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindInitial,
-		ContinuationID: obligation.SourceContinuationID, SourceSessionID: obligation.SourceSessionID,
-		DispatchRequestID: dispatchID, BaseRevision: intPointer(baseRevision),
-		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-	}
-	if _, err := tx.Exec(`INSERT INTO session_conclusion_dispatches
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, dispatch.ID, dispatch.ObligationID, string(dispatch.Kind), dispatch.ContinuationID,
-		dispatch.SourceSessionID, dispatch.DispatchRequestID, baseRevision, string(dispatch.DeliveryState),
-		formatTime(now), formatTime(now)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session initial Conclusion Dispatch: %w", err)
-	}
-	obligation.State = BlackboardConclusionReceiptDispatchRequested
-	obligation.ApplyIdempotencyKey = applyKey
-	obligation.AutomaticTurnCount = 1
-	obligation.BaseRevision = intPointer(baseRevision)
-	obligation.UpdatedAt = now
-	if _, err := tx.Exec(`UPDATE session_pending_blackboard_conclusions
-		SET state=?,apply_idempotency_key=?,automatic_turn_count=?,base_revision=?,updated_at=? WHERE id=?`,
-		string(obligation.State), applyKey, obligation.AutomaticTurnCount, baseRevision, formatTime(now), obligation.ID); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("advance Session Blackboard conclusion obligation: %w", err)
-	}
-	view := sessionObligationView(obligation)
-	view.ActiveDispatchID = dispatch.ID
-	view.DispatchKind = dispatch.Kind
-	view.DispatchRequestID = dispatch.DispatchRequestID
-	view.ContinuationID = dispatch.ContinuationID
-	view.SourceSessionID = dispatch.SourceSessionID
-	view.BaseRevision = dispatch.BaseRevision
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "dispatch_requested", "receipt_id": obligation.ID, "source_turn_id": obligation.SourceTurnID,
-		"request_id": dispatchID, "base_revision": baseRevision, "turn_kind": "control",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Session Blackboard conclusion dispatch: %w", err)
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), created, nil
 }
 
-// MarkBlackboardConclusionSendStarted closes the provider-acceptance ambiguity
-// window on the ACTIVE dispatch before SendTurn. Only the active dispatch may
-// claim the fence; replay observes the original timestamp.
 func (s *Service) MarkBlackboardConclusionSendStarted(dispatchRequestID string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || now.IsZero() {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionSendStarted(dispatchRequestID, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	result, err := tx.Exec(`UPDATE session_conclusion_dispatches SET send_attempt_count=1,send_started_at=?,updated_at=?
-		WHERE dispatch_request_id=? AND delivery_state=? AND send_attempt_count=0 AND send_started_at IS NULL`,
-		formatTime(now), formatTime(now), dispatchRequestID, string(ConclusionDispatchRequested))
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	changed, _ := result.RowsAffected()
-	view, err := sessionConclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if changed == 0 {
-		return view, false, nil
-	}
-	if changed != 1 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionAwaiting records provider acceptance of the Conclude
-// Turn on the ACTIVE dispatch. Replaying the same correlation is idempotent.
 func (s *Service) MarkBlackboardConclusionAwaiting(dispatchRequestID, controlTurnID string) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID, controlTurnID = strings.TrimSpace(dispatchRequestID), strings.TrimSpace(controlTurnID)
-	if dispatchRequestID == "" || controlTurnID == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionAwaiting(dispatchRequestID, controlTurnID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	return s.advanceSessionActiveConclusionDispatch(dispatchRequestID, ConclusionDispatchRequested, ConclusionDispatchAwaitingResult,
-		BlackboardConclusionReceiptAwaitingResult,
-		func(receipt BlackboardConclusionReceipt) bool { return receipt.ControlTurnID == controlTurnID },
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, dispatch *ConclusionDispatch, now time.Time) error {
-			dispatch.DeliveryState = ConclusionDispatchAwaitingResult
-			dispatch.ControlTurnID = controlTurnID
-			if _, err := tx.Exec(`UPDATE session_conclusion_dispatches SET delivery_state=?,control_turn_id=?,updated_at=? WHERE id=?`,
-				string(dispatch.DeliveryState), controlTurnID, formatTime(now), dispatch.ID); err != nil {
-				return err
-			}
-			return appendSessionBlackboardConclusionEventTx(tx, sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation), EventPayload{
-				"phase": "awaiting_result", "receipt_id": dispatch.ObligationID, "request_id": dispatchRequestID,
-				"source_turn_id": obligation.SourceTurnID, "control_turn_id": controlTurnID, "turn_kind": "control",
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// HandleBlackboardConclusionFailure durably resolves a failed Conclude Turn.
-// One invalid initial result may claim a single automatic repair, which
-// supersedes the failed dispatch and creates a NEW repair dispatch on the same
-// immutable continuation and source session.
 func (s *Service) HandleBlackboardConclusionFailure(dispatchRequestID string, code BlackboardConclusionErrorCode, detail ConclusionValidationDetail, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || cooldown < 0 ||
-		(code != BlackboardConclusionErrorInvalidResult && code != BlackboardConclusionErrorToolUseForbidden && code != BlackboardConclusionErrorRuntimeRecoveryRequired) {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if detail.Valid() && code != BlackboardConclusionErrorInvalidResult {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().HandleBlackboardConclusionFailure(dispatchRequestID, code, detail, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion failure: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadSessionActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired {
-		return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if obligation.State != BlackboardConclusionReceiptAwaitingResult || dispatch.DeliveryState != ConclusionDispatchAwaitingResult {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if owner.ConclusionRepairAllowed(code, obligation.AutomaticTurnCount, obligation.RepairCount, obligation.VersionRegenerationCount, obligation.ExplicitRetryCount) {
-		repairNumber := obligation.RepairCount + 1
-		requestID := sessionBlackboardConclusionAttemptRequestID("repair", dispatch.ContinuationID, obligation.SourceTurnID, repairNumber, "")
-		nextEligible := now.Add(cooldown)
-		nowDispatch := ConclusionDispatch{
-			ID: newIDMust(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRepair,
-			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
-			DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
-			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-		}
-		if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "superseded_by_repair", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if _, err := tx.Exec(`INSERT INTO session_conclusion_dispatches
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-			formatTime(now), formatTime(now)); err != nil {
-			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session repair Conclusion Dispatch: %w", err)
-		}
-		obligation.State = BlackboardConclusionReceiptRepairDispatchRequested
-		obligation.AutomaticTurnCount++
-		obligation.RepairCount++
-		obligation.ErrorCode = code
-		obligation.NextEligibleAt = &nextEligible
-		obligation.ValidationReason = detail.Reason
-		obligation.ValidationFieldPath = detail.FieldPath
-		obligation.ValidationExpected = detail.Expected
-		obligation.UpdatedAt = now
-		if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		view := sessionObligationView(obligation)
-		view.ActiveDispatchID = nowDispatch.ID
-		view.DispatchKind = nowDispatch.Kind
-		view.DispatchRequestID = nowDispatch.DispatchRequestID
-		view.ContinuationID = nowDispatch.ContinuationID
-		view.SourceSessionID = nowDispatch.SourceSessionID
-		view.BaseRevision = nowDispatch.BaseRevision
-		payload := EventPayload{"phase": "repair_requested", "receipt_id": obligation.ID, "request_id": requestID,
-			"error_code": string(code), "automatic_turn_count": obligation.AutomaticTurnCount, "repair_count": obligation.RepairCount, "turn_kind": "control"}
-		owner.AppendConclusionValidationEventPayload(payload, detail)
-		if err := appendSessionBlackboardConclusionEventTx(tx, view, payload, now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if err := tx.Commit(); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		return view, true, nil
-	}
-	actionCode := owner.ConclusionFailureActionCode(code, obligation.RepairCount, obligation.VersionRegenerationCount)
-	nextEligible := now.Add(cooldown)
-	if obligation.NextEligibleAt != nil {
-		nextEligible = obligation.NextEligibleAt.UTC()
-	}
-	var failErr error
-	obligation, failErr = sessionFailActiveDispatchTx(tx, obligation, dispatch, actionCode, nextEligible, detail, now)
-	if failErr != nil {
-		return BlackboardConclusionReceipt{}, false, failErr
-	}
-	view := sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	payload := EventPayload{"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"error_code": string(actionCode), "next_eligible_at": nextEligible.Format(time.RFC3339Nano)}
-	owner.AppendConclusionValidationEventPayload(payload, detail)
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, payload, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// ClaimBlackboardConclusionVersionSync records the intent to synchronize the
-// active dispatch's continuation before version regeneration can be claimed.
 func (s *Service) ClaimBlackboardConclusionVersionSync(dispatchRequestID string) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().ClaimBlackboardConclusionVersionSync(dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	return s.advanceSessionObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptValidated,
-		BlackboardConclusionReceiptVersionSyncRequested,
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
-			obligation.State = BlackboardConclusionReceiptVersionSyncRequested
-			obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
-			obligation.UpdatedAt = now
-			if _, err := tx.Exec(`UPDATE session_pending_blackboard_conclusions SET state=?,error_code=?,updated_at=? WHERE id=?`,
-				string(obligation.State), string(obligation.ErrorCode), formatTime(now), obligation.ID); err != nil {
-				return err
-			}
-			return appendSessionBlackboardConclusionEventTx(tx, sessionObligationView(*obligation), EventPayload{
-				"phase": "version_sync_requested", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-				"turn_kind": "control",
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// HandleBlackboardConclusionVersionConflict discards a validated result whose
-// revision guard lost a real race and claims one fresh semantic generation.
-// The old validated dispatch is superseded and a NEW version_regeneration
-// dispatch is created; budgets belong to the obligation and never reset.
 func (s *Service) HandleBlackboardConclusionVersionConflict(dispatchRequestID string, currentRevision int, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || currentRevision < 0 || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().HandleBlackboardConclusionVersionConflict(dispatchRequestID, currentRevision, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion version conflict: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadSessionActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired && obligation.ErrorCode == BlackboardConclusionErrorVersionConflict {
-		return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if obligation.State != BlackboardConclusionReceiptVersionSyncRequested || dispatch.BaseRevision == nil || currentRevision <= *dispatch.BaseRevision {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	nextEligible := now.Add(cooldown)
-	if owner.ConclusionVersionRegenerationAllowed(obligation.VersionRegenerationCount, obligation.AutomaticTurnCount, obligation.ExplicitRetryCount) {
-		requestID := sessionBlackboardConclusionAttemptRequestID("version", dispatch.ContinuationID, obligation.SourceTurnID, 1, fmt.Sprintf("%d", currentRevision))
-		nowDispatch := ConclusionDispatch{
-			ID: newIDMust(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindVersionRegeneration,
-			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
-			DispatchRequestID: requestID, BaseRevision: intPointer(currentRevision),
-			SynchronizedRevision: intPointer(currentRevision), DeliveryState: ConclusionDispatchRequested,
-			CreatedAt: now, UpdatedAt: now,
-		}
-		if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "superseded_by_version_regeneration", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if _, err := tx.Exec(`INSERT INTO session_conclusion_dispatches
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,synchronized_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, currentRevision, currentRevision, string(nowDispatch.DeliveryState),
-			formatTime(now), formatTime(now)); err != nil {
-			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session version regeneration Conclusion Dispatch: %w", err)
-		}
-		obligation.State = BlackboardConclusionReceiptVersionRegenerationDispatchRequested
-		obligation.VersionRegenerationCount = 1
-		obligation.AutomaticTurnCount++
-		obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
-		obligation.NextEligibleAt = &nextEligible
-		obligation.CanonicalResultJSON = nil
-		obligation.CanonicalResultSHA256 = ""
-		obligation.UpdatedAt = now
-		if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		view := sessionObligationView(obligation)
-		view.ActiveDispatchID = nowDispatch.ID
-		view.DispatchKind = nowDispatch.Kind
-		view.DispatchRequestID = nowDispatch.DispatchRequestID
-		view.ContinuationID = nowDispatch.ContinuationID
-		view.SourceSessionID = nowDispatch.SourceSessionID
-		view.BaseRevision = nowDispatch.BaseRevision
-		view.SynchronizedRevision = nowDispatch.SynchronizedRevision
-		if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-			"phase": "version_regeneration_requested", "receipt_id": obligation.ID, "request_id": requestID,
-			"base_revision": currentRevision, "error_code": string(BlackboardConclusionErrorVersionConflict),
-			"automatic_turn_count": obligation.AutomaticTurnCount, "version_regeneration_count": obligation.VersionRegenerationCount,
-			"turn_kind": "control",
-		}, now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if err := tx.Commit(); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		return view, true, nil
-	}
-
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
-	obligation.NextEligibleAt = &nextEligible
-	obligation.BaseRevision = intPointer(currentRevision)
-	obligation.CanonicalResultJSON = nil
-	obligation.CanonicalResultSHA256 = ""
-	obligation.UpdatedAt = now
-	if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"base_revision": currentRevision, "error_code": string(BlackboardConclusionErrorVersionConflict),
-		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "version_regeneration_exhausted",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionVersionConflictActionRequired rejects a validated
-// result whose record or change versions are semantically incompatible with
-// the apply contract and requires operator action immediately.
 func (s *Service) MarkBlackboardConclusionVersionConflictActionRequired(dispatchRequestID string, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	return s.MarkBlackboardConclusionApplyActionRequired(dispatchRequestID, BlackboardConclusionErrorVersionConflict, now, cooldown)
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionVersionConflictActionRequired(dispatchRequestID, now, cooldown)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
+	}
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionApplyActionRequired fails closed when a validated
-// result cannot be applied or its pre-regeneration synchronization fails.
 func (s *Service) MarkBlackboardConclusionApplyActionRequired(dispatchRequestID string, code BlackboardConclusionErrorCode, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || cooldown < 0 || !validSessionBlackboardConclusionErrorCode(code) {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionApplyActionRequired(dispatchRequestID, code, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin incompatible Session Blackboard conclusion version: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadSessionConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired && obligation.ErrorCode == code {
-		return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if obligation.State != BlackboardConclusionReceiptValidated && obligation.State != BlackboardConclusionReceiptVersionSyncRequested {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	nextEligible := now.Add(cooldown)
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = code
-	obligation.NextEligibleAt = &nextEligible
-	obligation.CanonicalResultJSON = nil
-	obligation.CanonicalResultSHA256 = ""
-	obligation.UpdatedAt = now
-	if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"base_revision": intPointerValue(dispatch.BaseRevision), "error_code": string(code),
-		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "apply_failed",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionRecoveryActionRequired closes crash windows after a
-// repair, version sync/regeneration, or operator-authorized retry was durably
-// claimed but could not finish. The reason is a closed operator-visible token.
 func (s *Service) MarkBlackboardConclusionRecoveryActionRequired(dispatchRequestID string, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || !owner.ValidConclusionRecoveryReason(reason) || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionRecoveryActionRequired(dispatchRequestID, reason, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadSessionConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	return s.markSessionConclusionRecoveryActionRequiredTx(tx, obligation, dispatch, reason, now, cooldown)
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionRecoveryActionRequiredByReceiptID resolves any
-// restart-stranded pre-apply obligation, including pending obligations that do
-// not yet have a dispatch. Replays preserve the original cooldown and counters.
 func (s *Service) MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligationID string, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	obligationID = strings.TrimSpace(obligationID)
-	if obligationID == "" || !owner.ValidConclusionRecoveryReason(reason) || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligationID, reason, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion dispatch recovery: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadSessionPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	dispatch, err := sessionActiveConclusionDispatchTx(tx, obligation.ID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return s.markSessionConclusionRecoveryActionRequiredTx(tx, obligation, dispatch, reason, now, cooldown)
+	return receiptFromConclusion(rec), changed, nil
 }
 
-func (s *Service) markSessionConclusionRecoveryActionRequiredTx(tx *sql.Tx, obligation PendingBlackboardConclusion, dispatch *ConclusionDispatch, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	if obligation.State == BlackboardConclusionReceiptActionRequired {
-		return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if !owner.ConclusionRecoveryEligible(obligation.State) {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	nextEligible := now.Add(cooldown)
-	if obligation.NextEligibleAt != nil {
-		nextEligible = obligation.NextEligibleAt.UTC()
-	}
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = BlackboardConclusionErrorRuntimeRecoveryRequired
-	obligation.RecoveryReason = reason
-	obligation.NextEligibleAt = &nextEligible
-	obligation.UpdatedAt = now
-	if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	// Supersede ANY active dispatch so a later provider callback resolves to a
-	// terminal delivery and is recorded as a late outcome instead of being
-	// silently dropped while the obligation is already action_required.
-	if dispatch != nil && owner.ConclusionDispatchActive(dispatch.DeliveryState) {
-		if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-	}
-	view := sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": sessionObligationDispatchRequestID(dispatch),
-		"error_code": string(obligation.ErrorCode), "recovery_reason": string(reason),
-		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "dispatch_recovery",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
-}
-
-// MarkBlackboardConclusionWorkTurnConflict resolves a conclusion dispatch that
-// a non-yielding provider work turn refused. Within the bounded conflict
-// budget it stays operator-retryable; once exhausted it becomes the distinct,
-// non-retryable never-settled terminal.
 func (s *Service) MarkBlackboardConclusionWorkTurnConflict(dispatchRequestID string, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionWorkTurnConflict(dispatchRequestID, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion work turn conflict: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadSessionActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired {
-		return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if dispatch.DeliveryState != ConclusionDispatchRequested {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	errorCode, reason := owner.ConclusionWorkTurnConflictOutcome(obligation.ExplicitRetryCount)
-	nextEligible := now.Add(cooldown)
-	if obligation.NextEligibleAt != nil {
-		nextEligible = obligation.NextEligibleAt.UTC()
-	}
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = errorCode
-	obligation.NextEligibleAt = &nextEligible
-	obligation.UpdatedAt = now
-	if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"error_code": string(errorCode), "next_eligible_at": nextEligible.Format(time.RFC3339Nano),
-		"reason": reason, "explicit_retry_count": obligation.ExplicitRetryCount,
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// BlackboardConclusionRecoveryCandidates lists obligations in pre-apply states
-// for an ownership-aware daemon coordinator. It never mutates state.
 func (s *Service) BlackboardConclusionRecoveryCandidates() ([]BlackboardConclusionReceipt, error) {
-	rows, err := s.db.Query(`SELECT `+sessionPendingBlackboardConclusionColumns+` FROM session_pending_blackboard_conclusions
-		WHERE state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
-		string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
-		string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
-		string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
+	recs, err := s.conclusions().BlackboardConclusionRecoveryCandidates()
 	if err != nil {
-		return nil, fmt.Errorf("list Session Blackboard conclusion recovery candidates: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanSessionPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan Session Blackboard conclusion recovery candidate: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate Session Blackboard conclusion recovery candidates: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, fmt.Errorf("close Session Blackboard conclusion recovery candidates: %w", err)
-	}
-	views := make([]BlackboardConclusionReceipt, 0, len(obligations))
-	for _, obligation := range obligations {
-		view, viewErr := sessionCombinedConclusionView(s.db, obligation)
-		if viewErr != nil {
-			return nil, fmt.Errorf("scan Session Blackboard conclusion recovery candidate view: %w", viewErr)
-		}
-		views = append(views, view)
-	}
-	return views, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// ReconcileStrandedBlackboardConclusionRecoveries makes durably claimed
-// repair, version sync/regeneration, and explicit retry work
-// operator-actionable after daemon restart.
 func (s *Service) ReconcileStrandedBlackboardConclusionRecoveries(now time.Time, cooldown time.Duration) ([]BlackboardConclusionReceipt, error) {
-	if cooldown < 0 {
-		return nil, ErrInvalidBlackboardConclusionReceipt
-	}
-	rows, err := s.db.Query(`SELECT `+sessionPendingBlackboardConclusionColumns+` FROM session_pending_blackboard_conclusions
-		WHERE state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
-		string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
-		string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
-		string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
+	recs, err := s.conclusions().ReconcileStrandedBlackboardConclusionRecoveries(now, cooldown)
 	if err != nil {
-		return nil, fmt.Errorf("list stranded Session Blackboard conclusion recoveries: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanSessionPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan stranded Session Blackboard conclusion recovery: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate stranded Session Blackboard conclusion recoveries: %w", err)
-	}
-	_ = rows.Close()
-	reconciled := make([]BlackboardConclusionReceipt, 0, len(obligations))
-	for _, obligation := range obligations {
-		receipt, changed, err := s.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligation.ID, ConclusionRecoveryDispatchFailed, now, cooldown)
-		if err != nil {
-			return nil, err
-		}
-		if changed {
-			reconciled = append(reconciled, receipt)
-		}
-	}
-	return reconciled, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// RetryBlackboardConclusion atomically claims one operator-authorized retry for
-// an action_required obligation. The retry supersedes the failed dispatch and
-// creates a NEW retry dispatch bound to the same immutable continuation and
-// source session. A never-dispatched obligation is re-armed to pending so the
-// initial dispatch claim runs on the live runtime.
 func (s *Service) RetryBlackboardConclusion(obligationID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	obligationID, idempotencyKey = strings.TrimSpace(obligationID), strings.TrimSpace(idempotencyKey)
-	if obligationID == "" || idempotencyKey == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, won, err := s.conclusions().RetryBlackboardConclusion(obligationID, idempotencyKey, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadSessionPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	receipt, won, err := retrySessionBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
-	if err != nil || !won {
-		return receipt, won, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return receipt, true, nil
+	return receiptFromConclusion(rec), won, nil
 }
 
-// RetryLatestBlackboardConclusion atomically applies a Session-scoped operator
-// retry key to the latest durable conclusion obligation.
 func (s *Service) RetryLatestBlackboardConclusion(sessionID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	sessionID, idempotencyKey = strings.TrimSpace(sessionID), strings.TrimSpace(idempotencyKey)
-	if sessionID == "" || idempotencyKey == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, won, err := s.conclusions().RetryLatestBlackboardConclusion(sessionID, idempotencyKey, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := scanSessionPendingBlackboardConclusion(tx.QueryRow(`SELECT `+sessionPendingBlackboardConclusionColumns+`
-		FROM session_pending_blackboard_conclusions WHERE session_id=? ORDER BY created_at DESC,id DESC LIMIT 1`, sessionID))
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	receipt, won, err := retrySessionBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
-	if err != nil || !won {
-		return receipt, won, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return receipt, true, nil
+	return receiptFromConclusion(rec), won, nil
 }
 
-func retrySessionBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	var priorObligationID string
-	err := tx.QueryRow(`SELECT obligation_id FROM session_assisted_conclusion_retry_keys
-		WHERE session_id=? AND idempotency_key=?`, obligation.SessionID, idempotencyKey).Scan(&priorObligationID)
-	if err == nil {
-		prior, loadErr := loadSessionPendingBlackboardConclusionByID(tx, priorObligationID)
-		if loadErr != nil {
-			return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(loadErr)
-		}
-		view, viewErr := sessionCombinedConclusionView(tx, prior)
-		if viewErr != nil {
-			return BlackboardConclusionReceipt{}, false, viewErr
-		}
-		return view, false, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("read Session Blackboard conclusion retry idempotency history: %w", err)
-	}
-	switch owner.ConclusionRetryDecisionFor(obligation.State, obligation.ErrorCode, obligation.RecoveryReason, obligation.NextEligibleAt, now) {
-	case owner.ConclusionRetryInvalidState:
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	case owner.ConclusionRetryNeverSettled:
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionWorkTurnNeverSettled
-	case owner.ConclusionRetryAcceptanceAmbiguous, owner.ConclusionRetryCooldown:
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
-	}
-	dispatch, err := sessionActiveConclusionDispatchTx(tx, obligation.ID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if dispatch == nil {
-		// No active dispatch (for example the failed repair was superseded).
-		// Bind the retry to the LATEST dispatch's immutable binding, which is
-		// either the live replacement (after a steer recovery) or the original
-		// source binding of the completed Work Turn.
-		dispatch, err = latestSessionConclusionDispatchTx(tx, obligation.ID)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-	}
-	retryNumber := obligation.ExplicitRetryCount + 1
-	if dispatch == nil {
-		initialRequestID, _ := sessionBlackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
-		obligation.State = BlackboardConclusionReceiptPending
-		obligation.ExplicitRetryCount++
-		obligation.OperatorRetryKey = idempotencyKey
-		obligation.ErrorCode = ""
-		obligation.NextEligibleAt = nil
-		obligation.UpdatedAt = now
-		if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if _, err := tx.Exec(`INSERT INTO session_assisted_conclusion_retry_keys
-			(session_id,obligation_id,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
-			obligation.SessionID, obligation.ID, idempotencyKey, initialRequestID, formatTime(now)); err != nil {
-			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session pending Blackboard conclusion retry history: %w", err)
-		}
-		if err := appendSessionBlackboardConclusionEventTx(tx, sessionObligationView(obligation), EventPayload{
-			"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": initialRequestID,
-			"explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control",
-		}, now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		return sessionObligationView(obligation), true, nil
-	}
-	requestID := sessionBlackboardConclusionAttemptRequestID("retry", dispatch.ContinuationID, obligation.SourceTurnID, retryNumber, idempotencyKey)
-	nowDispatch := ConclusionDispatch{
-		ID: newIDMust(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRetry,
-		ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
-		DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
-		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-	}
-	if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "superseded_by_retry", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if _, err := tx.Exec(`INSERT INTO session_conclusion_dispatches
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-		formatTime(now), formatTime(now)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session retry Conclusion Dispatch: %w", err)
-	}
-	obligation.State = BlackboardConclusionReceiptDispatchRequested
-	obligation.ExplicitRetryCount++
-	obligation.OperatorRetryKey = idempotencyKey
-	obligation.ErrorCode = ""
-	obligation.NextEligibleAt = nil
-	// The operator retry starts a fresh generation: the previous validated
-	// result and its bounded rejection detail are no longer current.
-	obligation.CanonicalResultJSON = nil
-	obligation.CanonicalResultSHA256 = ""
-	obligation.ValidationReason = ""
-	obligation.ValidationFieldPath = ""
-	obligation.ValidationExpected = ""
-	obligation.UpdatedAt = now
-	if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if _, err := tx.Exec(`INSERT INTO session_assisted_conclusion_retry_keys
-		(session_id,obligation_id,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
-		obligation.SessionID, obligation.ID, idempotencyKey, requestID, formatTime(now)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session Blackboard conclusion retry idempotency history: %w", err)
-	}
-	view := sessionObligationView(obligation)
-	view.ActiveDispatchID = nowDispatch.ID
-	view.DispatchKind = nowDispatch.Kind
-	view.DispatchRequestID = nowDispatch.DispatchRequestID
-	view.ContinuationID = nowDispatch.ContinuationID
-	view.SourceSessionID = nowDispatch.SourceSessionID
-	view.BaseRevision = nowDispatch.BaseRevision
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": requestID, "explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control"}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
-}
-
-// BlackboardConclusionByDispatchRequestID resolves the obligation whose ACTIVE
-// dispatch owns the provider request correlation. A callback that resolves to
-// a superseded or late dispatch is durably recorded as a late terminal delivery
-// outcome and returns ErrBlackboardConclusionDispatchInactive so the
-// coordinator drops it; it can never mutate the obligation or Blackboard.
 func (s *Service) BlackboardConclusionByDispatchRequestID(dispatchRequestID string) (BlackboardConclusionReceipt, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" {
-		return BlackboardConclusionReceipt{}, ErrInvalidBlackboardConclusionReceipt
-	}
-	dispatch, err := scanSessionConclusionDispatch(s.db.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-		FROM session_conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
+	rec, err := s.conclusions().BlackboardConclusionByDispatchRequestID(dispatchRequestID)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, sessionBlackboardConclusionLookupError(err)
+		return BlackboardConclusionReceipt{}, mapConclusionError(err)
 	}
-	obligation, err := loadSessionPendingBlackboardConclusionByID(s.db, dispatch.ObligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, sessionBlackboardConclusionLookupError(err)
-	}
-	if !owner.ConclusionDispatchActive(dispatch.DeliveryState) {
-		if dispatch.DeliveryState == ConclusionDispatchSuperseded {
-			_, _ = s.db.Exec(`UPDATE session_conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=?
-				WHERE dispatch_request_id=? AND delivery_state=?`,
-				string(ConclusionDispatchLateTerminal), "late_result", formatTime(time.Now().UTC()),
-				dispatchRequestID, string(ConclusionDispatchSuperseded))
-		}
-		return BlackboardConclusionReceipt{}, ErrBlackboardConclusionDispatchInactive
-	}
-	return sessionBlackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
+	return receiptFromConclusion(rec), nil
 }
 
-// RecordLateConclusionDispatchOutcome durably records a callback that resolved
-// to a superseded dispatch: the dispatch becomes late_terminal and can never
-// advance the obligation. It is idempotent.
 func (s *Service) RecordLateConclusionDispatchOutcome(dispatchRequestID string) error {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" {
-		return ErrInvalidBlackboardConclusionReceipt
-	}
-	_, err := s.db.Exec(`UPDATE session_conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=?
-		WHERE dispatch_request_id=? AND delivery_state=?`,
-		string(ConclusionDispatchLateTerminal), "late_result", formatTime(time.Now().UTC()),
-		dispatchRequestID, string(ConclusionDispatchSuperseded))
-	return err
+	return mapConclusionError(s.conclusions().RecordLateConclusionDispatchOutcome(dispatchRequestID))
 }
 
-// MarkBlackboardConclusionValidated persists canonical closed result bytes on
-// the obligation before Blackboard application.
 func (s *Service) MarkBlackboardConclusionValidated(dispatchRequestID string, canonicalResult []byte) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || len(canonicalResult) == 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionValidated(dispatchRequestID, canonicalResult)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	canonicalResult = append([]byte(nil), canonicalResult...)
-	hash := owner.CanonicalConclusionSHA256(canonicalResult)
-	return s.advanceSessionObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptAwaitingResult,
-		BlackboardConclusionReceiptValidated,
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
-			obligation.State = BlackboardConclusionReceiptValidated
-			obligation.CanonicalResultJSON = canonicalResult
-			obligation.CanonicalResultSHA256 = hash
-			obligation.ErrorCode = ""
-			obligation.NextEligibleAt = nil
-			obligation.UpdatedAt = now
-			if _, err := tx.Exec(`UPDATE session_pending_blackboard_conclusions
-				SET state=?,canonical_result_json=?,canonical_result_sha256=?,error_code=NULL,next_eligible_at=NULL,updated_at=? WHERE id=?`,
-				string(obligation.State), canonicalResult, hash, formatTime(now), obligation.ID); err != nil {
-				return err
-			}
-			dispatch, err := sessionActiveConclusionDispatchTx(tx, obligation.ID)
-			if err != nil {
-				return err
-			}
-			if dispatch == nil {
-				return ErrInvalidBlackboardConclusionReceipt
-			}
-			dispatch.DeliveryState = ConclusionDispatchValidated
-			if _, err := tx.Exec(`UPDATE session_conclusion_dispatches SET delivery_state=?,updated_at=? WHERE id=?`,
-				string(dispatch.DeliveryState), formatTime(now), dispatch.ID); err != nil {
-				return err
-			}
-			view := sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation)
-			return appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-				"phase": "result_validated", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-				"source_turn_id": obligation.SourceTurnID, "control_turn_id": dispatch.ControlTurnID, "result_hash": hash,
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionApplied completes the obligation with the exact
-// Blackboard revision returned by ApplyForSessionContinuation.
 func (s *Service) MarkBlackboardConclusionApplied(dispatchRequestID string, appliedRevision int) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || appliedRevision < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionApplied(dispatchRequestID, appliedRevision)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	return s.advanceSessionObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptValidated,
-		BlackboardConclusionReceiptApplied,
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
-			obligation.State = BlackboardConclusionReceiptApplied
-			obligation.AppliedRevision = intPointer(appliedRevision)
-			obligation.UpdatedAt = now
-			if _, err := tx.Exec(`UPDATE session_pending_blackboard_conclusions SET state=?,applied_revision=?,updated_at=? WHERE id=?`,
-				string(obligation.State), appliedRevision, formatTime(now), obligation.ID); err != nil {
-				return err
-			}
-			dispatch, err := sessionActiveConclusionDispatchTx(tx, obligation.ID)
-			if err != nil {
-				return err
-			}
-			if dispatch == nil {
-				return ErrInvalidBlackboardConclusionReceipt
-			}
-			dispatch.DeliveryState = ConclusionDispatchApplied
-			dispatch.TerminalOutcome = "applied"
-			if _, err := tx.Exec(`UPDATE session_conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=? WHERE id=?`,
-				string(dispatch.DeliveryState), dispatch.TerminalOutcome, formatTime(now), dispatch.ID); err != nil {
-				return err
-			}
-			view := sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation)
-			return appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-				"phase": "applied", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-				"source_turn_id": obligation.SourceTurnID, "control_turn_id": dispatch.ControlTurnID, "applied_revision": appliedRevision,
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// LatestBlackboardConclusion returns the newest durable obligation for a
-// Session together with its ACTIVE dispatch.
 func (s *Service) LatestBlackboardConclusion(sessionID string) (*BlackboardConclusionReceipt, error) {
 	if _, err := s.Get(sessionID); err != nil {
 		return nil, err
 	}
-	obligation, err := scanSessionPendingBlackboardConclusion(s.db.QueryRow(`
-		SELECT `+sessionPendingBlackboardConclusionColumns+`
-		FROM session_pending_blackboard_conclusions WHERE session_id=? ORDER BY created_at DESC,id DESC LIMIT 1`, sessionID))
-	if errors.Is(err, sql.ErrNoRows) {
+	rec, err := s.conclusions().LatestBlackboardConclusion(sessionID)
+	if err != nil {
+		return nil, mapConclusionError(err)
+	}
+	if rec == nil {
 		return nil, nil
 	}
-	if err != nil {
-		return nil, fmt.Errorf("load latest Session Blackboard conclusion obligation: %w", err)
-	}
-	view, err := sessionCombinedConclusionView(s.db, obligation)
-	if err != nil {
-		return nil, err
-	}
+	view := receiptFromConclusion(*rec)
 	return &view, nil
 }
 
-// ValidatedBlackboardConclusions returns durable apply intents for daemon
-// startup replay. It is read-only and preserves canonical and idempotency
-// lineage exactly as stored.
 func (s *Service) ValidatedBlackboardConclusions() ([]BlackboardConclusionReceipt, error) {
-	rows, err := s.db.Query(`SELECT `+sessionPendingBlackboardConclusionColumns+`
-		FROM session_pending_blackboard_conclusions WHERE state=? ORDER BY created_at,id`, string(BlackboardConclusionReceiptValidated))
+	recs, err := s.conclusions().ValidatedBlackboardConclusions()
 	if err != nil {
-		return nil, fmt.Errorf("list validated Session Blackboard conclusions: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanSessionPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan validated Session Blackboard conclusion: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate validated Session Blackboard conclusions: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, fmt.Errorf("close validated Session Blackboard conclusions: %w", err)
-	}
-	views := make([]BlackboardConclusionReceipt, 0, len(obligations))
-	for _, obligation := range obligations {
-		view, viewErr := sessionCombinedConclusionView(s.db, obligation)
-		if viewErr != nil {
-			return nil, fmt.Errorf("scan validated Session Blackboard conclusion view: %w", viewErr)
-		}
-		views = append(views, view)
-	}
-	return views, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// ConclusionDispatches returns the immutable dispatch history for an
-// obligation, newest first.
 func (s *Service) ConclusionDispatches(obligationID string) ([]ConclusionDispatch, error) {
-	obligationID = strings.TrimSpace(obligationID)
-	if obligationID == "" {
-		return nil, ErrInvalidBlackboardConclusionReceipt
-	}
-	rows, err := s.db.Query(`SELECT `+sessionConclusionDispatchColumns+` FROM session_conclusion_dispatches
-		WHERE obligation_id=? ORDER BY rowid DESC`, obligationID)
+	dispatches, err := s.conclusions().ConclusionDispatches(obligationID)
 	if err != nil {
-		return nil, fmt.Errorf("list Session Conclusion Dispatches: %w", err)
-	}
-	defer rows.Close()
-	var dispatches []ConclusionDispatch
-	for rows.Next() {
-		dispatch, scanErr := scanSessionConclusionDispatch(rows)
-		if scanErr != nil {
-			return nil, fmt.Errorf("scan Session Conclusion Dispatch: %w", scanErr)
-		}
-		dispatches = append(dispatches, dispatch)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate Session Conclusion Dispatches: %w", err)
+		return nil, mapConclusionError(err)
 	}
 	return dispatches, nil
 }
 
-// CreateRecoveryConclusionDispatches supersedes every in-flight Conclusion
-// Dispatch of a Session that is bound to the old Continuation and creates a NEW
-// recovery dispatch bound immutably to the replacement Continuation and
-// session. Historical dispatch identity is never rewritten (ADR 0021).
 func (s *Service) CreateRecoveryConclusionDispatches(sessionID, oldContinuationID, replacementContinuationID, replacementSessionID string) ([]BlackboardConclusionReceipt, error) {
-	sessionID, oldContinuationID, replacementContinuationID, replacementSessionID =
-		strings.TrimSpace(sessionID), strings.TrimSpace(oldContinuationID), strings.TrimSpace(replacementContinuationID), strings.TrimSpace(replacementSessionID)
-	if sessionID == "" || oldContinuationID == "" || replacementContinuationID == "" || replacementSessionID == "" || oldContinuationID == replacementContinuationID {
-		return nil, ErrInvalidBlackboardConclusionReceipt
-	}
-	now := time.Now().UTC()
-	tx, err := s.db.Begin()
+	recs, err := s.conclusions().CreateRecoveryConclusionDispatches(sessionID, oldContinuationID, replacementContinuationID, replacementSessionID)
 	if err != nil {
-		return nil, fmt.Errorf("begin Session recovery Conclusion Dispatch: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	rows, err := tx.Query(`SELECT `+sessionPendingBlackboardConclusionColumns+` FROM session_pending_blackboard_conclusions
-		WHERE session_id=? AND state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
-		sessionID, string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
-		string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
-		string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
-	if err != nil {
-		return nil, fmt.Errorf("list Session recovery Conclusion Dispatches: %w", err)
-	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanSessionPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan Session recovery Conclusion Dispatch obligation: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate Session recovery Conclusion Dispatch obligations: %w", err)
-	}
-	_ = rows.Close()
-
-	var views []BlackboardConclusionReceipt
-	for _, obligation := range obligations {
-		dispatch, dispatchErr := sessionActiveConclusionDispatchTx(tx, obligation.ID)
-		if dispatchErr != nil && !errors.Is(dispatchErr, sql.ErrNoRows) {
-			return nil, dispatchErr
-		}
-		boundToOld := dispatch != nil && dispatch.ContinuationID == oldContinuationID
-		boundToReplacement := dispatch != nil && dispatch.ContinuationID == replacementContinuationID
-		pendingBoundToOld := dispatch == nil && obligation.State == BlackboardConclusionReceiptPending && obligation.SourceContinuationID == oldContinuationID
-		if !boundToOld && !pendingBoundToOld {
-			if boundToReplacement {
-				view, viewErr := sessionCombinedConclusionView(tx, obligation)
-				if viewErr != nil {
-					return nil, viewErr
-				}
-				views = append(views, view)
-			}
-			continue
-		}
-		if dispatch != nil {
-			if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "superseded_by_recovery", now); err != nil {
-				return nil, err
-			}
-		}
-		number := sessionConclusionDispatchSequence(tx, obligation.ID) + 1
-		requestID := sessionBlackboardConclusionAttemptRequestID("recovery", replacementContinuationID, obligation.SourceTurnID, number, "")
-		nowDispatch := ConclusionDispatch{
-			ID: newIDMust(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
-			ContinuationID: replacementContinuationID, SourceSessionID: replacementSessionID,
-			DispatchRequestID: requestID, BaseRevision: sessionDispatchBaseRevision(dispatch),
-			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-		}
-		if _, err := tx.Exec(`INSERT INTO session_conclusion_dispatches
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-			formatTime(now), formatTime(now)); err != nil {
-			return nil, fmt.Errorf("store Session recovery Conclusion Dispatch: %w", err)
-		}
-		switch obligation.State {
-		case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptAwaitingResult:
-			obligation.State = BlackboardConclusionReceiptDispatchRequested
-		}
-		obligation.UpdatedAt = now
-		if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-			return nil, err
-		}
-		view := sessionObligationView(obligation)
-		view.ActiveDispatchID = nowDispatch.ID
-		view.DispatchKind = nowDispatch.Kind
-		view.DispatchRequestID = nowDispatch.DispatchRequestID
-		view.ContinuationID = nowDispatch.ContinuationID
-		view.SourceSessionID = nowDispatch.SourceSessionID
-		view.BaseRevision = nowDispatch.BaseRevision
-		if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-			"phase": "recovery_dispatch_created", "receipt_id": obligation.ID, "request_id": requestID,
-			"replacement_continuation_id": replacementContinuationID, "replacement_session_id": replacementSessionID,
-			"turn_kind": "control",
-		}, now); err != nil {
-			return nil, err
-		}
-		views = append(views, view)
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit Session recovery Conclusion Dispatches: %w", err)
-	}
-	return views, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// CreateRecoveryConclusionDispatch supersedes the active dispatch (if any) of
-// one obligation and creates a NEW recovery dispatch bound immutably to the
-// proven-live replacement continuation + session. The old dispatch identity is
-// never rewritten. Won is false when the obligation is already bound to the
-// target continuation or is terminal.
 func (s *Service) CreateRecoveryConclusionDispatch(obligationID, continuationID, sessionID string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	obligationID, continuationID, sessionID = strings.TrimSpace(obligationID), strings.TrimSpace(continuationID), strings.TrimSpace(sessionID)
-	if obligationID == "" || continuationID == "" || sessionID == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, created, err := s.conclusions().CreateRecoveryConclusionDispatch(obligationID, continuationID, sessionID, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session recovery Conclusion Dispatch: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadSessionPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	dispatch, err := sessionActiveConclusionDispatchTx(tx, obligation.ID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if dispatch != nil && dispatch.ContinuationID == continuationID && dispatch.SourceSessionID == sessionID {
-		view, viewErr := sessionCombinedConclusionView(tx, obligation)
-		if viewErr != nil {
-			return BlackboardConclusionReceipt{}, false, viewErr
-		}
-		return view, false, nil
-	}
-	if obligation.State == BlackboardConclusionReceiptApplied || obligation.State == BlackboardConclusionReceiptClean {
-		view, viewErr := sessionCombinedConclusionView(tx, obligation)
-		if viewErr != nil {
-			return BlackboardConclusionReceipt{}, false, viewErr
-		}
-		return view, false, nil
-	}
-	if dispatch != nil {
-		if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "superseded_by_recovery", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-	}
-	number := sessionConclusionDispatchSequence(tx, obligation.ID) + 1
-	requestID := sessionBlackboardConclusionAttemptRequestID("recovery", continuationID, obligation.SourceTurnID, number, "")
-	nowDispatch := ConclusionDispatch{
-		ID: newIDMust(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
-		ContinuationID: continuationID, SourceSessionID: sessionID,
-		DispatchRequestID: requestID, BaseRevision: sessionDispatchBaseRevision(dispatch),
-		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-	}
-	if _, err := tx.Exec(`INSERT INTO session_conclusion_dispatches
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-		formatTime(now), formatTime(now)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Session recovery Conclusion Dispatch: %w", err)
-	}
-	switch obligation.State {
-	case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptAwaitingResult:
-		obligation.State = BlackboardConclusionReceiptDispatchRequested
-	}
-	obligation.UpdatedAt = now
-	if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := sessionObligationView(obligation)
-	view.ActiveDispatchID = nowDispatch.ID
-	view.DispatchKind = nowDispatch.Kind
-	view.DispatchRequestID = nowDispatch.DispatchRequestID
-	view.ContinuationID = nowDispatch.ContinuationID
-	view.SourceSessionID = nowDispatch.SourceSessionID
-	view.BaseRevision = nowDispatch.BaseRevision
-	if err := appendSessionBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "recovery_dispatch_created", "receipt_id": obligation.ID, "request_id": requestID,
-		"replacement_continuation_id": continuationID, "replacement_session_id": sessionID,
-		"turn_kind": "control",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Session recovery Conclusion Dispatch: %w", err)
-	}
-	return view, true, nil
-}
-
-// --- internal helpers ---
-
-func sessionObligationView(obligation PendingBlackboardConclusion) BlackboardConclusionReceipt {
-	view := BlackboardConclusionReceipt{
-		ID: obligation.ID, SessionID: obligation.SessionID,
-		ContinuationID:  obligation.SourceContinuationID,
-		SourceRequestID: obligation.SourceRequestID, SourceRequestCorrelationExact: obligation.SourceRequestCorrelationExact,
-		SourceSessionID: obligation.SourceSessionID, SourceTurnID: obligation.SourceTurnID,
-		InternalState: obligation.State, SourceWorkWatermark: obligation.SourceWorkWatermark,
-		SemanticPersistenceWatermark: obligation.SemanticPersistenceWatermark,
-		SourceSelection:              obligation.SourceSelection, CanonicalResultJSON: obligation.CanonicalResultJSON,
-		CanonicalResultSHA256: obligation.CanonicalResultSHA256, ApplyIdempotencyKey: obligation.ApplyIdempotencyKey,
-		AppliedRevision: obligation.AppliedRevision, BaseRevision: obligation.BaseRevision, AutomaticTurnCount: obligation.AutomaticTurnCount,
-		RepairCount: obligation.RepairCount, VersionRegenerationCount: obligation.VersionRegenerationCount,
-		ExplicitRetryCount: obligation.ExplicitRetryCount, OperatorRetryKey: obligation.OperatorRetryKey,
-		NextEligibleAt: obligation.NextEligibleAt, ErrorCode: obligation.ErrorCode,
-		RecoveryReason: string(obligation.RecoveryReason), ValidationReason: obligation.ValidationReason,
-		ValidationFieldPath: obligation.ValidationFieldPath, ValidationExpected: obligation.ValidationExpected,
-		CreatedAt: obligation.CreatedAt, UpdatedAt: obligation.UpdatedAt,
-	}
-	return view
-}
-
-func sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch *ConclusionDispatch, obligation PendingBlackboardConclusion) BlackboardConclusionReceipt {
-	view := sessionObligationView(obligation)
-	if dispatch == nil {
-		return view
-	}
-	view.ContinuationID = dispatch.ContinuationID
-	view.SourceSessionID = dispatch.SourceSessionID
-	view.DispatchRequestID = dispatch.DispatchRequestID
-	view.ControlTurnID = dispatch.ControlTurnID
-	// The dispatch carries its own immutable base revision. For an active
-	// dispatch it is the current protocol base; for a superseded or terminal
-	// dispatch the obligation's latest claimed base revision is authoritative
-	// (for example the exhausted version-regeneration action_required state).
-	if owner.ConclusionDispatchActive(dispatch.DeliveryState) {
-		view.BaseRevision = dispatch.BaseRevision
-	}
-	if view.BaseRevision == nil {
-		view.BaseRevision = obligation.BaseRevision
-	}
-	view.SynchronizedRevision = dispatch.SynchronizedRevision
-	view.SendAttemptCount = dispatch.SendAttemptCount
-	view.SendStartedAt = dispatch.SendStartedAt
-	view.ActiveDispatchID = dispatch.ID
-	view.DispatchKind = dispatch.Kind
-	return view
-}
-
-type sessionQueryer interface {
-	QueryRow(string, ...any) *sql.Row
-}
-
-func sessionCombinedConclusionView(queryer sessionQueryer, obligation PendingBlackboardConclusion) (BlackboardConclusionReceipt, error) {
-	dispatch, err := scanSessionConclusionDispatch(queryer.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-		FROM session_conclusion_dispatches WHERE obligation_id=? AND delivery_state IN (?,?,?)
-		ORDER BY created_at DESC,id DESC LIMIT 1`, obligation.ID,
-		string(ConclusionDispatchRequested), string(ConclusionDispatchAwaitingResult), string(ConclusionDispatchValidated)))
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, fmt.Errorf("load Session active Conclusion Dispatch: %w", err)
-	}
-	if errors.Is(err, sql.ErrNoRows) {
-		// Terminal obligations (applied / action_required) keep their last
-		// dispatch as the visible delivery lineage.
-		latest, latestErr := scanSessionConclusionDispatch(queryer.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-			FROM session_conclusion_dispatches WHERE obligation_id=? ORDER BY rowid DESC LIMIT 1`, obligation.ID))
-		if latestErr != nil && !errors.Is(latestErr, sql.ErrNoRows) {
-			return BlackboardConclusionReceipt{}, fmt.Errorf("load Session latest Conclusion Dispatch: %w", latestErr)
-		}
-		if latestErr == nil {
-			return sessionBlackboardConclusionReceiptFromObligationDispatch(&latest, obligation), nil
-		}
-		return sessionBlackboardConclusionReceiptFromObligationDispatch(nil, obligation), nil
-	}
-	return sessionBlackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
-}
-
-func loadSessionPendingBlackboardConclusionByID(queryer sessionQueryer, obligationID string) (PendingBlackboardConclusion, error) {
-	return scanSessionPendingBlackboardConclusion(queryer.QueryRow(`SELECT `+sessionPendingBlackboardConclusionColumns+`
-		FROM session_pending_blackboard_conclusions WHERE id=?`, obligationID))
-}
-
-// loadSessionConclusionByDispatchRequestID resolves the obligation for any
-// dispatch request id, active or terminal. Callers that advance the protocol
-// must gate on the active dispatch themselves; this loader is used for
-// idempotent replay of terminal states (for example applied).
-func loadSessionConclusionByDispatchRequestID(tx *sql.Tx, dispatchRequestID string) (PendingBlackboardConclusion, *ConclusionDispatch, error) {
-	dispatch, err := scanSessionConclusionDispatch(tx.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-		FROM session_conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	obligation, err := loadSessionPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	return obligation, &dispatch, nil
-}
-
-func loadSessionActiveConclusionByDispatchRequestID(tx *sql.Tx, dispatchRequestID string) (PendingBlackboardConclusion, *ConclusionDispatch, error) {
-	dispatch, err := scanSessionConclusionDispatch(tx.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-		FROM session_conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	if !owner.ConclusionDispatchActive(dispatch.DeliveryState) {
-		// A callback for a superseded or late dispatch is obsolete: it must
-		// fail closed (ErrNotFound) and can never advance the obligation.
-		return PendingBlackboardConclusion{}, nil, sql.ErrNoRows
-	}
-	obligation, err := loadSessionPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	return obligation, &dispatch, nil
-}
-
-func sessionConclusionViewByDispatchRequestIDTx(tx *sql.Tx, dispatchRequestID string) (BlackboardConclusionReceipt, error) {
-	dispatch, err := scanSessionConclusionDispatch(tx.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-		FROM session_conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
-	if err != nil {
-		return BlackboardConclusionReceipt{}, err
-	}
-	obligation, err := loadSessionPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, err
-	}
-	return sessionBlackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
-}
-
-func latestSessionConclusionDispatchTx(tx *sql.Tx, obligationID string) (*ConclusionDispatch, error) {
-	dispatch, err := scanSessionConclusionDispatch(tx.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-		FROM session_conclusion_dispatches WHERE obligation_id=? ORDER BY rowid DESC LIMIT 1`, obligationID))
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &dispatch, nil
-}
-
-func sessionActiveConclusionDispatchTx(tx *sql.Tx, obligationID string) (*ConclusionDispatch, error) {
-	dispatch, err := scanSessionConclusionDispatch(tx.QueryRow(`SELECT `+sessionConclusionDispatchColumns+`
-		FROM session_conclusion_dispatches WHERE obligation_id=? AND delivery_state IN (?,?,?)
-		ORDER BY created_at DESC,id DESC LIMIT 1`, obligationID,
-		string(ConclusionDispatchRequested), string(ConclusionDispatchAwaitingResult), string(ConclusionDispatchValidated)))
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &dispatch, nil
-}
-
-func sessionSupersedeActiveDispatchTx(tx *sql.Tx, dispatch *ConclusionDispatch, outcome string, now time.Time) error {
-	dispatch.DeliveryState = ConclusionDispatchSuperseded
-	dispatch.TerminalOutcome = outcome
-	dispatch.UpdatedAt = now
-	if _, err := tx.Exec(`UPDATE session_conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=? WHERE id=?`,
-		string(dispatch.DeliveryState), outcome, formatTime(now), dispatch.ID); err != nil {
-		return fmt.Errorf("supersede Session Conclusion Dispatch: %w", err)
-	}
-	return nil
-}
-
-func sessionFailActiveDispatchTx(tx *sql.Tx, obligation PendingBlackboardConclusion, dispatch *ConclusionDispatch, code BlackboardConclusionErrorCode, nextEligible time.Time, detail ConclusionValidationDetail, now time.Time) (PendingBlackboardConclusion, error) {
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = code
-	obligation.NextEligibleAt = &nextEligible
-	obligation.ValidationReason = detail.Reason
-	obligation.ValidationFieldPath = detail.FieldPath
-	obligation.ValidationExpected = detail.Expected
-	obligation.UpdatedAt = now
-	if err := updateSessionObligationProtocolTx(tx, obligation); err != nil {
-		return PendingBlackboardConclusion{}, err
-	}
-	if dispatch != nil {
-		if err := sessionSupersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-			return PendingBlackboardConclusion{}, err
-		}
-	}
-	return obligation, nil
-}
-
-func updateSessionObligationProtocolTx(tx *sql.Tx, obligation PendingBlackboardConclusion) error {
-	if _, err := tx.Exec(`UPDATE session_pending_blackboard_conclusions
-		SET state=?,canonical_result_json=?,canonical_result_sha256=?,applied_revision=?,base_revision=?,automatic_turn_count=?,repair_count=?,
-		version_regeneration_count=?,explicit_retry_count=?,operator_retry_key=?,error_code=?,recovery_reason=?,next_eligible_at=?,
-		validation_reason=?,validation_field_path=?,validation_expected=?,updated_at=? WHERE id=?`,
-		string(obligation.State), obligation.CanonicalResultJSON, obligation.CanonicalResultSHA256,
-		intPointerValue(obligation.AppliedRevision), intPointerValue(obligation.BaseRevision), obligation.AutomaticTurnCount, obligation.RepairCount,
-		obligation.VersionRegenerationCount, obligation.ExplicitRetryCount, obligation.OperatorRetryKey,
-		string(obligation.ErrorCode), string(obligation.RecoveryReason),
-		formatTimePtr(obligation.NextEligibleAt), obligation.ValidationReason, obligation.ValidationFieldPath,
-		obligation.ValidationExpected, formatTime(obligation.UpdatedAt), obligation.ID); err != nil {
-		return fmt.Errorf("update Session Blackboard conclusion obligation: %w", err)
-	}
-	return nil
-}
-
-func (s *Service) advanceSessionObligationStateByDispatchRequest(dispatchRequestID string, from, to BlackboardConclusionReceiptState, advance func(*sql.Tx, *PendingBlackboardConclusion, time.Time) error) (BlackboardConclusionReceipt, bool, error) {
-	tx, err := s.db.Begin()
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion %s: %w", to, err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadSessionConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if obligation.State != from {
-		if obligation.State == to {
-			return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-		}
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now := time.Now().UTC()
-	if err := advance(tx, &obligation, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("mark Session Blackboard conclusion %s: %w", to, err)
-	}
-	view, err := sessionConclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Session Blackboard conclusion %s: %w", to, err)
-	}
-	return view, true, nil
-}
-
-func (s *Service) advanceSessionActiveConclusionDispatch(dispatchRequestID string, fromDispatch, toDispatch ConclusionDispatchState, toObligation BlackboardConclusionReceiptState,
-	replayMatches func(BlackboardConclusionReceipt) bool,
-	advance func(*sql.Tx, *PendingBlackboardConclusion, *ConclusionDispatch, time.Time) error,
-) (BlackboardConclusionReceipt, bool, error) {
-	tx, err := s.db.Begin()
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Session Blackboard conclusion %s: %w", toDispatch, err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadSessionActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, sessionBlackboardConclusionLookupError(err)
-	}
-	if dispatch == nil || dispatch.DeliveryState != fromDispatch {
-		if dispatch != nil && dispatch.DeliveryState == toDispatch && replayMatches(sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)) {
-			return sessionBlackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-		}
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now := time.Now().UTC()
-	if err := advance(tx, &obligation, dispatch, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("mark Session Blackboard conclusion %s: %w", toDispatch, err)
-	}
-	obligation.State = toObligation
-	obligation.UpdatedAt = now
-	if _, err := tx.Exec(`UPDATE session_pending_blackboard_conclusions SET state=?,updated_at=? WHERE id=?`,
-		string(obligation.State), formatTime(now), obligation.ID); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view, err := sessionConclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Session Blackboard conclusion %s: %w", toDispatch, err)
-	}
-	return view, true, nil
-}
-
-func scanSessionPendingBlackboardConclusion(row interface{ Scan(...any) error }) (PendingBlackboardConclusion, error) {
-	var obligation PendingBlackboardConclusion
-	var state, createdAt, updatedAt string
-	var nextEligibleAt, errorCode, recoveryReason, validationReason, validationFieldPath, validationExpected, applyKey, resultHash, operatorRetryKey sql.NullString
-	var appliedRevision, baseRevision sql.NullInt64
-	var canonicalResult []byte
-	if err := row.Scan(&obligation.ID, &obligation.SessionID, &obligation.SourceRequestID, &obligation.SourceRequestCorrelationExact,
-		&obligation.SourceContinuationID, &obligation.SourceSessionID, &obligation.SourceTurnID, &state,
-		&obligation.SourceWorkWatermark, &obligation.SemanticPersistenceWatermark,
-		&obligation.SourceSelection.ModelProviderID, &obligation.SourceSelection.Model, &obligation.SourceSelection.ReasoningEffort,
-		&canonicalResult, &resultHash, &applyKey, &appliedRevision, &baseRevision, &obligation.AutomaticTurnCount,
-		&obligation.RepairCount, &obligation.VersionRegenerationCount, &obligation.ExplicitRetryCount,
-		&operatorRetryKey, &nextEligibleAt, &errorCode, &recoveryReason,
-		&validationReason, &validationFieldPath, &validationExpected, &createdAt, &updatedAt); err != nil {
-		return PendingBlackboardConclusion{}, err
-	}
-	obligation.State = BlackboardConclusionReceiptState(state)
-	obligation.CanonicalResultJSON = append([]byte(nil), canonicalResult...)
-	obligation.CanonicalResultSHA256 = resultHash.String
-	obligation.ApplyIdempotencyKey = applyKey.String
-	obligation.OperatorRetryKey = operatorRetryKey.String
-	obligation.ErrorCode = BlackboardConclusionErrorCode(errorCode.String)
-	obligation.RecoveryReason = ConclusionRecoveryReason(recoveryReason.String)
-	obligation.ValidationReason = validationReason.String
-	obligation.ValidationFieldPath = validationFieldPath.String
-	obligation.ValidationExpected = validationExpected.String
-	if appliedRevision.Valid {
-		obligation.AppliedRevision = intPointer(int(appliedRevision.Int64))
-	}
-	if baseRevision.Valid {
-		obligation.BaseRevision = intPointer(int(baseRevision.Int64))
-	}
-	if nextEligibleAt.Valid {
-		parsed, err := time.Parse(time.RFC3339Nano, nextEligibleAt.String)
-		if err != nil {
-			return PendingBlackboardConclusion{}, fmt.Errorf("parse Session Blackboard conclusion next_eligible_at: %w", err)
-		}
-		obligation.NextEligibleAt = &parsed
-	}
-	var err error
-	if obligation.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
-		return PendingBlackboardConclusion{}, fmt.Errorf("parse Session Blackboard conclusion created_at: %w", err)
-	}
-	if obligation.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt); err != nil {
-		return PendingBlackboardConclusion{}, fmt.Errorf("parse Session Blackboard conclusion updated_at: %w", err)
-	}
-	return obligation, nil
-}
-
-func scanSessionConclusionDispatch(row interface{ Scan(...any) error }) (ConclusionDispatch, error) {
-	var dispatch ConclusionDispatch
-	var kind, deliveryState, createdAt, updatedAt string
-	var dispatchRequestID, controlTurnID, sendStartedAt, terminalOutcome sql.NullString
-	var baseRevision, synchronizedRevision sql.NullInt64
-	if err := row.Scan(&dispatch.ID, &dispatch.ObligationID, &kind, &dispatch.ContinuationID, &dispatch.SourceSessionID,
-		&dispatchRequestID, &controlTurnID, &baseRevision, &synchronizedRevision, &deliveryState,
-		&dispatch.SendAttemptCount, &sendStartedAt, &terminalOutcome, &createdAt, &updatedAt); err != nil {
-		return ConclusionDispatch{}, err
-	}
-	dispatch.Kind = ConclusionDispatchKind(kind)
-	dispatch.DeliveryState = ConclusionDispatchState(deliveryState)
-	dispatch.DispatchRequestID = dispatchRequestID.String
-	dispatch.ControlTurnID = controlTurnID.String
-	dispatch.TerminalOutcome = terminalOutcome.String
-	if baseRevision.Valid {
-		dispatch.BaseRevision = intPointer(int(baseRevision.Int64))
-	}
-	if synchronizedRevision.Valid {
-		dispatch.SynchronizedRevision = intPointer(int(synchronizedRevision.Int64))
-	}
-	if sendStartedAt.Valid {
-		parsed, err := time.Parse(time.RFC3339Nano, sendStartedAt.String)
-		if err != nil {
-			return ConclusionDispatch{}, fmt.Errorf("parse Session Conclusion Dispatch send_started_at: %w", err)
-		}
-		dispatch.SendStartedAt = &parsed
-	}
-	var err error
-	if dispatch.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
-		return ConclusionDispatch{}, fmt.Errorf("parse Session Conclusion Dispatch created_at: %w", err)
-	}
-	if dispatch.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt); err != nil {
-		return ConclusionDispatch{}, fmt.Errorf("parse Session Conclusion Dispatch updated_at: %w", err)
-	}
-	return dispatch, nil
-}
-
-func validSessionBlackboardConclusionErrorCode(code BlackboardConclusionErrorCode) bool {
-	return owner.ValidBlackboardConclusionErrorCode(code)
-}
-
-func sessionBlackboardConclusionLookupError(err error) error {
-	if errors.Is(err, sql.ErrNoRows) {
-		return ErrNotFound
-	}
-	return fmt.Errorf("load Session Blackboard conclusion obligation: %w", err)
-}
-
-func sessionBlackboardConclusionRequestLineage(continuationID, sourceTurnID string) (string, string) {
-	return owner.ConclusionRequestLineage(continuationID, sourceTurnID)
-}
-
-func sessionBlackboardConclusionAttemptRequestID(kind, continuationID, sourceTurnID string, number int, key string) string {
-	return owner.ConclusionAttemptRequestID(kind, continuationID, sourceTurnID, number, key)
-}
-
-func appendSessionBlackboardConclusionEventTx(tx *sql.Tx, receipt BlackboardConclusionReceipt, payload EventPayload, now time.Time) error {
-	payloadJSON, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("encode Session Blackboard conclusion Event: %w", err)
-	}
-	var maxSeq sql.NullInt64
-	if err := tx.QueryRow(`SELECT MAX(seq) FROM session_events WHERE session_id=?`, receipt.SessionID).Scan(&maxSeq); err != nil {
-		return fmt.Errorf("read Session Blackboard conclusion Event sequence: %w", err)
-	}
-	eventID := newIDMust()
-	if _, err := tx.Exec(`INSERT INTO session_events (id,session_id,seq,kind,payload_json,created_at)
-		VALUES (?,?,?,?,?,?)`, eventID, receipt.SessionID, int(maxSeq.Int64)+1,
-		string(EventKindBlackboardConclusion), string(payloadJSON), formatTime(now)); err != nil {
-		return fmt.Errorf("store Session Blackboard conclusion Event: %w", err)
-	}
-	return nil
-}
-
-func sessionConclusionDispatchSequence(tx *sql.Tx, obligationID string) int {
-	var count int
-	_ = tx.QueryRow(`SELECT COUNT(*) FROM session_conclusion_dispatches WHERE obligation_id=?`, obligationID).Scan(&count)
-	return count
-}
-
-func sessionDispatchBaseRevision(dispatch *ConclusionDispatch) *int {
-	if dispatch == nil {
-		return nil
-	}
-	return dispatch.BaseRevision
-}
-
-func sessionObligationDispatchRequestID(dispatch *ConclusionDispatch) string {
-	if dispatch == nil {
-		return ""
-	}
-	return dispatch.DispatchRequestID
-}
-
-func intPointer(value int) *int { return &value }
-
-func intPointerValue(value *int) any {
-	if value == nil {
-		return nil
-	}
-	return *value
-}
-
-func formatTimePtr(value *time.Time) any {
-	if value == nil {
-		return nil
-	}
-	return value.UTC().Format(time.RFC3339Nano)
+	return receiptFromConclusion(rec), created, nil
 }

--- a/internal/skill/importer.go
+++ b/internal/skill/importer.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -79,6 +80,49 @@ type skillsLockEntry struct {
 // when invoked with --agent amp. Bundles land at <workdir>/.agents/skills/<name>.
 const universalSkillsDir = ".agents/skills"
 
+// importShorthandPattern matches the slash-separated shorthand the skills CLI
+// resolves: a well-known name or owner/repo path. Segments start alphanumeric so
+// local paths, option-shaped strings, and other argv-hostile input cannot pass.
+var importShorthandPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*(/[A-Za-z0-9][A-Za-z0-9_.-]*)*$`)
+
+// importFilterPattern matches the optional @skill filter suffix of a shorthand.
+var importFilterPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+
+// validateImportSource reports whether source is a shape the fixed
+// `npx skills add` command may resolve: an https:// URL, or a shorthand such as
+// owner/repo or a well-known name with an optional @skill filter. Local paths,
+// non-HTTPS schemes, and option-shaped strings are rejected so the importer can
+// never redirect the fixed command shape at local files or inject options.
+func validateImportSource(source string) error {
+	if source == "" {
+		return fmt.Errorf("source_url is required")
+	}
+	if scheme, rest, ok := strings.Cut(source, "://"); ok {
+		if !strings.EqualFold(scheme, "https") {
+			return fmt.Errorf("source scheme %q is not allowed; use https", scheme)
+		}
+		if host := strings.TrimSpace(rest); host == "" || strings.HasPrefix(host, "/") {
+			return fmt.Errorf("https source must include a host")
+		}
+		return nil
+	}
+	if strings.HasPrefix(source, "-") {
+		return fmt.Errorf("source must not start with an option dash")
+	}
+	shorthand := source
+	filter := ""
+	if at := strings.LastIndex(source, "@"); at > 0 {
+		shorthand, filter = source[:at], source[at+1:]
+	}
+	if !importShorthandPattern.MatchString(shorthand) {
+		return fmt.Errorf("source %q is not an https URL or owner/repo shorthand", source)
+	}
+	if filter != "" && !importFilterPattern.MatchString(filter) {
+		return fmt.Errorf("source skill filter %q is invalid", filter)
+	}
+	return nil
+}
+
 // ImportSkill resolves and downloads a skill bundle from the request source.
 // It requires a non-empty SourceURL; Package and Ref are ignored. For sources
 // that contain multiple skills, it publishes the first one (use owner/repo@name
@@ -86,8 +130,8 @@ const universalSkillsDir = ".agents/skills"
 // provenance of the selected skill.
 func (i NPXSkillsImporter) ImportSkill(ctx context.Context, request ImportRequest) (ImportedBundle, error) {
 	sourceURL := strings.TrimSpace(request.SourceURL)
-	if sourceURL == "" {
-		return ImportedBundle{}, fmt.Errorf("%w: source_url is required", ErrInvalidSkill)
+	if err := validateImportSource(sourceURL); err != nil {
+		return ImportedBundle{}, fmt.Errorf("%w: %v", ErrInvalidSkill, err)
 	}
 	workdir, err := os.MkdirTemp("", "skill-import-*")
 	if err != nil {

--- a/internal/skill/importer_test.go
+++ b/internal/skill/importer_test.go
@@ -228,3 +228,55 @@ func TestImportRejectsSymlinkInBundle(t *testing.T) {
 		t.Fatalf("expected ErrInvalidSkill for symlink in bundle, got %v", err)
 	}
 }
+
+func TestImportRejectsUnsafeSourcesWithoutExecutingNpx(t *testing.T) {
+	for _, source := range []string{
+		"file:///etc/passwd",         // local file exfiltration
+		"http://plain.example/skill", // non-TLS fetch
+		"/etc/passwd",                // absolute local path
+		"../outside",                 // relative path escape shape
+		"-c",                         // option injection into the fixed npx command
+		"--skill",                    // option injection, long form
+		"git@evil:host/repo",         // unsupported remote syntax
+		"owner/repo;rm -rf",          // garbage charset must not reach argv
+		"owner//repo",                // empty path segment
+	} {
+		runner := &fakeRunner{}
+		imp := skill.NPXSkillsImporter{Runner: runner}
+		_, err := imp.ImportSkill(context.Background(), skill.ImportRequest{SourceURL: source})
+		if !errors.Is(err, skill.ErrInvalidSkill) {
+			t.Errorf("source %q: expected ErrInvalidSkill, got %v", source, err)
+		}
+		if len(runner.recorded) != 0 {
+			t.Errorf("source %q: importer must reject before executing npx, ran: %v", source, runner.recorded)
+		}
+	}
+}
+
+func TestImportAcceptsHTTPSSourcesAndShorthandSources(t *testing.T) {
+	for _, tc := range []struct {
+		source    string
+		bundle    string
+		sourceURL string
+	}{
+		{source: "https://github.com/owner/repo", bundle: "repo", sourceURL: "https://github.com/owner/repo"},
+		{source: "owner/repo", bundle: "repo", sourceURL: "owner/repo"},
+		{source: "owner/repo@helper", bundle: "helper", sourceURL: "https://github.com/owner/repo"},
+		{source: "pdf", bundle: "pdf", sourceURL: "pdf"},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			runner := &fakeRunner{install: func(dir string) error {
+				installBundle(t, dir, tc.bundle, tc.sourceURL, "github", map[string]string{"SKILL.md": sampleSkillMD})
+				return nil
+			}}
+			imp := skill.NPXSkillsImporter{Runner: runner}
+			bundle, err := imp.ImportSkill(context.Background(), skill.ImportRequest{SourceURL: tc.source})
+			if err != nil {
+				t.Fatalf("expected %q accepted, got %v", tc.source, err)
+			}
+			if bundle.Metadata.ID != tc.bundle {
+				t.Fatalf("expected bundle %q, got %q", tc.bundle, bundle.Metadata.ID)
+			}
+		})
+	}
+}

--- a/internal/task/blackboard_conclusion.go
+++ b/internal/task/blackboard_conclusion.go
@@ -3,105 +3,145 @@ package task
 import (
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"strings"
 	"time"
 
-	"pentest/internal/owner"
+	"pentest/internal/owner/conclusion"
 )
+
+// The Pending Blackboard Conclusion state machine is shared with Non-Project
+// Sessions through internal/owner/conclusion. This file keeps the Task-facing
+// API: owner eligibility checks, the Task receipt projection, and error
+// translation. Storage rules, dispatch lifecycle, and recovery settlement
+// belong to the shared engine.
+
+// PendingBlackboardConclusion is the durable obligation row, keyed by
+// (task, source session, source turn) and independent of any Runtime
+// Continuation. The shared engine names the owner identity OwnerID.
+type PendingBlackboardConclusion = conclusion.PendingBlackboardConclusion
+
+// ConclusionDispatch is one immutable delivery attempt for an obligation. Its
+// continuation and source session are written once at creation and never
+// updated; recovery creates a new dispatch instead of rewriting an old one.
+type ConclusionDispatch = conclusion.ConclusionDispatch
 
 // ErrBlackboardConclusionDispatchInactive reports a callback correlation that
 // resolved to a superseded or late Conclusion Dispatch. Only the ACTIVE
 // dispatch of an obligation may validate or apply a provider result, so a late
 // or duplicate result from an obsolete dispatch can never settle or corrupt
 // the obligation (ADR 0021).
-var ErrBlackboardConclusionDispatchInactive = errors.New("Blackboard conclusion dispatch is not the active delivery")
+var ErrBlackboardConclusionDispatchInactive = conclusion.ErrBlackboardConclusionDispatchInactive
 
-// PendingBlackboardConclusion is the durable obligation row. It is keyed by
-// (task, source session, source turn) and independent of any Runtime
-// Continuation; every delivery attempt is an immutable Conclusion Dispatch
-// child row.
-type PendingBlackboardConclusion struct {
-	ID                            string
-	TaskID                        string
-	SourceRequestID               string
-	SourceRequestCorrelationExact bool
-	SourceContinuationID          string
-	SourceSessionID               string
-	SourceTurnID                  string
-	State                         BlackboardConclusionReceiptState
-	SourceWorkWatermark           int
-	SemanticPersistenceWatermark  int
-	SourceSelection               TurnSelection
-	CanonicalResultJSON           []byte
-	CanonicalResultSHA256         string
-	ApplyIdempotencyKey           string
-	AppliedRevision               *int
-	BaseRevision                  *int
-	AutomaticTurnCount            int
-	RepairCount                   int
-	VersionRegenerationCount      int
-	ExplicitRetryCount            int
-	OperatorRetryKey              string
-	NextEligibleAt                *time.Time
-	ErrorCode                     BlackboardConclusionErrorCode
-	RecoveryReason                ConclusionRecoveryReason
-	ValidationReason              string
-	ValidationFieldPath           string
-	ValidationExpected            string
-	CreatedAt                     time.Time
-	UpdatedAt                     time.Time
+// taskConclusionDialect stores conclusion state against the Task tables.
+func taskConclusionDialect() conclusion.Dialect {
+	return conclusion.Dialect{
+		Subject:                 "Blackboard conclusion",
+		ObligationsTable:        "pending_blackboard_conclusions",
+		DispatchesTable:         "conclusion_dispatches",
+		OwnerColumn:             "task_id",
+		ContinuationsTable:      "task_continuations",
+		ContinuationOwnerColumn: "task_id",
+		EventKind:               string(EventKindBlackboardConclusion),
+		AppendEvent:             appendTaskConclusionEventTx,
+		RetryKeysTable:          "assisted_conclusion_retry_keys",
+		RetryKeysOwnerColumn:    "task_id",
+		RetryKeysReceiptColumn:  "receipt_id",
+		NewID:                   newID,
+	}
 }
 
-// ConclusionDispatch is one immutable delivery attempt for an obligation. Its
-// continuation and source session are written once at creation and never
-// updated; recovery creates a new dispatch instead of rewriting an old one.
-type ConclusionDispatch struct {
-	ID                   string
-	ObligationID         string
-	Kind                 ConclusionDispatchKind
-	ContinuationID       string
-	SourceSessionID      string
-	DispatchRequestID    string
-	ControlTurnID        string
-	BaseRevision         *int
-	SynchronizedRevision *int
-	DeliveryState        ConclusionDispatchState
-	SendAttemptCount     int
-	SendStartedAt        *time.Time
-	TerminalOutcome      string
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
+func appendTaskConclusionEventTx(tx *sql.Tx, ownerID, continuationID, kind string, payload map[string]any, now time.Time) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode Blackboard conclusion Event: %w", err)
+	}
+	var maxSeq sql.NullInt64
+	if err := tx.QueryRow(`SELECT MAX(seq) FROM task_events WHERE task_id=?`, ownerID).Scan(&maxSeq); err != nil {
+		return fmt.Errorf("read Blackboard conclusion Event sequence: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO task_events (id,task_id,continuation_id,seq,kind,payload_json,created_at)
+		VALUES (?,?,?,?,?,?,?)`, newID(), ownerID, continuationID, int(maxSeq.Int64)+1, kind, string(payloadJSON), now.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("store Blackboard conclusion Event: %w", err)
+	}
+	return nil
 }
 
-const pendingBlackboardConclusionColumns = `id,task_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,state,
-	source_work_watermark,semantic_persistence_watermark,source_model_provider_id,source_model,source_reasoning_effort,
-	canonical_result_json,canonical_result_sha256,apply_idempotency_key,applied_revision,base_revision,automatic_turn_count,
-	repair_count,version_regeneration_count,explicit_retry_count,operator_retry_key,next_eligible_at,error_code,recovery_reason,
-	validation_reason,validation_field_path,validation_expected,created_at,updated_at`
+// conclusions returns the shared conclusion engine bound to the Task tables.
+func (s *Service) conclusions() *conclusion.Engine {
+	return &conclusion.Engine{DB: s.db.DB, Dialect: taskConclusionDialect()}
+}
 
-const conclusionDispatchColumns = `id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,control_turn_id,base_revision,
-	synchronized_revision,delivery_state,send_attempt_count,send_started_at,terminal_outcome,created_at,updated_at`
+// mapConclusionError restamps engine sentinels as the Task-package sentinels
+// callers already match with errors.Is, preserving message and chain.
+func mapConclusionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return conclusion.MapSentinels(err,
+		conclusion.ErrOwnerNotFound, ErrNotFound,
+		conclusion.ErrInvalidBlackboardConclusionReceipt, ErrInvalidBlackboardConclusionReceipt,
+		conclusion.ErrBlackboardConclusionRetryCooldown, ErrBlackboardConclusionRetryCooldown,
+		conclusion.ErrBlackboardConclusionWorkTurnNeverSettled, ErrBlackboardConclusionWorkTurnNeverSettled,
+	)
+}
+
+func receiptFromConclusion(rec conclusion.BlackboardConclusionReceipt) BlackboardConclusionReceipt {
+	return BlackboardConclusionReceipt{
+		ID:                            rec.ID,
+		TaskID:                        rec.OwnerID,
+		ContinuationID:                rec.ContinuationID,
+		SourceRequestID:               rec.SourceRequestID,
+		SourceRequestCorrelationExact: rec.SourceRequestCorrelationExact,
+		SourceSessionID:               rec.SourceSessionID,
+		SourceTurnID:                  rec.SourceTurnID,
+		InternalState:                 rec.InternalState,
+		SourceWorkWatermark:           rec.SourceWorkWatermark,
+		SemanticPersistenceWatermark:  rec.SemanticPersistenceWatermark,
+		DispatchRequestID:             rec.DispatchRequestID,
+		ControlTurnID:                 rec.ControlTurnID,
+		BaseRevision:                  rec.BaseRevision,
+		SynchronizedRevision:          rec.SynchronizedRevision,
+		SourceSelection: TurnSelection{
+			ModelProviderID: rec.SourceSelection.ModelProviderID,
+			Model:           rec.SourceSelection.Model,
+			ReasoningEffort: rec.SourceSelection.ReasoningEffort,
+		},
+		CanonicalResultJSON:      rec.CanonicalResultJSON,
+		CanonicalResultSHA256:    rec.CanonicalResultSHA256,
+		ApplyIdempotencyKey:      rec.ApplyIdempotencyKey,
+		AppliedRevision:          rec.AppliedRevision,
+		AutomaticTurnCount:       rec.AutomaticTurnCount,
+		RepairCount:              rec.RepairCount,
+		VersionRegenerationCount: rec.VersionRegenerationCount,
+		ExplicitRetryCount:       rec.ExplicitRetryCount,
+		OperatorRetryKey:         rec.OperatorRetryKey,
+		SendAttemptCount:         rec.SendAttemptCount,
+		SendStartedAt:            rec.SendStartedAt,
+		NextEligibleAt:           rec.NextEligibleAt,
+		ErrorCode:                rec.ErrorCode,
+		RecoveryReason:           rec.RecoveryReason,
+		ActiveDispatchID:         rec.ActiveDispatchID,
+		DispatchKind:             rec.DispatchKind,
+		ValidationReason:         rec.ValidationReason,
+		ValidationFieldPath:      rec.ValidationFieldPath,
+		ValidationExpected:       rec.ValidationExpected,
+		CreatedAt:                rec.CreatedAt,
+		UpdatedAt:                rec.UpdatedAt,
+	}
+}
+
+func receiptsFromConclusion(recs []conclusion.BlackboardConclusionReceipt) []BlackboardConclusionReceipt {
+	out := make([]BlackboardConclusionReceipt, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, receiptFromConclusion(rec))
+	}
+	return out
+}
 
 // RecordBlackboardConclusionCheckpoint creates the one durable Pending
 // Blackboard Conclusion obligation for a completed assisted Work Runtime Turn.
-// The obligation is independent of any Runtime Continuation: the source
-// continuation is retained only as correlation for the initial dispatch.
 // Replay returns the original obligation.
 func (s *Service) RecordBlackboardConclusionCheckpoint(taskID, continuationID, sourceRequestID, sourceSessionID, sourceTurnID string, sourceSelection TurnSelection, watermarks SemanticDebtWatermarks) (BlackboardConclusionReceipt, bool, error) {
-	checkpoint, valid := (owner.ConclusionCheckpointInput{
-		OwnerID: taskID, ContinuationID: continuationID, SourceRequestID: sourceRequestID,
-		SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
-		ModelProviderID: sourceSelection.ModelProviderID, Model: sourceSelection.Model,
-		ReasoningEffort: sourceSelection.ReasoningEffort, Watermarks: watermarks,
-	}).Normalize()
-	if !valid {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	taskID, continuationID, sourceRequestID = checkpoint.OwnerID, checkpoint.ContinuationID, checkpoint.SourceRequestID
-	sourceSessionID, sourceTurnID, watermarks = checkpoint.SourceSessionID, checkpoint.SourceTurnID, checkpoint.Watermarks
-	sourceSelection = TurnSelection{ModelProviderID: checkpoint.ModelProviderID, Model: checkpoint.Model, ReasoningEffort: checkpoint.ReasoningEffort}
 	found, err := s.Get(taskID)
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, err
@@ -109,67 +149,12 @@ func (s *Service) RecordBlackboardConclusionCheckpoint(taskID, continuationID, s
 	if found.RunControls.BlackboardConclusionMode != BlackboardConclusionModeAssisted {
 		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
 	}
-
-	tx, err := s.db.Begin()
+	rec, created, err := s.conclusions().RecordBlackboardConclusionCheckpoint(taskID, continuationID, sourceRequestID, sourceSessionID, sourceTurnID,
+		conclusion.Selection{ModelProviderID: sourceSelection.ModelProviderID, Model: sourceSelection.Model, ReasoningEffort: sourceSelection.ReasoningEffort}, watermarks)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion obligation: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	var continuationTaskID string
-	if err := tx.QueryRow(`SELECT task_id FROM task_continuations WHERE id=?`, continuationID).Scan(&continuationTaskID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return BlackboardConclusionReceipt{}, false, ErrNotFound
-		}
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("load Blackboard conclusion Continuation: %w", err)
-	}
-	if continuationTaskID != taskID {
-		return BlackboardConclusionReceipt{}, false, ErrNotFound
-	}
-
-	prior, err := scanPendingBlackboardConclusion(tx.QueryRow(`SELECT `+pendingBlackboardConclusionColumns+`
-		FROM pending_blackboard_conclusions WHERE task_id=? AND source_session_id=? AND source_turn_id=?`, taskID, sourceSessionID, sourceTurnID))
-	if err == nil {
-		view, scanErr := combinedConclusionView(tx, prior)
-		if scanErr != nil {
-			return BlackboardConclusionReceipt{}, false, scanErr
-		}
-		return view, false, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("load Blackboard conclusion obligation: %w", err)
-	}
-
-	now := time.Now().UTC()
-	obligationState, phase := owner.InitialConclusionCheckpoint(watermarks)
-	obligation := PendingBlackboardConclusion{
-		ID: newID(), TaskID: taskID, SourceRequestID: sourceRequestID, SourceRequestCorrelationExact: true,
-		SourceContinuationID: continuationID, SourceSessionID: sourceSessionID, SourceTurnID: sourceTurnID,
-		State: obligationState, SourceWorkWatermark: watermarks.SourceWork,
-		SemanticPersistenceWatermark: watermarks.SemanticPersistence,
-		SourceSelection:              sourceSelection, CreatedAt: now, UpdatedAt: now,
-	}
-	if _, err := tx.Exec(`INSERT INTO pending_blackboard_conclusions
-		(id,task_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,state,source_work_watermark,semantic_persistence_watermark,
-		 source_model_provider_id,source_model,source_reasoning_effort,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, obligation.ID, obligation.TaskID, obligation.SourceRequestID,
-		obligation.SourceRequestCorrelationExact, obligation.SourceContinuationID, obligation.SourceSessionID, obligation.SourceTurnID,
-		string(obligation.State), obligation.SourceWorkWatermark, obligation.SemanticPersistenceWatermark,
-		obligation.SourceSelection.ModelProviderID, obligation.SourceSelection.Model, obligation.SourceSelection.ReasoningEffort,
-		obligation.CreatedAt.Format(time.RFC3339Nano), obligation.UpdatedAt.Format(time.RFC3339Nano)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Blackboard conclusion obligation: %w", err)
-	}
-
-	view := obligationView(obligation)
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": phase, "receipt_id": obligation.ID, "source_turn_id": obligation.SourceTurnID,
-		"source_work_watermark": obligation.SourceWorkWatermark, "semantic_persistence_watermark": obligation.SemanticPersistenceWatermark,
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Blackboard conclusion obligation: %w", err)
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), created, nil
 }
 
 // ClaimBlackboardConclusionDispatch creates the initial Conclusion Dispatch
@@ -177,964 +162,153 @@ func (s *Service) RecordBlackboardConclusionCheckpoint(taskID, continuationID, s
 // source session of the completed Work Runtime Turn. Replaying the same claim
 // returns the existing active dispatch unchanged.
 func (s *Service) ClaimBlackboardConclusionDispatch(obligationID string, baseRevision int) (BlackboardConclusionReceipt, bool, error) {
-	obligationID = strings.TrimSpace(obligationID)
-	if obligationID == "" || baseRevision < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	tx, err := s.db.Begin()
+	rec, created, err := s.conclusions().ClaimBlackboardConclusionDispatch(obligationID, baseRevision)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion dispatch: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if obligation.State != BlackboardConclusionReceiptPending {
-		if obligation.State == BlackboardConclusionReceiptClean {
-			view, viewErr := combinedConclusionView(tx, obligation)
-			return view, false, viewErr
-		}
-		// Replay: the obligation already claimed the deterministic initial
-		// dispatch. Return the existing ACTIVE dispatch unchanged when its
-		// request lineage and base revision match this replay.
-		dispatchID, _ := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
-		existing, err := activeConclusionDispatchTx(tx, obligation.ID)
-		if err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if existing != nil && existing.DispatchRequestID == dispatchID && existing.BaseRevision != nil && *existing.BaseRevision == baseRevision {
-			view, viewErr := combinedConclusionView(tx, obligation)
-			return view, false, viewErr
-		}
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	dispatchID, applyKey := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
-	now := time.Now().UTC()
-	dispatch := ConclusionDispatch{
-		ID: newID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindInitial,
-		ContinuationID: obligation.SourceContinuationID, SourceSessionID: obligation.SourceSessionID,
-		DispatchRequestID: dispatchID, BaseRevision: intPointer(baseRevision),
-		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-	}
-	if _, err := tx.Exec(`INSERT INTO conclusion_dispatches
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, dispatch.ID, dispatch.ObligationID, string(dispatch.Kind), dispatch.ContinuationID,
-		dispatch.SourceSessionID, dispatch.DispatchRequestID, baseRevision, string(dispatch.DeliveryState),
-		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store initial Conclusion Dispatch: %w", err)
-	}
-	obligation.State = BlackboardConclusionReceiptDispatchRequested
-	obligation.ApplyIdempotencyKey = applyKey
-	obligation.AutomaticTurnCount = 1
-	obligation.BaseRevision = intPointer(baseRevision)
-	obligation.UpdatedAt = now
-	if _, err := tx.Exec(`UPDATE pending_blackboard_conclusions
-		SET state=?,apply_idempotency_key=?,automatic_turn_count=?,base_revision=?,updated_at=? WHERE id=?`,
-		string(obligation.State), applyKey, obligation.AutomaticTurnCount, baseRevision, now.Format(time.RFC3339Nano), obligation.ID); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("advance Blackboard conclusion obligation: %w", err)
-	}
-	view := obligationView(obligation)
-	view.ActiveDispatchID = dispatch.ID
-	view.DispatchKind = dispatch.Kind
-	view.DispatchRequestID = dispatch.DispatchRequestID
-	view.ContinuationID = dispatch.ContinuationID
-	view.SourceSessionID = dispatch.SourceSessionID
-	view.BaseRevision = dispatch.BaseRevision
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "dispatch_requested", "receipt_id": obligation.ID, "source_turn_id": obligation.SourceTurnID,
-		"request_id": dispatchID, "base_revision": baseRevision, "turn_kind": "control",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Blackboard conclusion dispatch: %w", err)
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), created, nil
 }
 
-// MarkBlackboardConclusionSendStarted closes the provider-acceptance ambiguity
-// window on the ACTIVE dispatch before SendTurn. Only the active dispatch may
-// claim the fence; replay observes the original timestamp.
 func (s *Service) MarkBlackboardConclusionSendStarted(dispatchRequestID string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || now.IsZero() {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionSendStarted(dispatchRequestID, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	result, err := tx.Exec(`UPDATE conclusion_dispatches SET send_attempt_count=1,send_started_at=?,updated_at=?
-		WHERE dispatch_request_id=? AND delivery_state=? AND send_attempt_count=0 AND send_started_at IS NULL`,
-		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano), dispatchRequestID, string(ConclusionDispatchRequested))
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	changed, _ := result.RowsAffected()
-	view, err := conclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if changed == 0 {
-		return view, false, nil
-	}
-	if changed != 1 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionAwaiting records provider acceptance of the Conclude
-// Turn on the ACTIVE dispatch. Replaying the same correlation is idempotent.
 func (s *Service) MarkBlackboardConclusionAwaiting(dispatchRequestID, controlTurnID string) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID, controlTurnID = strings.TrimSpace(dispatchRequestID), strings.TrimSpace(controlTurnID)
-	if dispatchRequestID == "" || controlTurnID == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionAwaiting(dispatchRequestID, controlTurnID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	return s.advanceActiveConclusionDispatch(dispatchRequestID, ConclusionDispatchRequested, ConclusionDispatchAwaitingResult,
-		BlackboardConclusionReceiptAwaitingResult,
-		func(receipt BlackboardConclusionReceipt) bool { return receipt.ControlTurnID == controlTurnID },
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, dispatch *ConclusionDispatch, now time.Time) error {
-			dispatch.DeliveryState = ConclusionDispatchAwaitingResult
-			dispatch.ControlTurnID = controlTurnID
-			if _, err := tx.Exec(`UPDATE conclusion_dispatches SET delivery_state=?,control_turn_id=?,updated_at=? WHERE id=?`,
-				string(dispatch.DeliveryState), controlTurnID, now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
-				return err
-			}
-			return appendBlackboardConclusionEventTx(tx, blackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation), EventPayload{
-				"phase": "awaiting_result", "receipt_id": dispatch.ObligationID, "request_id": dispatchRequestID,
-				"source_turn_id": obligation.SourceTurnID, "control_turn_id": controlTurnID, "turn_kind": "control",
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// HandleBlackboardConclusionFailure durably resolves a failed Conclude Turn.
-// One invalid initial result may claim a single automatic repair, which
-// supersedes the failed dispatch and creates a NEW repair dispatch on the same
-// immutable continuation and source session. Forbidden tool use, runtime
-// failures, and later invalid results become stable operator-actionable states.
 func (s *Service) HandleBlackboardConclusionFailure(dispatchRequestID string, code BlackboardConclusionErrorCode, detail ConclusionValidationDetail, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || cooldown < 0 ||
-		(code != BlackboardConclusionErrorInvalidResult && code != BlackboardConclusionErrorToolUseForbidden && code != BlackboardConclusionErrorRuntimeRecoveryRequired) {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if detail.Valid() && code != BlackboardConclusionErrorInvalidResult {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().HandleBlackboardConclusionFailure(dispatchRequestID, code, detail, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion failure: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired {
-		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if obligation.State != BlackboardConclusionReceiptAwaitingResult || dispatch.DeliveryState != ConclusionDispatchAwaitingResult {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	if owner.ConclusionRepairAllowed(code, obligation.AutomaticTurnCount, obligation.RepairCount, obligation.VersionRegenerationCount, obligation.ExplicitRetryCount) {
-		repairNumber := obligation.RepairCount + 1
-		requestID := blackboardConclusionAttemptRequestID("repair", dispatch.ContinuationID, obligation.SourceTurnID, repairNumber, "")
-		nextEligible := now.Add(cooldown)
-		nowDispatch := ConclusionDispatch{
-			ID: newID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRepair,
-			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
-			DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
-			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-		}
-		if err := supersedeActiveDispatchTx(tx, dispatch, "superseded_by_repair", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if _, err := tx.Exec(`INSERT INTO conclusion_dispatches
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store repair Conclusion Dispatch: %w", err)
-		}
-		obligation.State = BlackboardConclusionReceiptRepairDispatchRequested
-		obligation.AutomaticTurnCount++
-		obligation.RepairCount++
-		obligation.ErrorCode = code
-		obligation.NextEligibleAt = &nextEligible
-		obligation.ValidationReason = detail.Reason
-		obligation.ValidationFieldPath = detail.FieldPath
-		obligation.ValidationExpected = detail.Expected
-		obligation.UpdatedAt = now
-		if err := updateObligationProtocolTx(tx, obligation); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		view := obligationView(obligation)
-		view.ActiveDispatchID = nowDispatch.ID
-		view.DispatchKind = nowDispatch.Kind
-		view.DispatchRequestID = nowDispatch.DispatchRequestID
-		view.ContinuationID = nowDispatch.ContinuationID
-		view.SourceSessionID = nowDispatch.SourceSessionID
-		view.BaseRevision = nowDispatch.BaseRevision
-		payload := EventPayload{"phase": "repair_requested", "receipt_id": obligation.ID, "request_id": requestID,
-			"error_code": string(code), "automatic_turn_count": obligation.AutomaticTurnCount, "repair_count": obligation.RepairCount, "turn_kind": "control"}
-		owner.AppendConclusionValidationEventPayload(payload, detail)
-		if err := appendBlackboardConclusionEventTx(tx, view, payload, now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if err := tx.Commit(); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		return view, true, nil
-	}
-	actionCode := owner.ConclusionFailureActionCode(code, obligation.RepairCount, obligation.VersionRegenerationCount)
-	nextEligible := now.Add(cooldown)
-	if obligation.NextEligibleAt != nil {
-		nextEligible = obligation.NextEligibleAt.UTC()
-	}
-	var failErr error
-	obligation, failErr = failActiveDispatchTx(tx, obligation, dispatch, actionCode, nextEligible, detail, now)
-	if failErr != nil {
-		return BlackboardConclusionReceipt{}, false, failErr
-	}
-	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	payload := EventPayload{"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"error_code": string(actionCode), "next_eligible_at": nextEligible.Format(time.RFC3339Nano)}
-	owner.AppendConclusionValidationEventPayload(payload, detail)
-	if err := appendBlackboardConclusionEventTx(tx, view, payload, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// ClaimBlackboardConclusionVersionSync records the intent to synchronize the
-// active dispatch's continuation before version regeneration can be claimed.
 func (s *Service) ClaimBlackboardConclusionVersionSync(dispatchRequestID string) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().ClaimBlackboardConclusionVersionSync(dispatchRequestID)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	return s.advanceObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptValidated,
-		BlackboardConclusionReceiptVersionSyncRequested,
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
-			obligation.State = BlackboardConclusionReceiptVersionSyncRequested
-			obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
-			obligation.UpdatedAt = now
-			if _, err := tx.Exec(`UPDATE pending_blackboard_conclusions SET state=?,error_code=?,updated_at=? WHERE id=?`,
-				string(obligation.State), string(obligation.ErrorCode), now.Format(time.RFC3339Nano), obligation.ID); err != nil {
-				return err
-			}
-			return appendBlackboardConclusionEventTx(tx, obligationView(*obligation), EventPayload{
-				"phase": "version_sync_requested", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-				"turn_kind": "control",
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// HandleBlackboardConclusionVersionConflict discards a validated result whose
-// revision guard lost a real race and claims one fresh semantic generation.
-// The old validated dispatch is superseded and a NEW version_regeneration
-// dispatch is created; budgets belong to the obligation and never reset.
 func (s *Service) HandleBlackboardConclusionVersionConflict(dispatchRequestID string, currentRevision int, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || currentRevision < 0 || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().HandleBlackboardConclusionVersionConflict(dispatchRequestID, currentRevision, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion version conflict: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired && obligation.ErrorCode == BlackboardConclusionErrorVersionConflict {
-		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if obligation.State != BlackboardConclusionReceiptVersionSyncRequested || dispatch.BaseRevision == nil || currentRevision <= *dispatch.BaseRevision {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	nextEligible := now.Add(cooldown)
-	if owner.ConclusionVersionRegenerationAllowed(obligation.VersionRegenerationCount, obligation.AutomaticTurnCount, obligation.ExplicitRetryCount) {
-		requestID := blackboardConclusionAttemptRequestID("version", dispatch.ContinuationID, obligation.SourceTurnID, 1, fmt.Sprintf("%d", currentRevision))
-		nowDispatch := ConclusionDispatch{
-			ID: newID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindVersionRegeneration,
-			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
-			DispatchRequestID: requestID, BaseRevision: intPointer(currentRevision),
-			SynchronizedRevision: intPointer(currentRevision), DeliveryState: ConclusionDispatchRequested,
-			CreatedAt: now, UpdatedAt: now,
-		}
-		if err := supersedeActiveDispatchTx(tx, dispatch, "superseded_by_version_regeneration", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if _, err := tx.Exec(`INSERT INTO conclusion_dispatches
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,synchronized_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, currentRevision, currentRevision, string(nowDispatch.DeliveryState),
-			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store version regeneration Conclusion Dispatch: %w", err)
-		}
-		obligation.State = BlackboardConclusionReceiptVersionRegenerationDispatchRequested
-		obligation.VersionRegenerationCount = 1
-		obligation.AutomaticTurnCount++
-		obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
-		obligation.NextEligibleAt = &nextEligible
-		obligation.CanonicalResultJSON = nil
-		obligation.CanonicalResultSHA256 = ""
-		obligation.UpdatedAt = now
-		if err := updateObligationProtocolTx(tx, obligation); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		view := obligationView(obligation)
-		view.ActiveDispatchID = nowDispatch.ID
-		view.DispatchKind = nowDispatch.Kind
-		view.DispatchRequestID = nowDispatch.DispatchRequestID
-		view.ContinuationID = nowDispatch.ContinuationID
-		view.SourceSessionID = nowDispatch.SourceSessionID
-		view.BaseRevision = nowDispatch.BaseRevision
-		view.SynchronizedRevision = nowDispatch.SynchronizedRevision
-		if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-			"phase": "version_regeneration_requested", "receipt_id": obligation.ID, "request_id": requestID,
-			"base_revision": currentRevision, "error_code": string(BlackboardConclusionErrorVersionConflict),
-			"automatic_turn_count": obligation.AutomaticTurnCount, "version_regeneration_count": obligation.VersionRegenerationCount,
-			"turn_kind": "control",
-		}, now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if err := tx.Commit(); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		return view, true, nil
-	}
-
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = BlackboardConclusionErrorVersionConflict
-	obligation.NextEligibleAt = &nextEligible
-	obligation.BaseRevision = intPointer(currentRevision)
-	obligation.CanonicalResultJSON = nil
-	obligation.CanonicalResultSHA256 = ""
-	obligation.UpdatedAt = now
-	if err := updateObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"base_revision": currentRevision, "error_code": string(BlackboardConclusionErrorVersionConflict),
-		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "version_regeneration_exhausted",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionVersionConflictActionRequired rejects a validated
-// result whose record or change versions are semantically incompatible with
-// the apply contract and requires operator action immediately.
 func (s *Service) MarkBlackboardConclusionVersionConflictActionRequired(dispatchRequestID string, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	return s.MarkBlackboardConclusionApplyActionRequired(dispatchRequestID, BlackboardConclusionErrorVersionConflict, now, cooldown)
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionVersionConflictActionRequired(dispatchRequestID, now, cooldown)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
+	}
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionApplyActionRequired fails closed when a validated
-// result cannot be applied or its pre-regeneration synchronization fails.
 func (s *Service) MarkBlackboardConclusionApplyActionRequired(dispatchRequestID string, code BlackboardConclusionErrorCode, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || cooldown < 0 || !validBlackboardConclusionErrorCode(code) {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionApplyActionRequired(dispatchRequestID, code, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin incompatible Blackboard conclusion version: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired && obligation.ErrorCode == code {
-		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if obligation.State != BlackboardConclusionReceiptValidated && obligation.State != BlackboardConclusionReceiptVersionSyncRequested {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	nextEligible := now.Add(cooldown)
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = code
-	obligation.NextEligibleAt = &nextEligible
-	obligation.CanonicalResultJSON = nil
-	obligation.CanonicalResultSHA256 = ""
-	obligation.UpdatedAt = now
-	if err := updateObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"base_revision": intPointerValue(dispatch.BaseRevision), "error_code": string(code),
-		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "apply_failed",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionRecoveryActionRequired closes crash windows after a
-// repair, version sync/regeneration, or operator-authorized retry was durably
-// claimed but could not finish. The reason is a closed operator-visible token.
 func (s *Service) MarkBlackboardConclusionRecoveryActionRequired(dispatchRequestID string, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || !owner.ValidConclusionRecoveryReason(reason) || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionRecoveryActionRequired(dispatchRequestID, reason, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	return s.markConclusionRecoveryActionRequiredTx(tx, obligation, dispatch, reason, now, cooldown)
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionRecoveryActionRequiredByReceiptID resolves any
-// restart-stranded pre-apply obligation, including pending obligations that do
-// not yet have a dispatch. Replays preserve the original cooldown and counters.
 func (s *Service) MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligationID string, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	obligationID = strings.TrimSpace(obligationID)
-	if obligationID == "" || !owner.ValidConclusionRecoveryReason(reason) || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligationID, reason, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion dispatch recovery: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	dispatch, err := activeConclusionDispatchTx(tx, obligation.ID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return s.markConclusionRecoveryActionRequiredTx(tx, obligation, dispatch, reason, now, cooldown)
+	return receiptFromConclusion(rec), changed, nil
 }
 
-func (s *Service) markConclusionRecoveryActionRequiredTx(tx *sql.Tx, obligation PendingBlackboardConclusion, dispatch *ConclusionDispatch, reason ConclusionRecoveryReason, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	if obligation.State == BlackboardConclusionReceiptActionRequired {
-		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	if !owner.ConclusionRecoveryEligible(obligation.State) {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	nextEligible := now.Add(cooldown)
-	if obligation.NextEligibleAt != nil {
-		nextEligible = obligation.NextEligibleAt.UTC()
-	}
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = BlackboardConclusionErrorRuntimeRecoveryRequired
-	obligation.RecoveryReason = reason
-	obligation.NextEligibleAt = &nextEligible
-	obligation.UpdatedAt = now
-	if err := updateObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	// Supersede ANY active dispatch so a later provider callback resolves to a
-	// terminal delivery and is recorded as a late outcome instead of being
-	// silently dropped while the obligation is already action_required.
-	if dispatch != nil && owner.ConclusionDispatchActive(dispatch.DeliveryState) {
-		if err := supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-	}
-	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": obligationDispatchRequestID(dispatch),
-		"error_code": string(obligation.ErrorCode), "recovery_reason": string(reason),
-		"next_eligible_at": nextEligible.Format(time.RFC3339Nano), "reason": "dispatch_recovery",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
-}
-
-// MarkBlackboardConclusionWorkTurnConflict resolves a conclusion dispatch that
-// a non-yielding provider work turn refused. Within the bounded conflict
-// budget it stays operator-retryable; once exhausted it becomes the distinct,
-// non-retryable never-settled terminal.
 func (s *Service) MarkBlackboardConclusionWorkTurnConflict(dispatchRequestID string, now time.Time, cooldown time.Duration) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || cooldown < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionWorkTurnConflict(dispatchRequestID, now, cooldown)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion work turn conflict: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if obligation.State == BlackboardConclusionReceiptActionRequired {
-		return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-	}
-	eligible := dispatch.DeliveryState == ConclusionDispatchRequested
-	if !eligible {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	errorCode, reason := owner.ConclusionWorkTurnConflictOutcome(obligation.ExplicitRetryCount)
-	nextEligible := now.Add(cooldown)
-	if obligation.NextEligibleAt != nil {
-		nextEligible = obligation.NextEligibleAt.UTC()
-	}
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = errorCode
-	obligation.NextEligibleAt = &nextEligible
-	obligation.UpdatedAt = now
-	if err := updateObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "action_required", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-		"error_code": string(errorCode), "next_eligible_at": nextEligible.Format(time.RFC3339Nano),
-		"reason": reason, "explicit_retry_count": obligation.ExplicitRetryCount,
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// BlackboardConclusionRecoveryCandidates lists obligations in pre-apply states
-// for an ownership-aware daemon coordinator. It never mutates state.
 func (s *Service) BlackboardConclusionRecoveryCandidates() ([]BlackboardConclusionReceipt, error) {
-	rows, err := s.db.Query(`SELECT `+pendingBlackboardConclusionColumns+` FROM pending_blackboard_conclusions
-		WHERE state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
-		string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
-		string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
-		string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
+	recs, err := s.conclusions().BlackboardConclusionRecoveryCandidates()
 	if err != nil {
-		return nil, fmt.Errorf("list Blackboard conclusion recovery candidates: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan Blackboard conclusion recovery candidate: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate Blackboard conclusion recovery candidates: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, fmt.Errorf("close Blackboard conclusion recovery candidates: %w", err)
-	}
-	views := make([]BlackboardConclusionReceipt, 0, len(obligations))
-	for _, obligation := range obligations {
-		view, viewErr := combinedConclusionView(s.db, obligation)
-		if viewErr != nil {
-			return nil, fmt.Errorf("scan Blackboard conclusion recovery candidate view: %w", viewErr)
-		}
-		views = append(views, view)
-	}
-	return views, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// ReconcileStrandedBlackboardConclusionRecoveries makes durably claimed
-// repair, version sync/regeneration, and explicit retry work
-// operator-actionable after daemon restart. It excludes indistinguishable
-// initial dispatch claims (their independent recovery policy cannot be
-// inferred) unless an explicit retry was already recorded.
 func (s *Service) ReconcileStrandedBlackboardConclusionRecoveries(now time.Time, cooldown time.Duration) ([]BlackboardConclusionReceipt, error) {
-	if cooldown < 0 {
-		return nil, ErrInvalidBlackboardConclusionReceipt
-	}
-	rows, err := s.db.Query(`SELECT `+pendingBlackboardConclusionColumns+` FROM pending_blackboard_conclusions
-		WHERE state IN (?,?,?) OR (state=? AND explicit_retry_count>0) OR (state=? AND (repair_count>0 OR version_regeneration_count>0 OR explicit_retry_count>0))
-		ORDER BY created_at,id`, string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested), string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptDispatchRequested),
-		string(BlackboardConclusionReceiptAwaitingResult))
+	recs, err := s.conclusions().ReconcileStrandedBlackboardConclusionRecoveries(now, cooldown)
 	if err != nil {
-		return nil, fmt.Errorf("list stranded Blackboard conclusion recoveries: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan stranded Blackboard conclusion recovery: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate stranded Blackboard conclusion recoveries: %w", err)
-	}
-	_ = rows.Close()
-	reconciled := make([]BlackboardConclusionReceipt, 0, len(obligations))
-	for _, obligation := range obligations {
-		receipt, changed, err := s.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(obligation.ID, ConclusionRecoveryDispatchFailed, now, cooldown)
-		if err != nil {
-			return nil, err
-		}
-		if changed {
-			reconciled = append(reconciled, receipt)
-		}
-	}
-	return reconciled, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// RetryBlackboardConclusion atomically claims one operator-authorized retry for
-// an action_required obligation. The retry supersedes the failed dispatch and
-// creates a NEW retry dispatch bound to the same immutable continuation and
-// source session. A never-dispatched obligation is re-armed to pending so the
-// initial dispatch claim runs on the live runtime.
 func (s *Service) RetryBlackboardConclusion(obligationID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	obligationID, idempotencyKey = strings.TrimSpace(obligationID), strings.TrimSpace(idempotencyKey)
-	if obligationID == "" || idempotencyKey == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, won, err := s.conclusions().RetryBlackboardConclusion(obligationID, idempotencyKey, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	receipt, won, err := retryBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
-	if err != nil || !won {
-		return receipt, won, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return receipt, true, nil
+	return receiptFromConclusion(rec), won, nil
 }
 
 // RetryLatestBlackboardConclusion atomically applies a Task-scoped operator
 // retry key to the latest durable conclusion obligation.
 func (s *Service) RetryLatestBlackboardConclusion(taskID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	taskID, idempotencyKey = strings.TrimSpace(taskID), strings.TrimSpace(idempotencyKey)
-	if taskID == "" || idempotencyKey == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, won, err := s.conclusions().RetryLatestBlackboardConclusion(taskID, idempotencyKey, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := scanPendingBlackboardConclusion(tx.QueryRow(`SELECT `+pendingBlackboardConclusionColumns+`
-		FROM pending_blackboard_conclusions WHERE task_id=? ORDER BY created_at DESC,id DESC LIMIT 1`, taskID))
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	receipt, won, err := retryBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
-	if err != nil || !won {
-		return receipt, won, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return receipt, true, nil
+	return receiptFromConclusion(rec), won, nil
 }
 
-func retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	var priorObligationID string
-	err := tx.QueryRow(`SELECT receipt_id FROM assisted_conclusion_retry_keys
-		WHERE task_id=? AND idempotency_key=?`, obligation.TaskID, idempotencyKey).Scan(&priorObligationID)
-	if err == nil {
-		prior, loadErr := loadPendingBlackboardConclusionByID(tx, priorObligationID)
-		if loadErr != nil {
-			return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(loadErr)
-		}
-		view, viewErr := combinedConclusionView(tx, prior)
-		if viewErr != nil {
-			return BlackboardConclusionReceipt{}, false, viewErr
-		}
-		return view, false, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("read Blackboard conclusion retry idempotency history: %w", err)
-	}
-	switch owner.ConclusionRetryDecisionFor(obligation.State, obligation.ErrorCode, obligation.RecoveryReason, obligation.NextEligibleAt, now) {
-	case owner.ConclusionRetryInvalidState:
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	case owner.ConclusionRetryNeverSettled:
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionWorkTurnNeverSettled
-	case owner.ConclusionRetryAcceptanceAmbiguous, owner.ConclusionRetryCooldown:
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
-	}
-	dispatch, err := activeConclusionDispatchTx(tx, obligation.ID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if dispatch == nil {
-		// No active dispatch (for example the failed repair was superseded).
-		// Bind the retry to the LATEST dispatch's immutable binding, which is
-		// either the live replacement (after a steer recovery) or the original
-		// source binding of the completed Work Turn.
-		dispatch, err = latestConclusionDispatchTx(tx, obligation.ID)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-	}
-	retryNumber := obligation.ExplicitRetryCount + 1
-	if dispatch == nil {
-		// Never-dispatched obligation: re-arm to pending so the initial claim
-		// runs on the live runtime. The retry history records the deterministic
-		// initial request lineage.
-		initialRequestID, _ := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
-		obligation.State = BlackboardConclusionReceiptPending
-		obligation.ExplicitRetryCount++
-		obligation.OperatorRetryKey = idempotencyKey
-		obligation.ErrorCode = ""
-		obligation.NextEligibleAt = nil
-		obligation.UpdatedAt = now
-		if err := updateObligationProtocolTx(tx, obligation); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		if _, err := tx.Exec(`INSERT INTO assisted_conclusion_retry_keys
-			(task_id,receipt_id,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
-			obligation.TaskID, obligation.ID, idempotencyKey, initialRequestID, now.Format(time.RFC3339Nano)); err != nil {
-			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store pending Blackboard conclusion retry history: %w", err)
-		}
-		if err := appendBlackboardConclusionEventTx(tx, obligationView(obligation), EventPayload{
-			"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": initialRequestID,
-			"explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control",
-		}, now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-		return obligationView(obligation), true, nil
-	}
-	requestID := blackboardConclusionAttemptRequestID("retry", dispatch.ContinuationID, obligation.SourceTurnID, retryNumber, idempotencyKey)
-	nowDispatch := ConclusionDispatch{
-		ID: newID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRetry,
-		ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
-		DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
-		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-	}
-	if err := supersedeActiveDispatchTx(tx, dispatch, "superseded_by_retry", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if _, err := tx.Exec(`INSERT INTO conclusion_dispatches
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store retry Conclusion Dispatch: %w", err)
-	}
-	obligation.State = BlackboardConclusionReceiptDispatchRequested
-	obligation.ExplicitRetryCount++
-	obligation.OperatorRetryKey = idempotencyKey
-	obligation.ErrorCode = ""
-	obligation.NextEligibleAt = nil
-	// The operator retry starts a fresh generation: the previous validated
-	// result and its bounded rejection detail are no longer current.
-	obligation.CanonicalResultJSON = nil
-	obligation.CanonicalResultSHA256 = ""
-	obligation.ValidationReason = ""
-	obligation.ValidationFieldPath = ""
-	obligation.ValidationExpected = ""
-	obligation.UpdatedAt = now
-	if err := updateObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if _, err := tx.Exec(`INSERT INTO assisted_conclusion_retry_keys
-		(task_id,receipt_id,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
-		obligation.TaskID, obligation.ID, idempotencyKey, requestID, now.Format(time.RFC3339Nano)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store Blackboard conclusion retry idempotency history: %w", err)
-	}
-	view := obligationView(obligation)
-	view.ActiveDispatchID = nowDispatch.ID
-	view.DispatchKind = nowDispatch.Kind
-	view.DispatchRequestID = nowDispatch.DispatchRequestID
-	view.ContinuationID = nowDispatch.ContinuationID
-	view.SourceSessionID = nowDispatch.SourceSessionID
-	view.BaseRevision = nowDispatch.BaseRevision
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": requestID, "explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control"}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	return view, true, nil
-}
-
-// BlackboardConclusionByDispatchRequestID resolves the obligation whose ACTIVE
-// dispatch owns the provider request correlation. Only the ACTIVE dispatch may
-// validate or apply a result: a callback that resolves to a superseded or late
-// dispatch is durably recorded as a late terminal delivery outcome and returns
-// ErrBlackboardConclusionDispatchInactive so the coordinator drops it. It can
-// never mutate the obligation or Blackboard (ADR 0021).
 func (s *Service) BlackboardConclusionByDispatchRequestID(dispatchRequestID string) (BlackboardConclusionReceipt, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" {
-		return BlackboardConclusionReceipt{}, ErrInvalidBlackboardConclusionReceipt
-	}
-	dispatch, err := scanConclusionDispatch(s.db.QueryRow(`SELECT `+conclusionDispatchColumns+`
-		FROM conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
+	rec, err := s.conclusions().BlackboardConclusionByDispatchRequestID(dispatchRequestID)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, blackboardConclusionLookupError(err)
+		return BlackboardConclusionReceipt{}, mapConclusionError(err)
 	}
-	obligation, err := loadPendingBlackboardConclusionByID(s.db, dispatch.ObligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, blackboardConclusionLookupError(err)
-	}
-	if !conclusionDispatchIsActive(dispatch.DeliveryState) {
-		// A late or duplicate result for an obsolete dispatch. Record the
-		// bounded late outcome on this dispatch (idempotent) and reject the
-		// callback so it cannot settle or corrupt the current obligation.
-		if dispatch.DeliveryState == ConclusionDispatchSuperseded {
-			_, _ = s.db.Exec(`UPDATE conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=?
-				WHERE dispatch_request_id=? AND delivery_state=?`,
-				string(ConclusionDispatchLateTerminal), "late_result", time.Now().UTC().Format(time.RFC3339Nano),
-				dispatchRequestID, string(ConclusionDispatchSuperseded))
-		}
-		return BlackboardConclusionReceipt{}, ErrBlackboardConclusionDispatchInactive
-	}
-	return blackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
+	return receiptFromConclusion(rec), nil
 }
 
-// RecordLateConclusionDispatchOutcome durably records a callback that resolved
-// to a superseded dispatch: the dispatch becomes late_terminal and can never
-// advance the obligation. It is idempotent.
 func (s *Service) RecordLateConclusionDispatchOutcome(dispatchRequestID string) error {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" {
-		return ErrInvalidBlackboardConclusionReceipt
-	}
-	_, err := s.db.Exec(`UPDATE conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=?
-		WHERE dispatch_request_id=? AND delivery_state=?`,
-		string(ConclusionDispatchLateTerminal), "late_result", time.Now().UTC().Format(time.RFC3339Nano),
-		dispatchRequestID, string(ConclusionDispatchSuperseded))
-	return err
+	return mapConclusionError(s.conclusions().RecordLateConclusionDispatchOutcome(dispatchRequestID))
 }
 
-func conclusionDispatchIsActive(state ConclusionDispatchState) bool {
-	return owner.ConclusionDispatchActive(state)
-}
-
-// MarkBlackboardConclusionValidated persists canonical closed result bytes on
-// the obligation before Blackboard application.
 func (s *Service) MarkBlackboardConclusionValidated(dispatchRequestID string, canonicalResult []byte) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || len(canonicalResult) == 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionValidated(dispatchRequestID, canonicalResult)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	canonicalResult = append([]byte(nil), canonicalResult...)
-	hash := owner.CanonicalConclusionSHA256(canonicalResult)
-	return s.advanceObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptAwaitingResult,
-		BlackboardConclusionReceiptValidated,
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
-			obligation.State = BlackboardConclusionReceiptValidated
-			obligation.CanonicalResultJSON = canonicalResult
-			obligation.CanonicalResultSHA256 = hash
-			obligation.ErrorCode = ""
-			obligation.NextEligibleAt = nil
-			obligation.UpdatedAt = now
-			if _, err := tx.Exec(`UPDATE pending_blackboard_conclusions
-				SET state=?,canonical_result_json=?,canonical_result_sha256=?,error_code=NULL,next_eligible_at=NULL,updated_at=? WHERE id=?`,
-				string(obligation.State), canonicalResult, hash, now.Format(time.RFC3339Nano), obligation.ID); err != nil {
-				return err
-			}
-			dispatch, err := activeConclusionDispatchTx(tx, obligation.ID)
-			if err != nil {
-				return err
-			}
-			if dispatch == nil {
-				return ErrInvalidBlackboardConclusionReceipt
-			}
-			dispatch.DeliveryState = ConclusionDispatchValidated
-			if _, err := tx.Exec(`UPDATE conclusion_dispatches SET delivery_state=?,updated_at=? WHERE id=?`,
-				string(dispatch.DeliveryState), now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
-				return err
-			}
-			view := blackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation)
-			return appendBlackboardConclusionEventTx(tx, view, EventPayload{
-				"phase": "result_validated", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-				"source_turn_id": obligation.SourceTurnID, "control_turn_id": dispatch.ControlTurnID, "result_hash": hash,
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
-// MarkBlackboardConclusionApplied completes the obligation with the exact
-// Blackboard revision returned by ApplyForContinuation.
 func (s *Service) MarkBlackboardConclusionApplied(dispatchRequestID string, appliedRevision int) (BlackboardConclusionReceipt, bool, error) {
-	dispatchRequestID = strings.TrimSpace(dispatchRequestID)
-	if dispatchRequestID == "" || appliedRevision < 0 {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+	rec, changed, err := s.conclusions().MarkBlackboardConclusionApplied(dispatchRequestID, appliedRevision)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	return s.advanceObligationStateByDispatchRequest(dispatchRequestID, BlackboardConclusionReceiptValidated,
-		BlackboardConclusionReceiptApplied,
-		func(tx *sql.Tx, obligation *PendingBlackboardConclusion, now time.Time) error {
-			obligation.State = BlackboardConclusionReceiptApplied
-			obligation.AppliedRevision = intPointer(appliedRevision)
-			obligation.UpdatedAt = now
-			if _, err := tx.Exec(`UPDATE pending_blackboard_conclusions SET state=?,applied_revision=?,updated_at=? WHERE id=?`,
-				string(obligation.State), appliedRevision, now.Format(time.RFC3339Nano), obligation.ID); err != nil {
-				return err
-			}
-			dispatch, err := activeConclusionDispatchTx(tx, obligation.ID)
-			if err != nil {
-				return err
-			}
-			if dispatch == nil {
-				return ErrInvalidBlackboardConclusionReceipt
-			}
-			dispatch.DeliveryState = ConclusionDispatchApplied
-			dispatch.TerminalOutcome = "applied"
-			if _, err := tx.Exec(`UPDATE conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=? WHERE id=?`,
-				string(dispatch.DeliveryState), dispatch.TerminalOutcome, now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
-				return err
-			}
-			view := blackboardConclusionReceiptFromObligationDispatch(dispatch, *obligation)
-			return appendBlackboardConclusionEventTx(tx, view, EventPayload{
-				"phase": "applied", "receipt_id": obligation.ID, "request_id": dispatchRequestID,
-				"source_turn_id": obligation.SourceTurnID, "control_turn_id": dispatch.ControlTurnID, "applied_revision": appliedRevision,
-			}, now)
-		})
+	return receiptFromConclusion(rec), changed, nil
 }
 
 // LatestBlackboardConclusion returns the newest durable obligation for a Task
@@ -1143,714 +317,45 @@ func (s *Service) LatestBlackboardConclusion(taskID string) (*BlackboardConclusi
 	if _, err := s.Get(taskID); err != nil {
 		return nil, err
 	}
-	obligation, err := scanPendingBlackboardConclusion(s.db.QueryRow(`
-		SELECT `+pendingBlackboardConclusionColumns+`
-		FROM pending_blackboard_conclusions WHERE task_id=? ORDER BY created_at DESC,id DESC LIMIT 1`, taskID))
-	if errors.Is(err, sql.ErrNoRows) {
+	rec, err := s.conclusions().LatestBlackboardConclusion(taskID)
+	if err != nil {
+		return nil, mapConclusionError(err)
+	}
+	if rec == nil {
 		return nil, nil
 	}
-	if err != nil {
-		return nil, fmt.Errorf("load latest Blackboard conclusion obligation: %w", err)
-	}
-	view, err := combinedConclusionView(s.db, obligation)
-	if err != nil {
-		return nil, err
-	}
+	view := receiptFromConclusion(*rec)
 	return &view, nil
 }
 
-// ValidatedBlackboardConclusions returns durable apply intents for daemon
-// startup replay. It is read-only and preserves canonical and idempotency
-// lineage exactly as stored.
 func (s *Service) ValidatedBlackboardConclusions() ([]BlackboardConclusionReceipt, error) {
-	rows, err := s.db.Query(`SELECT `+pendingBlackboardConclusionColumns+`
-		FROM pending_blackboard_conclusions WHERE state=? ORDER BY created_at,id`, string(BlackboardConclusionReceiptValidated))
+	recs, err := s.conclusions().ValidatedBlackboardConclusions()
 	if err != nil {
-		return nil, fmt.Errorf("list validated Blackboard conclusions: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan validated Blackboard conclusion: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate validated Blackboard conclusions: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, fmt.Errorf("close validated Blackboard conclusions: %w", err)
-	}
-	views := make([]BlackboardConclusionReceipt, 0, len(obligations))
-	for _, obligation := range obligations {
-		view, viewErr := combinedConclusionView(s.db, obligation)
-		if viewErr != nil {
-			return nil, fmt.Errorf("scan validated Blackboard conclusion view: %w", viewErr)
-		}
-		views = append(views, view)
-	}
-	return views, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// ConclusionDispatches returns the immutable dispatch history for an
-// obligation, newest first. The obligation row itself is not projected.
 func (s *Service) ConclusionDispatches(obligationID string) ([]ConclusionDispatch, error) {
-	obligationID = strings.TrimSpace(obligationID)
-	if obligationID == "" {
-		return nil, ErrInvalidBlackboardConclusionReceipt
-	}
-	rows, err := s.db.Query(`SELECT `+conclusionDispatchColumns+` FROM conclusion_dispatches
-		WHERE obligation_id=? ORDER BY rowid DESC`, obligationID)
+	dispatches, err := s.conclusions().ConclusionDispatches(obligationID)
 	if err != nil {
-		return nil, fmt.Errorf("list Conclusion Dispatches: %w", err)
-	}
-	defer rows.Close()
-	var dispatches []ConclusionDispatch
-	for rows.Next() {
-		dispatch, scanErr := scanConclusionDispatch(rows)
-		if scanErr != nil {
-			return nil, fmt.Errorf("scan Conclusion Dispatch: %w", scanErr)
-		}
-		dispatches = append(dispatches, dispatch)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate Conclusion Dispatches: %w", err)
+		return nil, mapConclusionError(err)
 	}
 	return dispatches, nil
 }
 
-// CreateRecoveryConclusionDispatches supersedes every in-flight Conclusion
-// Dispatch of a Task that is bound to the old Continuation and creates a NEW
-// recovery dispatch bound immutably to the replacement Continuation and
-// session. This replaces the old mutable receipt rebinding (#197): historical
-// dispatch identity is never rewritten. The obligation state is re-armed to the
-// matching pre-send protocol state so the daemon can re-dispatch.
 func (s *Service) CreateRecoveryConclusionDispatches(taskID, oldContinuationID, replacementContinuationID, replacementSessionID string) ([]BlackboardConclusionReceipt, error) {
-	taskID, oldContinuationID, replacementContinuationID, replacementSessionID =
-		strings.TrimSpace(taskID), strings.TrimSpace(oldContinuationID), strings.TrimSpace(replacementContinuationID), strings.TrimSpace(replacementSessionID)
-	if taskID == "" || oldContinuationID == "" || replacementContinuationID == "" || replacementSessionID == "" || oldContinuationID == replacementContinuationID {
-		return nil, ErrInvalidBlackboardConclusionReceipt
-	}
-	now := time.Now().UTC()
-	tx, err := s.db.Begin()
+	recs, err := s.conclusions().CreateRecoveryConclusionDispatches(taskID, oldContinuationID, replacementContinuationID, replacementSessionID)
 	if err != nil {
-		return nil, fmt.Errorf("begin recovery Conclusion Dispatch: %w", err)
+		return nil, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	rows, err := tx.Query(`SELECT `+pendingBlackboardConclusionColumns+` FROM pending_blackboard_conclusions
-		WHERE task_id=? AND state IN (?,?,?,?,?,?) ORDER BY created_at,id`,
-		taskID, string(BlackboardConclusionReceiptPending), string(BlackboardConclusionReceiptDispatchRequested),
-		string(BlackboardConclusionReceiptRepairDispatchRequested), string(BlackboardConclusionReceiptVersionSyncRequested),
-		string(BlackboardConclusionReceiptVersionRegenerationDispatchRequested), string(BlackboardConclusionReceiptAwaitingResult))
-	if err != nil {
-		return nil, fmt.Errorf("list recovery Conclusion Dispatches: %w", err)
-	}
-	var obligations []PendingBlackboardConclusion
-	for rows.Next() {
-		obligation, scanErr := scanPendingBlackboardConclusion(rows)
-		if scanErr != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("scan recovery Conclusion Dispatch obligation: %w", scanErr)
-		}
-		obligations = append(obligations, obligation)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, fmt.Errorf("iterate recovery Conclusion Dispatch obligations: %w", err)
-	}
-	_ = rows.Close()
-
-	var views []BlackboardConclusionReceipt
-	for _, obligation := range obligations {
-		dispatch, dispatchErr := activeConclusionDispatchTx(tx, obligation.ID)
-		if dispatchErr != nil && !errors.Is(dispatchErr, sql.ErrNoRows) {
-			return nil, dispatchErr
-		}
-		boundToOld := dispatch != nil && dispatch.ContinuationID == oldContinuationID
-		boundToReplacement := dispatch != nil && dispatch.ContinuationID == replacementContinuationID
-		pendingBoundToOld := dispatch == nil && obligation.State == BlackboardConclusionReceiptPending && obligation.SourceContinuationID == oldContinuationID
-		if !boundToOld && !pendingBoundToOld {
-			if boundToReplacement {
-				view, viewErr := combinedConclusionView(tx, obligation)
-				if viewErr != nil {
-					return nil, viewErr
-				}
-				views = append(views, view)
-			}
-			continue
-		}
-		if dispatch != nil {
-			if err := supersedeActiveDispatchTx(tx, dispatch, "superseded_by_recovery", now); err != nil {
-				return nil, err
-			}
-		}
-		number := conclusionDispatchSequence(tx, obligation.ID) + 1
-		requestID := blackboardConclusionAttemptRequestID("recovery", replacementContinuationID, obligation.SourceTurnID, number, "")
-		nowDispatch := ConclusionDispatch{
-			ID: newID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
-			ContinuationID: replacementContinuationID, SourceSessionID: replacementSessionID,
-			DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
-			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-		}
-		if _, err := tx.Exec(`INSERT INTO conclusion_dispatches
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-			return nil, fmt.Errorf("store recovery Conclusion Dispatch: %w", err)
-		}
-		switch obligation.State {
-		case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptAwaitingResult:
-			obligation.State = BlackboardConclusionReceiptDispatchRequested
-		}
-		obligation.UpdatedAt = now
-		if err := updateObligationProtocolTx(tx, obligation); err != nil {
-			return nil, err
-		}
-		view := obligationView(obligation)
-		view.ActiveDispatchID = nowDispatch.ID
-		view.DispatchKind = nowDispatch.Kind
-		view.DispatchRequestID = nowDispatch.DispatchRequestID
-		view.ContinuationID = nowDispatch.ContinuationID
-		view.SourceSessionID = nowDispatch.SourceSessionID
-		view.BaseRevision = nowDispatch.BaseRevision
-		if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-			"phase": "recovery_dispatch_created", "receipt_id": obligation.ID, "request_id": requestID,
-			"replacement_continuation_id": replacementContinuationID, "replacement_session_id": replacementSessionID,
-			"turn_kind": "control",
-		}, now); err != nil {
-			return nil, err
-		}
-		views = append(views, view)
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit recovery Conclusion Dispatches: %w", err)
-	}
-	return views, nil
+	return receiptsFromConclusion(recs), nil
 }
 
-// CreateRecoveryConclusionDispatch supersedes the active dispatch (if any) of
-// one obligation and creates a NEW recovery dispatch bound immutably to the
-// proven-live replacement continuation + session. It is the single-obligation
-// form used by restart recovery when the active dispatch is bound to a dead
-// continuation; the old dispatch identity is never rewritten. Won is false when
-// the obligation is already bound to the target continuation or is terminal.
 func (s *Service) CreateRecoveryConclusionDispatch(obligationID, continuationID, sessionID string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	obligationID, continuationID, sessionID = strings.TrimSpace(obligationID), strings.TrimSpace(continuationID), strings.TrimSpace(sessionID)
-	if obligationID == "" || continuationID == "" || sessionID == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now = now.UTC()
-	tx, err := s.db.Begin()
+	rec, created, err := s.conclusions().CreateRecoveryConclusionDispatch(obligationID, continuationID, sessionID, now)
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin recovery Conclusion Dispatch: %w", err)
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, err := loadPendingBlackboardConclusionByID(tx, obligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	dispatch, err := activeConclusionDispatchTx(tx, obligation.ID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if dispatch != nil && dispatch.ContinuationID == continuationID && dispatch.SourceSessionID == sessionID {
-		view, viewErr := combinedConclusionView(tx, obligation)
-		if viewErr != nil {
-			return BlackboardConclusionReceipt{}, false, viewErr
-		}
-		return view, false, nil
-	}
-	if obligation.State == BlackboardConclusionReceiptApplied || obligation.State == BlackboardConclusionReceiptClean {
-		view, viewErr := combinedConclusionView(tx, obligation)
-		if viewErr != nil {
-			return BlackboardConclusionReceipt{}, false, viewErr
-		}
-		return view, false, nil
-	}
-	if dispatch != nil {
-		if err := supersedeActiveDispatchTx(tx, dispatch, "superseded_by_recovery", now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
-		}
-	}
-	number := conclusionDispatchSequence(tx, obligation.ID) + 1
-	requestID := blackboardConclusionAttemptRequestID("recovery", continuationID, obligation.SourceTurnID, number, "")
-	nowDispatch := ConclusionDispatch{
-		ID: newID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
-		ContinuationID: continuationID, SourceSessionID: sessionID,
-		DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
-		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
-	}
-	if _, err := tx.Exec(`INSERT INTO conclusion_dispatches
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
-		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
-		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store recovery Conclusion Dispatch: %w", err)
-	}
-	switch obligation.State {
-	case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptAwaitingResult:
-		obligation.State = BlackboardConclusionReceiptDispatchRequested
-	}
-	obligation.UpdatedAt = now
-	if err := updateObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view := obligationView(obligation)
-	view.ActiveDispatchID = nowDispatch.ID
-	view.DispatchKind = nowDispatch.Kind
-	view.DispatchRequestID = nowDispatch.DispatchRequestID
-	view.ContinuationID = nowDispatch.ContinuationID
-	view.SourceSessionID = nowDispatch.SourceSessionID
-	view.BaseRevision = nowDispatch.BaseRevision
-	if err := appendBlackboardConclusionEventTx(tx, view, EventPayload{
-		"phase": "recovery_dispatch_created", "receipt_id": obligation.ID, "request_id": requestID,
-		"replacement_continuation_id": continuationID, "replacement_session_id": sessionID,
-		"turn_kind": "control",
-	}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit recovery Conclusion Dispatch: %w", err)
-	}
-	return view, true, nil
-}
-
-// --- internal helpers ---
-
-func obligationView(obligation PendingBlackboardConclusion) BlackboardConclusionReceipt {
-	view := BlackboardConclusionReceipt{
-		ID: obligation.ID, TaskID: obligation.TaskID,
-		ContinuationID:  obligation.SourceContinuationID,
-		SourceRequestID: obligation.SourceRequestID, SourceRequestCorrelationExact: obligation.SourceRequestCorrelationExact,
-		SourceSessionID: obligation.SourceSessionID, SourceTurnID: obligation.SourceTurnID,
-		InternalState: obligation.State, SourceWorkWatermark: obligation.SourceWorkWatermark,
-		SemanticPersistenceWatermark: obligation.SemanticPersistenceWatermark,
-		SourceSelection:              obligation.SourceSelection, CanonicalResultJSON: obligation.CanonicalResultJSON,
-		CanonicalResultSHA256: obligation.CanonicalResultSHA256, ApplyIdempotencyKey: obligation.ApplyIdempotencyKey,
-		AppliedRevision: obligation.AppliedRevision, BaseRevision: obligation.BaseRevision, AutomaticTurnCount: obligation.AutomaticTurnCount,
-		RepairCount: obligation.RepairCount, VersionRegenerationCount: obligation.VersionRegenerationCount,
-		ExplicitRetryCount: obligation.ExplicitRetryCount, OperatorRetryKey: obligation.OperatorRetryKey,
-		NextEligibleAt: obligation.NextEligibleAt, ErrorCode: obligation.ErrorCode,
-		RecoveryReason: string(obligation.RecoveryReason), ValidationReason: obligation.ValidationReason,
-		ValidationFieldPath: obligation.ValidationFieldPath, ValidationExpected: obligation.ValidationExpected,
-		CreatedAt: obligation.CreatedAt, UpdatedAt: obligation.UpdatedAt,
-	}
-	return view
-}
-
-func blackboardConclusionReceiptFromObligationDispatch(dispatch *ConclusionDispatch, obligation PendingBlackboardConclusion) BlackboardConclusionReceipt {
-	view := obligationView(obligation)
-	if dispatch == nil {
-		return view
-	}
-	view.ContinuationID = dispatch.ContinuationID
-	view.SourceSessionID = dispatch.SourceSessionID
-	view.DispatchRequestID = dispatch.DispatchRequestID
-	view.ControlTurnID = dispatch.ControlTurnID
-	// The dispatch carries its own immutable base revision. For an active
-	// dispatch it is the current protocol base; for a superseded or terminal
-	// dispatch the obligation's latest claimed base revision is authoritative
-	// (for example the exhausted version-regeneration action_required state).
-	if owner.ConclusionDispatchActive(dispatch.DeliveryState) {
-		view.BaseRevision = dispatch.BaseRevision
-	}
-	if view.BaseRevision == nil {
-		view.BaseRevision = obligation.BaseRevision
-	}
-	view.SynchronizedRevision = dispatch.SynchronizedRevision
-	view.SendAttemptCount = dispatch.SendAttemptCount
-	view.SendStartedAt = dispatch.SendStartedAt
-	view.ActiveDispatchID = dispatch.ID
-	view.DispatchKind = dispatch.Kind
-	return view
-}
-
-func combinedConclusionView(queryer interface {
-	QueryRow(string, ...any) *sql.Row
-}, obligation PendingBlackboardConclusion) (BlackboardConclusionReceipt, error) {
-	dispatch, err := scanConclusionDispatch(queryer.QueryRow(`SELECT `+conclusionDispatchColumns+`
-		FROM conclusion_dispatches WHERE obligation_id=? AND delivery_state IN (?,?,?)
-		ORDER BY created_at DESC,id DESC LIMIT 1`, obligation.ID,
-		string(ConclusionDispatchRequested), string(ConclusionDispatchAwaitingResult), string(ConclusionDispatchValidated)))
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, fmt.Errorf("load active Conclusion Dispatch: %w", err)
-	}
-	if errors.Is(err, sql.ErrNoRows) {
-		// Terminal obligations (applied / action_required) keep their last
-		// dispatch as the visible delivery lineage.
-		latest, latestErr := scanConclusionDispatch(queryer.QueryRow(`SELECT `+conclusionDispatchColumns+`
-			FROM conclusion_dispatches WHERE obligation_id=? ORDER BY rowid DESC LIMIT 1`, obligation.ID))
-		if latestErr != nil && !errors.Is(latestErr, sql.ErrNoRows) {
-			return BlackboardConclusionReceipt{}, fmt.Errorf("load latest Conclusion Dispatch: %w", latestErr)
-		}
-		if latestErr == nil {
-			return blackboardConclusionReceiptFromObligationDispatch(&latest, obligation), nil
-		}
-		return blackboardConclusionReceiptFromObligationDispatch(nil, obligation), nil
-	}
-	return blackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
-}
-
-type obligationQueryer interface {
-	QueryRow(string, ...any) *sql.Row
-}
-
-func loadPendingBlackboardConclusionByID(queryer obligationQueryer, obligationID string) (PendingBlackboardConclusion, error) {
-	return scanPendingBlackboardConclusion(queryer.QueryRow(`SELECT `+pendingBlackboardConclusionColumns+`
-		FROM pending_blackboard_conclusions WHERE id=?`, obligationID))
-}
-
-// loadConclusionByDispatchRequestID resolves the obligation for any dispatch
-// request id, active or terminal. Callers that advance the protocol must gate
-// on the active dispatch themselves; this loader is used for idempotent replay
-// of terminal states (for example applied).
-func loadConclusionByDispatchRequestID(tx *sql.Tx, dispatchRequestID string) (PendingBlackboardConclusion, *ConclusionDispatch, error) {
-	dispatch, err := scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
-		FROM conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	obligation, err := loadPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	return obligation, &dispatch, nil
-}
-
-func loadActiveConclusionByDispatchRequestID(tx *sql.Tx, dispatchRequestID string) (PendingBlackboardConclusion, *ConclusionDispatch, error) {
-	dispatch, err := scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
-		FROM conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	if !owner.ConclusionDispatchActive(dispatch.DeliveryState) {
-		// A callback for a superseded or late dispatch is obsolete: it must
-		// fail closed (ErrNotFound) and can never advance the obligation.
-		return PendingBlackboardConclusion{}, nil, sql.ErrNoRows
-	}
-	obligation, err := loadPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
-	if err != nil {
-		return PendingBlackboardConclusion{}, nil, err
-	}
-	return obligation, &dispatch, nil
-}
-
-func conclusionViewByDispatchRequestIDTx(tx *sql.Tx, dispatchRequestID string) (BlackboardConclusionReceipt, error) {
-	dispatch, err := scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
-		FROM conclusion_dispatches WHERE dispatch_request_id=?`, dispatchRequestID))
-	if err != nil {
-		return BlackboardConclusionReceipt{}, err
-	}
-	obligation, err := loadPendingBlackboardConclusionByID(tx, dispatch.ObligationID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, err
-	}
-	return blackboardConclusionReceiptFromObligationDispatch(&dispatch, obligation), nil
-}
-
-func latestConclusionDispatchTx(tx *sql.Tx, obligationID string) (*ConclusionDispatch, error) {
-	dispatch, err := scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
-		FROM conclusion_dispatches WHERE obligation_id=? ORDER BY rowid DESC LIMIT 1`, obligationID))
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &dispatch, nil
-}
-
-func activeConclusionDispatchTx(tx *sql.Tx, obligationID string) (*ConclusionDispatch, error) {
-	dispatch, err := scanConclusionDispatch(tx.QueryRow(`SELECT `+conclusionDispatchColumns+`
-		FROM conclusion_dispatches WHERE obligation_id=? AND delivery_state IN (?,?,?)
-		ORDER BY created_at DESC,id DESC LIMIT 1`, obligationID,
-		string(ConclusionDispatchRequested), string(ConclusionDispatchAwaitingResult), string(ConclusionDispatchValidated)))
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &dispatch, nil
-}
-
-func supersedeActiveDispatchTx(tx *sql.Tx, dispatch *ConclusionDispatch, outcome string, now time.Time) error {
-	dispatch.DeliveryState = ConclusionDispatchSuperseded
-	dispatch.TerminalOutcome = outcome
-	dispatch.UpdatedAt = now
-	if _, err := tx.Exec(`UPDATE conclusion_dispatches SET delivery_state=?,terminal_outcome=?,updated_at=? WHERE id=?`,
-		string(dispatch.DeliveryState), outcome, now.Format(time.RFC3339Nano), dispatch.ID); err != nil {
-		return fmt.Errorf("supersede Conclusion Dispatch: %w", err)
-	}
-	return nil
-}
-
-func failActiveDispatchTx(tx *sql.Tx, obligation PendingBlackboardConclusion, dispatch *ConclusionDispatch, code BlackboardConclusionErrorCode, nextEligible time.Time, detail ConclusionValidationDetail, now time.Time) (PendingBlackboardConclusion, error) {
-	obligation.State = BlackboardConclusionReceiptActionRequired
-	obligation.ErrorCode = code
-	obligation.NextEligibleAt = &nextEligible
-	obligation.ValidationReason = detail.Reason
-	obligation.ValidationFieldPath = detail.FieldPath
-	obligation.ValidationExpected = detail.Expected
-	obligation.UpdatedAt = now
-	if err := updateObligationProtocolTx(tx, obligation); err != nil {
-		return PendingBlackboardConclusion{}, err
-	}
-	if dispatch != nil {
-		if err := supersedeActiveDispatchTx(tx, dispatch, "action_required", now); err != nil {
-			return PendingBlackboardConclusion{}, err
-		}
-	}
-	return obligation, nil
-}
-
-func updateObligationProtocolTx(tx *sql.Tx, obligation PendingBlackboardConclusion) error {
-	if _, err := tx.Exec(`UPDATE pending_blackboard_conclusions
-		SET state=?,canonical_result_json=?,canonical_result_sha256=?,applied_revision=?,base_revision=?,automatic_turn_count=?,repair_count=?,
-		version_regeneration_count=?,explicit_retry_count=?,operator_retry_key=?,error_code=?,recovery_reason=?,next_eligible_at=?,
-		validation_reason=?,validation_field_path=?,validation_expected=?,updated_at=? WHERE id=?`,
-		string(obligation.State), obligation.CanonicalResultJSON, obligation.CanonicalResultSHA256,
-		intPointerValue(obligation.AppliedRevision), intPointerValue(obligation.BaseRevision), obligation.AutomaticTurnCount, obligation.RepairCount,
-		obligation.VersionRegenerationCount, obligation.ExplicitRetryCount, obligation.OperatorRetryKey,
-		string(obligation.ErrorCode), string(obligation.RecoveryReason),
-		formatTimePtr(obligation.NextEligibleAt), obligation.ValidationReason, obligation.ValidationFieldPath,
-		obligation.ValidationExpected, obligation.UpdatedAt.Format(time.RFC3339Nano), obligation.ID); err != nil {
-		return fmt.Errorf("update Blackboard conclusion obligation: %w", err)
-	}
-	return nil
-}
-
-// advanceObligationStateByDispatchRequest transitions the obligation's protocol
-// state, verifying the request id still resolves to the ACTIVE dispatch.
-func (s *Service) advanceObligationStateByDispatchRequest(dispatchRequestID string, from, to BlackboardConclusionReceiptState, advance func(*sql.Tx, *PendingBlackboardConclusion, time.Time) error) (BlackboardConclusionReceipt, bool, error) {
-	tx, err := s.db.Begin()
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion %s: %w", to, err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if obligation.State != from {
-		if obligation.State == to {
-			return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-		}
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now := time.Now().UTC()
-	if err := advance(tx, &obligation, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("mark Blackboard conclusion %s: %w", to, err)
-	}
-	view, err := conclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Blackboard conclusion %s: %w", to, err)
-	}
-	return view, true, nil
-}
-
-// advanceActiveConclusionDispatch transitions the ACTIVE dispatch's delivery
-// state together with the obligation protocol state. Only the active dispatch
-// may advance.
-func (s *Service) advanceActiveConclusionDispatch(dispatchRequestID string, fromDispatch, toDispatch ConclusionDispatchState, toObligation BlackboardConclusionReceiptState,
-	replayMatches func(BlackboardConclusionReceipt) bool,
-	advance func(*sql.Tx, *PendingBlackboardConclusion, *ConclusionDispatch, time.Time) error,
-) (BlackboardConclusionReceipt, bool, error) {
-	tx, err := s.db.Begin()
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("begin Blackboard conclusion %s: %w", toDispatch, err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	obligation, dispatch, err := loadActiveConclusionByDispatchRequestID(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, blackboardConclusionLookupError(err)
-	}
-	if dispatch == nil || dispatch.DeliveryState != fromDispatch {
-		if dispatch != nil && dispatch.DeliveryState == toDispatch && replayMatches(blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation)) {
-			return blackboardConclusionReceiptFromObligationDispatch(dispatch, obligation), false, nil
-		}
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
-	}
-	now := time.Now().UTC()
-	if err := advance(tx, &obligation, dispatch, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("mark Blackboard conclusion %s: %w", toDispatch, err)
-	}
-	obligation.State = toObligation
-	obligation.UpdatedAt = now
-	if _, err := tx.Exec(`UPDATE pending_blackboard_conclusions SET state=?,updated_at=? WHERE id=?`,
-		string(obligation.State), now.Format(time.RFC3339Nano), obligation.ID); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	view, err := conclusionViewByDispatchRequestIDTx(tx, dispatchRequestID)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit Blackboard conclusion %s: %w", toDispatch, err)
-	}
-	return view, true, nil
-}
-
-func scanPendingBlackboardConclusion(row interface{ Scan(...any) error }) (PendingBlackboardConclusion, error) {
-	var obligation PendingBlackboardConclusion
-	var state, createdAt, updatedAt string
-	var nextEligibleAt, errorCode, recoveryReason, validationReason, validationFieldPath, validationExpected, applyKey, resultHash, operatorRetryKey sql.NullString
-	var appliedRevision, baseRevision sql.NullInt64
-	var canonicalResult []byte
-	if err := row.Scan(&obligation.ID, &obligation.TaskID, &obligation.SourceRequestID, &obligation.SourceRequestCorrelationExact,
-		&obligation.SourceContinuationID, &obligation.SourceSessionID, &obligation.SourceTurnID, &state,
-		&obligation.SourceWorkWatermark, &obligation.SemanticPersistenceWatermark,
-		&obligation.SourceSelection.ModelProviderID, &obligation.SourceSelection.Model, &obligation.SourceSelection.ReasoningEffort,
-		&canonicalResult, &resultHash, &applyKey, &appliedRevision, &baseRevision, &obligation.AutomaticTurnCount,
-		&obligation.RepairCount, &obligation.VersionRegenerationCount, &obligation.ExplicitRetryCount,
-		&operatorRetryKey, &nextEligibleAt, &errorCode, &recoveryReason,
-		&validationReason, &validationFieldPath, &validationExpected, &createdAt, &updatedAt); err != nil {
-		return PendingBlackboardConclusion{}, err
-	}
-	obligation.State = BlackboardConclusionReceiptState(state)
-	obligation.CanonicalResultJSON = append([]byte(nil), canonicalResult...)
-	obligation.CanonicalResultSHA256 = resultHash.String
-	obligation.ApplyIdempotencyKey = applyKey.String
-	obligation.OperatorRetryKey = operatorRetryKey.String
-	obligation.ErrorCode = BlackboardConclusionErrorCode(errorCode.String)
-	obligation.RecoveryReason = ConclusionRecoveryReason(recoveryReason.String)
-	obligation.ValidationReason = validationReason.String
-	obligation.ValidationFieldPath = validationFieldPath.String
-	obligation.ValidationExpected = validationExpected.String
-	if appliedRevision.Valid {
-		obligation.AppliedRevision = intPointer(int(appliedRevision.Int64))
-	}
-	if baseRevision.Valid {
-		obligation.BaseRevision = intPointer(int(baseRevision.Int64))
-	}
-	if nextEligibleAt.Valid {
-		parsed, err := time.Parse(time.RFC3339Nano, nextEligibleAt.String)
-		if err != nil {
-			return PendingBlackboardConclusion{}, fmt.Errorf("parse Blackboard conclusion next_eligible_at: %w", err)
-		}
-		obligation.NextEligibleAt = &parsed
-	}
-	var err error
-	if obligation.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
-		return PendingBlackboardConclusion{}, fmt.Errorf("parse Blackboard conclusion created_at: %w", err)
-	}
-	if obligation.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt); err != nil {
-		return PendingBlackboardConclusion{}, fmt.Errorf("parse Blackboard conclusion updated_at: %w", err)
-	}
-	return obligation, nil
-}
-
-func scanConclusionDispatch(row interface{ Scan(...any) error }) (ConclusionDispatch, error) {
-	var dispatch ConclusionDispatch
-	var kind, deliveryState, createdAt, updatedAt string
-	var dispatchRequestID, controlTurnID, sendStartedAt, terminalOutcome sql.NullString
-	var baseRevision, synchronizedRevision sql.NullInt64
-	if err := row.Scan(&dispatch.ID, &dispatch.ObligationID, &kind, &dispatch.ContinuationID, &dispatch.SourceSessionID,
-		&dispatchRequestID, &controlTurnID, &baseRevision, &synchronizedRevision, &deliveryState,
-		&dispatch.SendAttemptCount, &sendStartedAt, &terminalOutcome, &createdAt, &updatedAt); err != nil {
-		return ConclusionDispatch{}, err
-	}
-	dispatch.Kind = ConclusionDispatchKind(kind)
-	dispatch.DeliveryState = ConclusionDispatchState(deliveryState)
-	dispatch.DispatchRequestID = dispatchRequestID.String
-	dispatch.ControlTurnID = controlTurnID.String
-	dispatch.TerminalOutcome = terminalOutcome.String
-	if baseRevision.Valid {
-		dispatch.BaseRevision = intPointer(int(baseRevision.Int64))
-	}
-	if synchronizedRevision.Valid {
-		dispatch.SynchronizedRevision = intPointer(int(synchronizedRevision.Int64))
-	}
-	if sendStartedAt.Valid {
-		parsed, err := time.Parse(time.RFC3339Nano, sendStartedAt.String)
-		if err != nil {
-			return ConclusionDispatch{}, fmt.Errorf("parse Conclusion Dispatch send_started_at: %w", err)
-		}
-		dispatch.SendStartedAt = &parsed
-	}
-	var err error
-	if dispatch.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt); err != nil {
-		return ConclusionDispatch{}, fmt.Errorf("parse Conclusion Dispatch created_at: %w", err)
-	}
-	if dispatch.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt); err != nil {
-		return ConclusionDispatch{}, fmt.Errorf("parse Conclusion Dispatch updated_at: %w", err)
-	}
-	return dispatch, nil
-}
-
-func validBlackboardConclusionErrorCode(code BlackboardConclusionErrorCode) bool {
-	return owner.ValidBlackboardConclusionErrorCode(code)
-}
-
-func blackboardConclusionLookupError(err error) error {
-	if errors.Is(err, sql.ErrNoRows) {
-		return ErrNotFound
-	}
-	return fmt.Errorf("load Blackboard conclusion obligation: %w", err)
-}
-
-func blackboardConclusionRequestLineage(continuationID, sourceTurnID string) (string, string) {
-	return owner.ConclusionRequestLineage(continuationID, sourceTurnID)
-}
-
-func blackboardConclusionAttemptRequestID(kind, continuationID, sourceTurnID string, number int, key string) string {
-	return owner.ConclusionAttemptRequestID(kind, continuationID, sourceTurnID, number, key)
-}
-
-func appendBlackboardConclusionEventTx(tx *sql.Tx, receipt BlackboardConclusionReceipt, payload EventPayload, now time.Time) error {
-	payloadJSON, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("encode Blackboard conclusion Event: %w", err)
-	}
-	var maxSeq sql.NullInt64
-	if err := tx.QueryRow(`SELECT MAX(seq) FROM task_events WHERE task_id=?`, receipt.TaskID).Scan(&maxSeq); err != nil {
-		return fmt.Errorf("read Blackboard conclusion Event sequence: %w", err)
-	}
-	if _, err := tx.Exec(`INSERT INTO task_events (id,task_id,continuation_id,seq,kind,payload_json,created_at)
-		VALUES (?,?,?,?,?,?,?)`, newID(), receipt.TaskID, receipt.ContinuationID, int(maxSeq.Int64)+1,
-		string(EventKindBlackboardConclusion), string(payloadJSON), now.Format(time.RFC3339Nano)); err != nil {
-		return fmt.Errorf("store Blackboard conclusion Event: %w", err)
-	}
-	return nil
-}
-
-func conclusionDispatchSequence(tx *sql.Tx, obligationID string) int {
-	var count int
-	_ = tx.QueryRow(`SELECT COUNT(*) FROM conclusion_dispatches WHERE obligation_id=?`, obligationID).Scan(&count)
-	return count
-}
-
-func dispatchBaseRevision(dispatch *ConclusionDispatch) *int {
-	if dispatch == nil {
-		return nil
-	}
-	return dispatch.BaseRevision
-}
-
-func obligationDispatchRequestID(dispatch *ConclusionDispatch) string {
-	if dispatch == nil {
-		return ""
-	}
-	return dispatch.DispatchRequestID
-}
-
-func intPointerValue(value *int) any {
-	if value == nil {
-		return nil
-	}
-	return *value
-}
-
-func formatTimePtr(value *time.Time) any {
-	if value == nil {
-		return nil
-	}
-	return value.UTC().Format(time.RFC3339Nano)
+	return receiptFromConclusion(rec), created, nil
 }

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Ensure the local dev toolchain (node/npm via nvm, Go) is on PATH for
+# non-interactive shells.
+#
+# Why this exists:
+#   nvm and the Go toolchain are exported by ~/.bashrc, but Makefile recipes
+#   and other non-interactive bash invocations never source ~/.bashrc (and
+#   .bashrc returns early for non-interactive shells anyway), so `node`,
+#   `npm`, and `go` are invisible and `make build` fails with "command not
+#   found".
+#
+# This file is sourced via BASH_ENV (set in the Makefile) so every
+# non-interactive bash recipe gets the toolchain on PATH. It is a no-op when a
+# tool is already installed system-wide (e.g. actions/setup-node /
+# actions/setup-go in CI).
+#
+# Safe to source multiple times: it never calls `exit` and never sets `set -e`.
+
+# --- node / npm (via nvm) -------------------------------------------------
+if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+	had_node=0
+	command -v node >/dev/null 2>&1 && had_node=1
+
+	NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+
+	# Activate nvm if present (respects the `default` alias when it is valid).
+	if [ -s "$NVM_DIR/nvm.sh" ]; then
+		# shellcheck source=/dev/null
+		. "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
+	fi
+
+	# nvm.sh may fail to activate a version when the default alias is stale, so
+	# fall back to the newest installed nvm node and put its bin dir on PATH.
+	if [ "$had_node" -eq 0 ] && ! command -v node >/dev/null 2>&1; then
+		node_root="$NVM_DIR/versions/node"
+		if [ -d "$node_root" ]; then
+			latest="$(ls -1v "$node_root" 2>/dev/null | tail -1)"
+			if [ -n "$latest" ] && [ -x "$node_root/$latest/bin/node" ]; then
+				export PATH="$node_root/$latest/bin:$PATH"
+			fi
+		fi
+	fi
+fi
+
+# --- Go toolchain ---------------------------------------------------------
+if ! command -v go >/dev/null 2>&1; then
+	for go_bin in \
+		"${GOROOT:-}/bin" \
+		"/usr/local/go/bin" \
+		"$HOME/go/bin" \
+		/usr/lib/go/bin; do
+		if [ -n "$go_bin" ] && [ -x "$go_bin/go" ]; then
+			export PATH="$go_bin:$PATH"
+			break
+		fi
+	done
+fi

--- a/scripts/sandbox_image_defaults_test.go
+++ b/scripts/sandbox_image_defaults_test.go
@@ -2,6 +2,7 @@ package scripts_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -48,42 +49,34 @@ func TestRetiredSandboxImageDefaultsAreAbsent(t *testing.T) {
 	repoRoot := repoRoot(t)
 	retired := []string{"pentest-sandbox:latest", "gemini_kali-gemini-kali:latest"}
 
-	err := filepath.WalkDir(repoRoot, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		rel, err := filepath.Rel(repoRoot, path)
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			if rel == ".git" || rel == "web/node_modules" || rel == "web/dist" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if strings.HasSuffix(rel, "_test.go") {
-			return nil
+	// Scan only git-tracked files. Walking the working tree instead breaks on
+	// developer machines: task Runtime homes under runs/ hold downloaded
+	// challenge sources and permission-restricted directories that are local
+	// state, never product source.
+	tracked, err := exec.Command("git", "-C", repoRoot, "ls-files").Output()
+	if err != nil {
+		t.Fatalf("list tracked files: %v", err)
+	}
+	for _, rel := range strings.Split(strings.TrimSpace(string(tracked)), "\n") {
+		if rel == "" || strings.HasSuffix(rel, "_test.go") {
+			continue
 		}
 		switch filepath.Ext(rel) {
 		case ".go", ".html", ".js", ".md", ".py", ".sh", ".ts", ".tsx", ".yaml", ".yml":
 		default:
 			if filepath.Base(rel) != "Makefile" {
-				return nil
+				continue
 			}
 		}
-		contents, err := os.ReadFile(path)
+		contents, err := os.ReadFile(filepath.Join(repoRoot, rel))
 		if err != nil {
-			return err
+			t.Errorf("read %s: %v", rel, err)
+			continue
 		}
 		for _, image := range retired {
 			if strings.Contains(string(contents), image) {
 				t.Errorf("%s must not retain the retired sandbox image default %q", rel, image)
 			}
 		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("scan sandbox image defaults: %v", err)
 	}
 }

--- a/skills/bundles/wsl-pdf-scan/SKILL.md
+++ b/skills/bundles/wsl-pdf-scan/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: wsl-pdf-scan
+description: Static malware triage of PDF files using WSL tools (pdfid, pdf-parser, python3). Produces hashes, active-content keyword scan, JavaScript/XFA/embedded-file inspection, URI extraction, text preview, and a risk verdict. Use when the user explicitly invokes /wsl-pdf-scan or asks to analyze whether a PDF is malicious using WSL.
+---
+
+# WSL PDF Malware Scan
+
+Static (no-execution) triage of one or more PDF files via WSL. Never open the PDF in a viewer.
+
+## Bundled scripts (use these first)
+
+Let `SKILL=/mnt/c/<workspace>/.qoder/skills/wsl-pdf-scan/scripts`. All scripts accept Windows (`D:\temp\a.pdf`) or WSL paths — conversion via `wslpath` is built in.
+
+| Script | Purpose |
+|---|---|
+| `scan.sh [--text] <file>...` | One-shot triage: fingerprint + pdfid + python cross-check (+ optional text dump). Multi-file. |
+| `deep_dive.sh <file> --auto` | Auto-locate & dump all JS/XFA/EmbeddedFile/OpenAction objects, decode streams, threat-pattern grep. Or pass explicit object numbers. |
+| `pdf_triage.py <file> [--text]` | Pure-stdlib scanner (works even without pdfid/pdf-parser). |
+
+## Quoting rules (critical)
+
+- File names often contain spaces or apostrophes (`Supplier's_...`). Inline `wsl.exe -e bash -c "..."` quoting WILL break on them (silent ExitCode 1).
+- Preferred invocation — pass the file as a double-quoted **argument** to a bundled script:
+  `wsl.exe -e bash "$SKILL/scan.sh" "D:\temp\Supplier's file.pdf"`
+- Only if ad-hoc commands are unavoidable, write them into a temp `.sh` in the workspace and run it; delete temp scripts and `/tmp/pdfscan` when done.
+
+## Workflow
+
+### Step 1 — One-shot triage
+```bash
+wsl.exe -e bash "$SKILL/scan.sh" "<file1>" "<file2>"
+```
+Covers fingerprint (`file`/hashes), pdfid indicators, and the python cross-check in one pass.
+Danger indicators: `/JS`, `/JavaScript`, `/OpenAction`, `/AA`, `/Launch`, `/EmbeddedFile`, `/RichMedia`, `/XFA`, `/JBIG2Decode`, `/Encrypt`. If **all zero** → skip to Step 3.
+
+### Step 2 — Deep-dive flagged objects
+```bash
+wsl.exe -e bash "$SKILL/deep_dive.sh" "<file>" --auto
+```
+Dumps each flagged object's dict + decoded stream to `/tmp/pdfscan/`, then greps all dumps for threat patterns (URLs, launchURL, unescape/fromCharCode/eval, .exe/powershell).
+Interpretation:
+- Known-benign: Adobe LiveCycle `!ADBE::*VersChk*` version-check JS boilerplate (alerts + `cgi.adobe.com` URL only).
+- Standard namespace URLs (xfa.org, ns.adobe.com, w3.org, purl.org) are benign. LiveCycle forms legitimately produce ~10 `/EmbeddedFile` XFA packets — not smuggled files.
+- `/OpenAction`, `/AA`, `/Launch`, `/SubmitForm`, `/GoToR` pointing at scripts/executables/external hosts = malicious until proven otherwise.
+For manual inspection of a specific object: `pdf-parser -o <N> -f -d /tmp/out.bin "$F"`.
+
+### Step 3 — Content & context check
+- Metadata (Producer/Creator/dates/Author) is already in `scan.sh` output.
+- Re-run with `--text` to extract visible text and confirm it matches the filename's claimed topic:
+  `wsl.exe -e bash "$SKILL/scan.sh" --text "<file>"`
+- Validate every `/URI`: domain must match the purported sender organization; flag lookalike domains, IP literals, URL shorteners, non-HTTPS credential pages.
+- Even for a technically clean file, warn about social-engineering context (RfQ/invoice/shipping lures are common BEC bait) if the document solicits replies, payments, or credentials.
+- Clean up: `wsl.exe -e bash -c "rm -rf /tmp/pdfscan"` after reporting.
+
+## Verdict report format
+
+Per file, output a Markdown section with:
+1. Table: size/version/pages, MD5, SHA256, producer/creator/dates.
+2. Active-content findings with per-indicator explanation (including why flagged items are benign, if so).
+3. URI list with legitimacy assessment.
+4. Content summary vs. filename claim.
+5. Verdict: **恶意 / 可疑 / 低风险（未发现恶意迹象）** + recommendation (VirusTotal hash lookup, sandboxed viewer, sender verification).
+
+Match the user's language (default Chinese if the user writes Chinese).

--- a/skills/bundles/wsl-pdf-scan/scripts/deep_dive.sh
+++ b/skills/bundles/wsl-pdf-scan/scripts/deep_dive.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Deep-dive flagged PDF objects: dump decoded streams + grep threat patterns.
+# Usage: deep_dive.sh <file> <objnum> [objnum...]
+#        deep_dive.sh <file> --auto     (auto-locate JS/XFA/EmbeddedFile objects via pdf-parser)
+RAW="$1"; shift
+case "$RAW" in
+  [A-Za-z]:*) F="$(wslpath -u "$RAW")" ;;
+  *)          F="$RAW" ;;
+esac
+[ ! -f "$F" ] && { echo "[!] file not found: $F"; exit 1; }
+command -v pdf-parser >/dev/null 2>&1 || { echo "[!] pdf-parser not installed"; exit 1; }
+
+OUT=/tmp/pdfscan
+rm -rf "$OUT"; mkdir -p "$OUT"
+
+OBJS="$*"
+if [ "$1" = "--auto" ]; then
+  echo "---- locating objects flagged for /JS /JavaScript /XFA /EmbeddedFile /OpenAction /AA /Launch ----"
+  STATS=$(pdf-parser -a "$F" 2>/dev/null)
+  echo "$STATS" | grep -E '^\s*/(JS|JavaScript|XFA|EmbeddedFile|OpenAction|AA|Launch|RichMedia|SubmitForm)\b'
+  OBJS=$(echo "$STATS" | grep -E '^\s*/(JS|JavaScript|XFA|EmbeddedFile|OpenAction|AA|Launch|RichMedia|SubmitForm)\b' \
+        | sed 's/.*: //' | tr ',' '\n' | tr -d ' ' | sort -un | tr '\n' ' ')
+  echo "objects to dump: $OBJS"
+fi
+
+for o in $OBJS; do
+  echo "===== obj $o ====="
+  # show the object dict first
+  DICT=$(pdf-parser -o "$o" "$F" 2>/dev/null | grep -v '^This program\|^Should you')
+  echo "$DICT"
+  # follow one level of references (JS action dicts point at separate stream objects)
+  REFS="$REFS $(echo "$DICT" | grep '^ Referencing:' | grep -oE '[0-9]+ 0 R' | awk '{print $1}')"
+  # dump decoded stream if present
+  pdf-parser -o "$o" -f -d "$OUT/obj_$o.bin" "$F" >/dev/null 2>&1
+  if [ -s "$OUT/obj_$o.bin" ]; then
+    echo "--- decoded stream ($(stat -c%s "$OUT/obj_$o.bin") bytes), first 2000 bytes: ---"
+    head -c 2000 "$OUT/obj_$o.bin"; echo
+  fi
+  echo
+done
+
+# second pass: dump referenced objects not already covered
+for r in $(echo $REFS | tr ' ' '\n' | sort -un); do
+  case " $OBJS " in *" $r "*) continue ;; esac
+  echo "===== referenced obj $r ====="
+  pdf-parser -o "$r" -f -d "$OUT/obj_$r.bin" "$F" >/dev/null 2>&1
+  if [ -s "$OUT/obj_$r.bin" ]; then
+    echo "--- decoded stream ($(stat -c%s "$OUT/obj_$r.bin") bytes), first 2000 bytes: ---"
+    head -c 2000 "$OUT/obj_$r.bin"; echo
+  else
+    pdf-parser -o "$r" "$F" 2>/dev/null | grep -v '^This program\|^Should you'
+  fi
+  echo
+done
+
+echo "===== threat-pattern grep across all dumped streams ====="
+grep -aioE 'https?://[^"< )]+|<script[^>]*>|app\.launchURL|util\.printf|unescape *\(|fromCharCode|eval *\(|\.exe\b|cmd\.exe|powershell|\\\\u[0-9a-f]{4}%?' \
+  "$OUT"/*.bin 2>/dev/null | sort | uniq -c | sort -rn | head -50 \
+  || echo "(no dumps or no matches)"
+echo
+echo "[i] dumps kept in $OUT for manual review; delete with: rm -rf $OUT"
+exit 0

--- a/skills/bundles/wsl-pdf-scan/scripts/pdf_triage.py
+++ b/skills/bundles/wsl-pdf-scan/scripts/pdf_triage.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Static PDF malware triage - stdlib only (zlib).
+
+Usage:
+    python3 pdf_triage.py <file.pdf>          # full triage
+    python3 pdf_triage.py <file.pdf> --text   # also dump extracted page text
+"""
+import re
+import sys
+import zlib
+
+path = sys.argv[1]
+want_text = '--text' in sys.argv[2:]
+data = open(path, 'rb').read()
+
+print(f"[i] size={len(data)} bytes, header={data[:16]!r}")
+if not data.startswith(b'%PDF-'):
+    print("[!] NOT a PDF header - possible disguised file type")
+
+# 1. Decompress every FlateDecode stream and rescan keywords inside
+stream_re = re.compile(rb'stream\r?\n(.*?)\r?\nendstream', re.S)
+streams = stream_re.findall(data)
+print(f"[i] stream objects found: {len(streams)}")
+
+decompressed = b''
+fail = 0
+for s in streams:
+    try:
+        decompressed += zlib.decompress(s)
+    except Exception:
+        fail += 1
+print(f"[i] streams decompressed OK: {len(streams) - fail}, failed/non-flate: {fail}")
+
+keywords = [b'/JavaScript', b'/JS', b'/OpenAction', b'/AA', b'/Launch',
+            b'/EmbeddedFile', b'/RichMedia', b'/XFA', b'/SubmitForm',
+            b'/GoToR', b'/GoToE', b'/URI', b'cmd.exe', b'powershell',
+            b'unescape(', b'String.fromCharCode', b'.exe']
+print("\n[keyword scan: raw file + decompressed streams]")
+for kw in keywords:
+    n_raw = data.count(kw)
+    n_dec = decompressed.count(kw)
+    if n_raw or n_dec:
+        print(f"  {kw.decode(errors='replace')}: raw={n_raw} decompressed={n_dec}")
+
+# 2. Extract all URIs (raw + decompressed, literal + hex-encoded)
+uri_re = re.compile(rb'/URI\s*\(([^)]*)\)')
+uris = set(uri_re.findall(data)) | set(uri_re.findall(decompressed))
+print(f"\n[URIs found: {len(uris)}]")
+for u in sorted(uris):
+    print("  ", u.decode(errors='replace'))
+urihex_re = re.compile(rb'/URI\s*<([0-9A-Fa-f\s]+)>')
+for m in set(urihex_re.findall(data)) | set(urihex_re.findall(decompressed)):
+    print("   (hex)", bytes.fromhex(m.decode().replace(' ', '')).decode(errors='replace'))
+
+# 3. Object inventory
+obj_re = re.compile(rb'(\d+)\s+(\d+)\s+obj(.*?)endobj', re.S)
+types = {}
+for num, gen, body in obj_re.findall(data):
+    m = re.search(rb'/Type\s*/(\w+)', body)
+    t = m.group(1).decode() if m else '(none)'
+    types[t] = types.get(t, 0) + 1
+print(f"\n[object types] {types}")
+
+# 4. Suspicious dict keys hidden inside ObjStm/decompressed content
+susp_re = re.compile(rb'/(OpenAction|AA|Launch|EmbeddedFiles?|Filespec|JavaScript|JS)\b')
+hits = sorted(set(h.decode() for h in susp_re.findall(decompressed)))
+print(f"[suspicious dict keys in ObjStm/decompressed]: {hits or 'none'}")
+
+# 5. Metadata
+print("\n[metadata]")
+for kw in (b'/Producer', b'/Creator', b'/CreationDate', b'/ModDate', b'/Author', b'/Title'):
+    for src in (data, decompressed):
+        m = re.search(re.escape(kw) + rb'\s*\(([^)]{0,120})\)', src)
+        if m:
+            print(f"  {kw.decode()}: {m.group(1).decode(errors='replace')}")
+            break
+
+# 6. Data after last %%EOF (smuggling trick)
+eof = data.rfind(b'%%EOF')
+trailing = len(data) - (eof + 5) if eof >= 0 else -1
+print(f"\n[trailing bytes after last %%EOF]: {trailing}")
+
+# 7. Embedded executable signatures
+for sig, name in [(b'MZ\x90', 'PE exe'), (b'PK\x03\x04', 'ZIP/OOXML'),
+                  (b'\x7fELF', 'ELF'), (b'#!/', 'script shebang')]:
+    for label, src in (('raw', data), ('decompressed', decompressed)):
+        idx = src.find(sig)
+        if idx > 1024:  # ignore header area
+            print(f"[!] {name} signature in {label} at offset {idx}")
+
+# 8. Optional page text extraction (Tj / TJ operators)
+if want_text:
+    parts = re.findall(rb'\((.*?)(?<!\\)\)\s*Tj', decompressed)
+    parts += [m for arr in re.findall(rb'\[(.*?)\]\s*TJ', decompressed, re.S)
+              for m in re.findall(rb'\((.*?)(?<!\\)\)', arr)]
+    print("\n[extracted text, first 2500 chars]")
+    print(b' '.join(parts).decode('latin-1', errors='replace')[:2500])

--- a/skills/bundles/wsl-pdf-scan/scripts/scan.sh
+++ b/skills/bundles/wsl-pdf-scan/scripts/scan.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# One-shot PDF malware triage. Accepts Windows (D:\x\y.pdf) or WSL (/mnt/d/x/y.pdf) paths.
+# Usage: scan.sh [--text] <file> [<file>...]
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEXT_FLAG=""
+[ "$1" = "--text" ] && { TEXT_FLAG="--text"; shift; }
+[ $# -eq 0 ] && { echo "Usage: scan.sh [--text] <file> [<file>...]"; exit 1; }
+
+for RAW in "$@"; do
+  case "$RAW" in
+    [A-Za-z]:*) F="$(wslpath -u "$RAW")" ;;
+    *)          F="$RAW" ;;
+  esac
+  echo "======================================================================"
+  echo "== $F"
+  if [ ! -f "$F" ]; then echo "[!] file not found"; continue; fi
+
+  echo "---- fingerprint ----"
+  ls -la "$F"
+  file "$F"
+  md5sum "$F"
+  sha256sum "$F"
+
+  echo "---- pdfid ----"
+  if command -v pdfid >/dev/null 2>&1; then
+    pdfid "$F"
+  else
+    echo "(pdfid not installed - relying on python triage below)"
+  fi
+
+  echo "---- python triage ----"
+  python3 "$SCRIPT_DIR/pdf_triage.py" "$F" $TEXT_FLAG
+  echo
+done
+exit 0

--- a/web/src/components/WorkspaceSidebar.test.tsx
+++ b/web/src/components/WorkspaceSidebar.test.tsx
@@ -116,7 +116,7 @@ describe("WorkspaceSidebar", () => {
 
     const nonProject = await screen.findByRole("region", { name: /non-project/i });
     expect(await within(nonProject).findByRole("link", { name: /failed session.*runtime failure/i })).toBeInTheDocument();
-    const projectRegion = screen.getByRole("region", { name: /open project project dashboard/i });
+    const projectRegion = await screen.findByRole("region", { name: /open project project dashboard/i });
     await user.click(within(projectRegion).getByRole("button", { name: /expand project/i }));
     expect(await within(projectRegion).findByRole("link", { name: /failed task.*runtime failure/i })).toBeInTheDocument();
   });
@@ -145,6 +145,11 @@ describe("WorkspaceSidebar", () => {
       </ThemeProvider>,
     );
     await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/sessions/session-archived", expect.anything()));
+    // Wait until the sessions data has rendered, so the negative assertion
+    // below passes because the archived Session is excluded, not because the
+    // list has not loaded yet.
+    const nonProject = await screen.findByRole("region", { name: /non-project/i });
+    await within(nonProject).findByText(/no open sessions/i);
     expect(screen.queryByRole("link", { name: /archived session/i })).not.toBeInTheDocument();
   });
 
@@ -312,7 +317,7 @@ describe("WorkspaceSidebar", () => {
       "/projects/project-1",
     );
 
-    const sessionActions = within(nonProject).getByRole("button", { name: /more actions for session one/i });
+    const sessionActions = await within(nonProject).findByRole("button", { name: /more actions for session one/i });
     await user.click(sessionActions);
     const menu = within(nonProject).getByRole("menu", { name: /session one actions/i });
     expect(within(menu).getByRole("menuitem", { name: /rename/i })).toBeInTheDocument();

--- a/web/src/components/WorkspaceSidebar.test.tsx
+++ b/web/src/components/WorkspaceSidebar.test.tsx
@@ -115,7 +115,7 @@ describe("WorkspaceSidebar", () => {
     );
 
     const nonProject = await screen.findByRole("region", { name: /non-project/i });
-    expect(within(nonProject).getByRole("link", { name: /failed session.*runtime failure/i })).toBeInTheDocument();
+    expect(await within(nonProject).findByRole("link", { name: /failed session.*runtime failure/i })).toBeInTheDocument();
     const projectRegion = screen.getByRole("region", { name: /open project project dashboard/i });
     await user.click(within(projectRegion).getByRole("button", { name: /expand project/i }));
     expect(await within(projectRegion).findByRole("link", { name: /failed task.*runtime failure/i })).toBeInTheDocument();
@@ -192,7 +192,7 @@ describe("WorkspaceSidebar", () => {
     expect(screen.getByRole("link", { name: /non-project/i })).toHaveAttribute("href", "/sessions");
     expect(screen.getByRole("link", { name: /projects/i })).toHaveAttribute("href", "/");
     expect(screen.getByRole("link", { name: /new project/i })).toHaveAttribute("href", "/?new=1");
-    expect(screen.getByRole("link", { name: /active project project dashboard/i })).toHaveAttribute(
+    expect(await screen.findByRole("link", { name: /active project project dashboard/i })).toHaveAttribute(
       "href",
       "/projects/project-active",
     );
@@ -385,7 +385,7 @@ describe("WorkspaceSidebar", () => {
     );
 
     const nonProject = await screen.findByRole("region", { name: /non-project/i });
-    const sessionLinks = within(nonProject).getAllByRole("link", { name: /session conversation/i });
+    const sessionLinks = await within(nonProject).findAllByRole("link", { name: /session conversation/i });
     expect(sessionLinks.map((link) => link.textContent?.trim())).toEqual([
       "Busy session session conversation",
       "Idle session 1 session conversation",
@@ -452,9 +452,9 @@ describe("WorkspaceSidebar", () => {
     );
 
     const nonProject = await screen.findByRole("region", { name: /non-project/i });
-    expect(within(nonProject).getByText(/no open sessions/i)).toBeInTheDocument();
+    expect(await within(nonProject).findByText(/no open sessions/i)).toBeInTheDocument();
     const projects = screen.getByRole("region", { name: /projects/i });
-    expect(within(projects).getByRole("alert")).toHaveTextContent("projects unavailable");
+    expect(await within(projects).findByRole("alert")).toHaveTextContent("projects unavailable");
     expect(within(nonProject).queryByRole("alert")).not.toBeInTheDocument();
   });
 

--- a/web/src/pages/BlackboardPage.test.tsx
+++ b/web/src/pages/BlackboardPage.test.tsx
@@ -459,7 +459,7 @@ describe("Blackboard UI v2 workflows", () => {
       expect.stringContaining("/reason-task-proposals/reason-proposal-1/approve"),
       expect.objectContaining({ method: "POST" }),
     ));
-    expect(within(region).queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
+    await waitFor(() => expect(within(region).queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument());
   });
 
   it("keeps dangling anomaly links actionable and wraps long keys", async () => {

--- a/web/src/pages/RuntimeProfilesPage.test.tsx
+++ b/web/src/pages/RuntimeProfilesPage.test.tsx
@@ -320,7 +320,7 @@ describe("RuntimeProfilesPage", () => {
     expect(screen.queryByPlaceholderText("https://api.example.test/v1")).not.toBeInTheDocument();
     expect(screen.getByText("Model override")).toBeInTheDocument();
 
-    const providerSelect = screen.getByDisplayValue("Mimo (MIMO_API_KEY) (incompatible)");
+    const providerSelect = await screen.findByDisplayValue("Mimo (MIMO_API_KEY) (incompatible)");
     expect(providerSelect).toBeInTheDocument();
     for (const option of Array.from(providerSelect.querySelectorAll("option")).map((node) => node.textContent)) {
       expect(option).not.toMatch(/Anthropic \(ANTHROPIC_API_KEY\)$/);
@@ -579,7 +579,7 @@ describe("RuntimeProfilesPage", () => {
     await userEvent.click(await screen.findByRole("button", { name: "Promote to preset" }));
 
     await waitFor(() => expect(promoted).toBe(true));
-    expect(screen.queryByRole("button", { name: "Promote to preset" })).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Promote to preset" })).not.toBeInTheDocument());
   });
 
   it("keeps long Codex generated config preview from widening the page", async () => {

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -539,12 +539,16 @@ describe("SessionDetailPage Runtime Owner History Window (#202)", () => {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
+    // The second Session's history stays pending until the test releases it,
+    // so the ordering assertion below is deterministic instead of racing a timer.
+    let releaseSessionBHistory!: () => void;
+    const sessionBHistory = new Promise<void>((resolve) => {
+      releaseSessionBHistory = resolve;
+    });
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
-      // The second Session's history resolves slowly so the first Session's
-      // rows must disappear before the new ones render.
       if (url.includes("sessions/session-b/") && (url.includes("/timeline") || url.includes("/transcript"))) {
-        await new Promise((resolve) => setTimeout(resolve, 80));
+        await sessionBHistory;
       }
       if (url.includes("sessions/session-a/transcript")) {
         return json({ session_id: "session-a", entries: [{ id: "a-1", seq: 1, continuation: 1, kind: "message", role: "assistant", text: "Session A content", created_at: "2026-08-01T01:00:00Z" }], cursor: 1 });
@@ -584,6 +588,7 @@ describe("SessionDetailPage Runtime Owner History Window (#202)", () => {
       expect(screen.queryByText("Session A content")).not.toBeInTheDocument();
     });
     expect(screen.queryByText("Session B content")).not.toBeInTheDocument();
+    releaseSessionBHistory();
     expect(await screen.findByText("Session B content")).toBeInTheDocument();
     expect(screen.queryByText("Session A content")).not.toBeInTheDocument();
   });

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -103,7 +103,7 @@ describe("SessionDetailPage", () => {
     expect(screen.getByTestId("task-composer")).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Session message" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Continuation model provider" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "MiMo" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "MiMo" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Conversation" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "Timeline" })).toHaveAttribute("aria-pressed", "false");
   });
@@ -239,6 +239,7 @@ describe("SessionDetailPage", () => {
     expect(screen.getAllByTestId("transcript-row")).toHaveLength(2);
     expect(screen.getAllByTestId("transcript-row")[1]).toHaveTextContent("Runtime ready");
     expect(screen.getByRole("button", { name: "Queue message" })).toBeInTheDocument();
+    await screen.findByRole("option", { name: "MiMo" });
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model provider" }), "mimo");
     expect(screen.getByRole("combobox", { name: "Continuation model" })).toHaveValue("mimo-v2");
     const composer = screen.getByRole("textbox", { name: "Session message" });

--- a/web/src/pages/SessionHomePage.test.tsx
+++ b/web/src/pages/SessionHomePage.test.tsx
@@ -82,6 +82,8 @@ describe("SessionHomePage", () => {
 
     renderPage();
 
+    // Launch-controls data lands after first paint; anchor on a fetched option.
+    await screen.findByRole("option", { name: "MiMo" });
     expect(await screen.findByLabelText("Runtime")).toBeInTheDocument();
     expect(screen.getByLabelText("Model provider")).toBeInTheDocument();
     expect(screen.getByLabelText("Model")).toBeInTheDocument();
@@ -173,7 +175,7 @@ describe("SessionHomePage", () => {
     renderPage(["/sessions/archived"], "archived");
 
     expect(await screen.findByRole("heading", { level: 1, name: "Archived Sessions" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /open archived notes session/i })).toHaveAttribute("href", "/sessions/session-archived");
+    expect(await screen.findByRole("link", { name: /open archived notes session/i })).toHaveAttribute("href", "/sessions/session-archived");
     expect(screen.getByRole("button", { name: /restore archived notes/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /delete archived notes/i })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /new session/i })).not.toBeInTheDocument();
@@ -189,6 +191,7 @@ describe("SessionHomePage", () => {
 
     renderPage();
 
+    await screen.findByRole("option", { name: "MiMo" });
     const input = await screen.findByRole("textbox", { name: /initial input/i });
     await user.type(input, "Check the exposed service");
     await user.click(screen.getByRole("button", { name: /create session/i }));
@@ -241,6 +244,7 @@ describe("SessionHomePage", () => {
 
     renderPage();
 
+    await screen.findByRole("option", { name: "MiMo" });
     await user.type(await screen.findByRole("textbox", { name: /initial input/i }), "Inspect the standalone target");
     await user.selectOptions(screen.getByRole("combobox", { name: /blackboard conclusions/i }), "assisted");
     await user.click(screen.getByRole("button", { name: /create session/i }));
@@ -312,6 +316,7 @@ describe("SessionHomePage", () => {
     const user = userEvent.setup();
     render(<RouterProvider router={router} />);
 
+    await screen.findByRole("option", { name: "MiMo" });
     await user.type(await screen.findByRole("textbox", { name: /initial input/i }), "Check the exposed service");
     await user.click(screen.getByRole("button", { name: /create session/i }));
 

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -1879,12 +1879,16 @@ describe("TaskDetailPage Runtime Owner History Window (#202)", () => {
     const user = userEvent.setup();
     const scrollIntoView = vi.fn();
     Object.defineProperty(Element.prototype, "scrollIntoView", { value: scrollIntoView, configurable: true });
+    // The second owner's history stays pending until the test releases it, so
+    // the ordering assertion below is deterministic instead of racing a timer.
+    let releaseSecondOwnerHistory!: () => void;
+    const secondOwnerHistory = new Promise<void>((resolve) => {
+      releaseSecondOwnerHistory = resolve;
+    });
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
-      // The second owner's history resolves slowly so the old owner's rows
-      // must disappear before the new ones can render.
       if (url.includes("tasks/task-2/") && (url.includes("/timeline") || url.includes("/transcript"))) {
-        await new Promise((resolve) => setTimeout(resolve, 80));
+        await secondOwnerHistory;
       }
       if (url.includes("tasks/task-1/timeline")) {
         return json({ task_id: "task-1", items: [{ seq: 1, type: "text", content: "First task timeline", created_at: "2026-01-01T00:00:00Z" }], cursor: 1 });
@@ -1928,6 +1932,7 @@ describe("TaskDetailPage Runtime Owner History Window (#202)", () => {
     });
     expect(screen.queryByText("First task timeline")).not.toBeInTheDocument();
     expect(screen.queryByText("Second task content")).not.toBeInTheDocument();
+    releaseSecondOwnerHistory();
     expect(await screen.findByText("Second task content")).toBeInTheDocument();
     // Nothing from the first owner leaks into the second owner's workspace.
     expect(screen.queryByText("First task content")).not.toBeInTheDocument();

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -759,7 +759,7 @@ describe("TaskDetailPage", () => {
     expect(screen.getByRole("button", { name: /Resume and send/ })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Continuation model provider" })).toHaveClass("focus-visible:ring-2");
     expect(screen.getByRole("combobox", { name: "Continuation model" })).toHaveClass("focus-visible:ring-2");
-    expect(screen.getByRole("option", { name: "MiMo" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "MiMo" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "Anthropic" })).not.toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Use Codex/ })).not.toBeInTheDocument();
   });
@@ -823,7 +823,9 @@ describe("TaskDetailPage", () => {
     renderPage();
 
     await screen.findByText("Conversation should be hidden by default");
+    await screen.findByRole("option", { name: "MiMo" });
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model provider" }), "mimo");
+    await screen.findByRole("option", { name: "mimo-v2-pro" });
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model" }), "mimo-v2-pro");
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation reasoning effort" }), "xhigh");
     await user.type(screen.getByPlaceholderText("Focus on admin.example.com next…"), "continue with mimo");
@@ -1262,6 +1264,7 @@ describe("TaskDetailPage", () => {
     renderPage();
 
     await screen.findByText("Conversation should be hidden by default");
+    await screen.findByRole("option", { name: "MiMo" });
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model provider" }), "mimo");
     await user.type(screen.getByPlaceholderText("Focus on admin.example.com next…"), "outside projected set");
     expect(screen.getByRole("button", { name: "Switch provider and resume" })).toBeEnabled();
@@ -1305,6 +1308,7 @@ describe("TaskDetailPage", () => {
     renderPage();
 
     await screen.findByText("Conversation should be hidden by default");
+    await screen.findByRole("option", { name: "MiMo" });
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model provider" }), "mimo");
     await user.type(screen.getByPlaceholderText("Focus on admin.example.com next…"), "bind a provider");
     expect(screen.getByRole("button", { name: "Switch provider and resume" })).toBeEnabled();

--- a/web/src/pages/TaskLaunchPage.test.tsx
+++ b/web/src/pages/TaskLaunchPage.test.tsx
@@ -121,6 +121,7 @@ describe("TaskLaunchPage", () => {
     expect(await screen.findByRole("heading", { name: /Launch Reason Task/i })).toBeInTheDocument();
     expect(screen.queryByLabelText("Task type")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Reason Task goal")).toHaveAttribute("readonly");
+    await waitFor(() => expect(screen.getByRole("button", { name: /Launch Reason Task/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /Launch Reason Task/i }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
@@ -213,6 +214,9 @@ describe("TaskLaunchPage", () => {
 
     renderPage();
 
+    // The launch form renders before its plugins/providers/profiles/project
+    // batch lands; an option from that batch is the readiness anchor.
+    await screen.findByRole("option", { name: "MiMo" });
     const taskType = await screen.findByLabelText("Task type");
     expect(taskType).toHaveValue("");
     await userEvent.selectOptions(taskType, "pentest");
@@ -296,7 +300,7 @@ describe("TaskLaunchPage", () => {
     expect(screen.getByLabelText("Model provider")).toBeInTheDocument();
     expect(screen.getByLabelText("Model")).toBeInTheDocument();
     expect(screen.queryByLabelText("Runtime profile")).not.toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "MiMo" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "MiMo" })).toBeInTheDocument();
   });
 
   it("keeps interactive launch available when assisted conclusions are unsupported", async () => {
@@ -342,7 +346,7 @@ describe("TaskLaunchPage", () => {
     expect(screen.getByText(/does not expose the complete persistent Turn, normalized Tool\/Turn event, and closed AttemptResult contract/i)).toBeInTheDocument();
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("Task goal"), "Run recon");
-    expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled();
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
   });
 
   it("shows enabled skills before launch for preset path", async () => {
@@ -949,6 +953,7 @@ describe("TaskLaunchPage", () => {
 
     await selectPentestTaskType();
     await userEvent.type(await screen.findByLabelText("Task goal"), "Run with extension");
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     expect(await screen.findByText("Runtime extensions")).toBeInTheDocument();
@@ -1066,6 +1071,7 @@ describe("TaskLaunchPage", () => {
     renderPage();
     await selectPentestTaskType();
     await userEvent.type(await screen.findByLabelText("Task goal"), "Probe sandbox env");
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     expect(await screen.findByText("Container environment")).toBeInTheDocument();
@@ -1295,6 +1301,7 @@ describe("TaskLaunchPage", () => {
     renderPage();
 
     const modelSelect = await screen.findByLabelText("Model");
+    await screen.findByRole("option", { name: "mimo-v2-pro" });
     await userEvent.selectOptions(modelSelect, "mimo-v2-pro");
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("Task goal"), "Run recon");
@@ -1412,6 +1419,7 @@ describe("TaskLaunchPage", () => {
     await userEvent.selectOptions(await screen.findByLabelText("Docker network"), "host_proxy_only");
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("Task goal"), "Run recon");
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     await waitFor(() => {
@@ -1535,6 +1543,7 @@ describe("TaskLaunchPage", () => {
     await userEvent.click(await screen.findByRole("checkbox", { name: /vpn tun/i }));
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("Task goal"), "Connect OpenVPN");
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     await waitFor(() => {
@@ -1610,6 +1619,7 @@ describe("TaskLaunchPage", () => {
     expect(screen.getByLabelText("Podman network")).toBeInTheDocument();
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("Task goal"), "Use podman");
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/projects/project-1/tasks"), expect.objectContaining({ method: "POST" }));
@@ -1724,6 +1734,7 @@ describe("TaskLaunchPage", () => {
     await userEvent.selectOptions(screen.getByLabelText("Runner"), "docker");
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("Task goal"), "Run recon");
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     await waitFor(() => {
@@ -1937,6 +1948,7 @@ describe("TaskLaunchPage", () => {
     await userEvent.upload(screen.getByLabelText("Attachments"), file);
     expect(screen.getByText("notes.txt")).toBeInTheDocument();
 
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     await waitFor(() => expect(createBody).toBeInstanceOf(FormData));


### PR DESCRIPTION
…iagnostic logs to runtime

- Runtime no longer projects PENTEST_AUTH_TOKEN, but instead uses a smaller one PENTEST_INTERFACE_TOKEN (Continuation Interface Grant) certification
- Added Redactor.RedactString to diagnose provider-bridge and Docker Output anonymization prevents credentials from being written to the operator log
- Extract the blackboard conclusion logic into the internal/owner/conclusion package and supplement it with testing
- CI adds web unit testing steps; Added dev-env.sh and WSL PDF scanning skill packs