### PR TITLE
refactor(daemon): close the Task/Session duplication ring

### DIFF
--- a/internal/daemon/blackboard_conclusion.go
+++ b/internal/daemon/blackboard_conclusion.go
@@ -95,30 +95,7 @@ func (server *Server) dispatchBlackboardConclusion(ctx context.Context, pending 
 	if !won {
 		return nil
 	}
-	return server.sendBlackboardConclusionTurn(ctx, receipt, concludeBlackboardDirective(snapshot.Revision))
-}
-
-func concludeBlackboardDirective(baseRevision int) string {
-	return fmt.Sprintf(`Stop security testing and perform only the Harness conclusion below.
-Return exactly one JSON object (no markdown fences, no prose) with this shape and base_revision %d:
-{"schema":"runtime-attempt-result/v1","base_revision":%d,"attempt":{"key":"attempt/example","create":true,"summary":"One sentence outcome of the completed work.","outcome":"inconclusive"},"tested_targets":[{"key":"objective/example","create_objective":{"objective":"What was tested."}}],"produced_targets":[]}
-Conclude only the current source Work Turn. Do not restate an older terminal Attempt.
-Use only existing Blackboard Keys and versions already present in the conversation from the completed source Work Turn. Copy them exactly; never change punctuation or switch between ':' and '/'. If an exact existing key and version are not already known, do not guess or look them up. Create a new descriptive slash-style Attempt or Objective key and use an inconclusive, failed, or blocked outcome without produced targets. A new key must not be a punctuation alias of a current or historical key.
-Replace example keys and summaries with this Turn's real semantic targets.
-Rules: outcome must be one of succeeded, failed, blocked, or inconclusive. Use inconclusive/failed/blocked when the Turn did not create durable produced graph targets. succeeded requires at least one produced_targets entry that references an already-existing Blackboard key with expected_version; do not invent produced_targets on an empty board.
-Describe one Attempt and at least one tested target. Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, finish the Task, or write the Blackboard directly.`, baseRevision, baseRevision)
-}
-
-func repairBlackboardDirective(baseRevision int, detail owner.ConclusionValidationDetail) string {
-	directive := fmt.Sprintf(`Your previous Blackboard conclusion result was invalid.
-Stop security testing and correct only that semantic result.
-Return exactly one JSON object (no markdown fences, no prose) with schema runtime-attempt-result/v1 and base_revision %d.
-If the board has no existing produced targets, use outcome "inconclusive" (or failed/blocked) with produced_targets [].
-Example:
-{"schema":"runtime-attempt-result/v1","base_revision":%d,"attempt":{"key":"attempt/example","create":true,"summary":"One sentence outcome of the completed work.","outcome":"inconclusive"},"tested_targets":[{"key":"objective/example","create_objective":{"objective":"What was tested."}}],"produced_targets":[]}
-Conclude only the current source Work Turn. Use only existing Blackboard Keys and versions already present in the conversation. Copy them exactly; never change punctuation or switch between ':' and '/'. If an exact existing key and version are not already known, do not guess or look them up. Create a new descriptive slash-style Attempt or Objective key and use an inconclusive, failed, or blocked outcome without produced targets. Do not restate an older terminal Attempt.
-Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, finish the Task, or write the Blackboard directly.`, baseRevision, baseRevision)
-	return conclusionValidationRepairLine(detail) + "\n" + directive
+	return server.sendBlackboardConclusionTurn(ctx, receipt, concludeDirective(taskConclusionDirectiveProfile, snapshot.Revision))
 }
 
 // conclusionValidationRepairLine renders the bounded public reason for one
@@ -136,13 +113,6 @@ func conclusionValidationRepairLine(detail owner.ConclusionValidationDetail) str
 		line += ". Expected: " + detail.Expected
 	}
 	return line + "."
-}
-
-func regenerateBlackboardDirective(baseRevision int) string {
-	return fmt.Sprintf(`The Project Blackboard changed after your previous semantic result was produced.
-Regenerate the semantic result against base_revision %d. Use only exact Blackboard Keys and versions already present in the conversation. If a required current version is not already known, create new descriptive slash-style Attempt and Objective keys and use an inconclusive, failed, or blocked outcome with no produced targets. Do not guess or look up current state.
-Return exactly one JSON object with schema runtime-attempt-result/v1.
-Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, finish the Task, or write the Blackboard directly.`, baseRevision)
 }
 
 func (server *Server) blackboardConclusionCoordinator(taskID string) runtime.AssistedConclusionCoordinator {
@@ -220,7 +190,7 @@ func (server *Server) dispatchBlackboardConclusionRepair(ctx context.Context, re
 	if receipt.BaseRevision == nil {
 		return fmt.Errorf("Blackboard conclusion repair has no base revision")
 	}
-	return server.sendBlackboardConclusionTurn(ctx, receipt, repairBlackboardDirective(*receipt.BaseRevision, conclusionDetailFromTaskReceipt(receipt)))
+	return server.sendBlackboardConclusionTurn(ctx, receipt, repairDirective(taskConclusionDirectiveProfile, *receipt.BaseRevision, conclusionDetailFromTaskReceipt(receipt)))
 }
 
 func conclusionDetailFromTaskReceipt(receipt task.BlackboardConclusionReceipt) owner.ConclusionValidationDetail {
@@ -258,35 +228,26 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 		writeError(response, http.StatusNotFound, "task not found")
 		return
 	}
-	idempotencyKey := strings.TrimSpace(request.Header.Get("Idempotency-Key"))
-	if idempotencyKey == "" {
-		writeError(response, http.StatusBadRequest, "Idempotency-Key is required")
-		return
-	}
-	latest, err := server.tasks.LatestBlackboardConclusion(taskID)
-	if err != nil || latest == nil {
-		writeError(response, http.StatusNotFound, "task not found")
-		return
-	}
-	if latest.RecoveryReason == string(task.ConclusionRecoveryAcceptanceAmbiguous) {
-		// An acceptance-ambiguous provider delivery is never resent: a generic
-		// Retry could duplicate a request the provider already accepted.
-		writeError(response, http.StatusConflict, "Blackboard conclusion cannot be retried after an acceptance-ambiguous delivery")
-		return
-	}
-	retried, won, err := server.tasks.RetryLatestBlackboardConclusion(taskID, idempotencyKey, time.Now().UTC())
-	if err != nil {
-		if errors.Is(err, task.ErrBlackboardConclusionRetryCooldown) {
-			writeError(response, http.StatusConflict, "Blackboard conclusion retry is not yet available")
-			return
-		}
-		writeError(response, http.StatusConflict, "Blackboard conclusion cannot be retried")
-		return
-	}
-	if won {
-		if retried.InternalState == task.BlackboardConclusionReceiptPending {
-			server.scheduleBlackboardConclusionDispatch(retried)
-		} else {
+	var retried task.BlackboardConclusionReceipt
+	server.serveBlackboardConclusionRetry(response, request, conclusionRetrySpec{
+		latest: func() (string, bool, error) {
+			latest, err := server.tasks.LatestBlackboardConclusion(taskID)
+			if err != nil || latest == nil {
+				return "", false, err
+			}
+			return latest.RecoveryReason, true, nil
+		},
+		retry: func(idempotencyKey string) (bool, bool, error) {
+			var won bool
+			var err error
+			retried, won, err = server.tasks.RetryLatestBlackboardConclusion(taskID, idempotencyKey, time.Now().UTC())
+			if err != nil {
+				return false, false, err
+			}
+			return won, retried.InternalState == task.BlackboardConclusionReceiptPending, nil
+		},
+		dispatchPending: func() { server.scheduleBlackboardConclusionDispatch(retried) },
+		dispatchRepair: func() {
 			queued := server.enqueueProviderTaskControl(taskID, func(ctx context.Context) {
 				if err := server.dispatchBlackboardConclusionRepair(ctx, retried); err != nil {
 					server.recoverBlackboardConclusionDispatchFailure(retried, err)
@@ -295,18 +256,12 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 			if !queued {
 				server.recoverBlackboardConclusionDispatchFailure(retried, fmt.Errorf("provider control queue is closed"))
 			}
-		}
-	}
-	detailed, err := server.taskDetail(taskID)
-	if err != nil {
-		writeTaskError(response, err)
-		return
-	}
-	status := http.StatusOK
-	if won {
-		status = http.StatusAccepted
-	}
-	writeJSON(response, status, detailed)
+		},
+		detail: func() (any, error) { return server.taskDetail(taskID) },
+		writeOwnerError: func(response http.ResponseWriter, err error) {
+			writeTaskError(response, err)
+		},
+	})
 }
 
 func (server *Server) recoverBlackboardConclusionDispatchFailure(receipt task.BlackboardConclusionReceipt, cause error) {
@@ -359,15 +314,15 @@ func (server *Server) scheduleRecoveredConclusionDispatch(view task.BlackboardCo
 }
 
 func (server *Server) dispatchRecoveredConclusionDispatch(ctx context.Context, view task.BlackboardConclusionReceipt) error {
-	directive := concludeBlackboardDirective(pointerValue(view.BaseRevision))
+	directive := concludeDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	switch view.InternalState {
 	case task.BlackboardConclusionReceiptRepairDispatchRequested:
-		directive = repairBlackboardDirective(pointerValue(view.BaseRevision), conclusionDetailFromTaskReceipt(view))
+		directive = repairDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromTaskReceipt(view))
 	case task.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
-		directive = regenerateBlackboardDirective(pointerValue(view.BaseRevision))
+		directive = regenerateDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	default:
 		if view.ExplicitRetryCount > 0 {
-			directive = repairBlackboardDirective(pointerValue(view.BaseRevision), conclusionDetailFromTaskReceipt(view))
+			directive = repairDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromTaskReceipt(view))
 		}
 	}
 	return server.sendBlackboardConclusionTurn(ctx, view, directive)
@@ -624,7 +579,7 @@ func (server *Server) dispatchBlackboardConclusionVersionRegeneration(ctx contex
 	if receipt.BaseRevision == nil {
 		return fmt.Errorf("Blackboard conclusion regeneration has no base revision")
 	}
-	return server.sendBlackboardConclusionTurn(ctx, receipt, regenerateBlackboardDirective(*receipt.BaseRevision))
+	return server.sendBlackboardConclusionTurn(ctx, receipt, regenerateDirective(taskConclusionDirectiveProfile, *receipt.BaseRevision))
 }
 
 func (server *Server) sendBlackboardConclusionTurn(ctx context.Context, receipt task.BlackboardConclusionReceipt, directive string) error {

--- a/internal/daemon/blackboard_conclusion_recovery.go
+++ b/internal/daemon/blackboard_conclusion_recovery.go
@@ -148,9 +148,9 @@ func (server *Server) resumeLiveBlackboardConclusionObligation(ctx context.Conte
 				case task.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
 					return server.dispatchBlackboardConclusionVersionRegeneration(controlCtx, obligation)
 				default:
-					directive := concludeBlackboardDirective(baseRevision)
+					directive := concludeDirective(taskConclusionDirectiveProfile, baseRevision)
 					if explicitRetryCount > 0 {
-						directive = repairBlackboardDirective(baseRevision, conclusionDetailFromTaskReceipt(obligation))
+						directive = repairDirective(taskConclusionDirectiveProfile, baseRevision, conclusionDetailFromTaskReceipt(obligation))
 					}
 					return server.sendBlackboardConclusionTurn(controlCtx, obligation, directive)
 				}

--- a/internal/daemon/conclusion_directive_parity_test.go
+++ b/internal/daemon/conclusion_directive_parity_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"pentest/internal/owner"
+)
+
+// The Task and Session conclusion directives are one owner-neutral prompt with
+// owner-specific nouns. These tests hold both twins to the same semantic rules
+// so the prompts cannot drift apart again (ADR 0020).
+type directivePair struct {
+	name     string
+	conclude func(int) string
+	repair   func(int, owner.ConclusionValidationDetail) string
+	regen    func(int) string
+	board    string
+	finishes string
+}
+
+func directivePairs() []directivePair {
+	return []directivePair{
+		{
+			name: "task", conclude: func(rev int) string { return concludeDirective(taskConclusionDirectiveProfile, rev) },
+			repair: func(rev int, detail owner.ConclusionValidationDetail) string {
+				return repairDirective(taskConclusionDirectiveProfile, rev, detail)
+			},
+			regen: func(rev int) string { return regenerateDirective(taskConclusionDirectiveProfile, rev) },
+			board: "Blackboard", finishes: "finish the Task",
+		},
+		{
+			name: "session", conclude: func(rev int) string { return concludeDirective(sessionConclusionDirectiveProfile, rev) },
+			repair: func(rev int, detail owner.ConclusionValidationDetail) string {
+				return repairDirective(sessionConclusionDirectiveProfile, rev, detail)
+			},
+			regen: func(rev int) string { return regenerateDirective(sessionConclusionDirectiveProfile, rev) },
+			board: "Session Blackboard", finishes: "finish the Session",
+		},
+	}
+}
+
+func TestConcludeDirectivesShareAntiFabricationRules(t *testing.T) {
+	for _, pair := range directivePairs() {
+		directive := pair.conclude(7)
+		for _, rule := range []string{
+			"Use inconclusive/failed/blocked when the Turn did not create durable produced graph targets.",
+			"succeeded requires at least one produced_targets entry that references an already-existing " + pair.board + " key with expected_version",
+			"do not invent produced_targets on an empty board",
+			"Describe one Attempt and at least one tested target.",
+			"never change punctuation or switch between ':' and '/'",
+		} {
+			if !strings.Contains(directive, rule) {
+				t.Errorf("%s conclude directive lost shared rule: %q", pair.name, rule)
+			}
+		}
+		if !strings.Contains(directive, pair.finishes) {
+			t.Errorf("%s conclude directive lost owner finish clause %q", pair.name, pair.finishes)
+		}
+		if !strings.Contains(directive, "with this shape and base_revision 7") || !strings.Contains(directive, `"base_revision":7`) {
+			t.Errorf("%s conclude directive lost base_revision binding", pair.name)
+		}
+	}
+}
+
+func TestRepairDirectivesShareProducedTargetsFallbackAndExample(t *testing.T) {
+	detail := owner.ConclusionValidationDetail{Reason: "shape", FieldPath: "attempt", Expected: "object"}
+	for _, pair := range directivePairs() {
+		directive := pair.repair(9, detail)
+		for _, rule := range []string{
+			`If the board has no existing produced targets, use outcome "inconclusive" (or failed/blocked) with produced_targets [].`,
+			"Example:",
+			`{"schema":"runtime-attempt-result/v1","base_revision":9`,
+			"Validation: shape at attempt. Expected: object.",
+			"Copy them exactly; never change punctuation or switch between ':' and '/'",
+		} {
+			if !strings.Contains(directive, rule) {
+				t.Errorf("%s repair directive lost shared rule: %q", pair.name, rule)
+			}
+		}
+		if !strings.Contains(directive, pair.finishes) {
+			t.Errorf("%s repair directive lost owner finish clause %q", pair.name, pair.finishes)
+		}
+	}
+}
+
+func TestRegenerateDirectivesShareRules(t *testing.T) {
+	for _, pair := range directivePairs() {
+		directive := pair.regen(12)
+		for _, rule := range []string{
+			"Regenerate the semantic result against base_revision 12.",
+			"Use only exact " + pair.board + " Keys and versions already present in the conversation",
+			"use an inconclusive, failed, or blocked outcome with no produced targets",
+		} {
+			if !strings.Contains(directive, rule) {
+				t.Errorf("%s regenerate directive lost shared rule: %q", pair.name, rule)
+			}
+		}
+		if !strings.Contains(directive, pair.finishes) {
+			t.Errorf("%s regenerate directive lost owner finish clause %q", pair.name, pair.finishes)
+		}
+	}
+}

--- a/internal/daemon/conclusion_directives.go
+++ b/internal/daemon/conclusion_directives.go
@@ -1,0 +1,89 @@
+package daemon
+
+import (
+	"fmt"
+
+	"pentest/internal/owner"
+)
+
+// conclusionDirectiveProfile carries only the owner-specific wording that
+// separates a Task conclusion directive from a Session one. Every semantic
+// rule in the builders below is owner-neutral (ADR 0020): both owners enforce
+// identical shape, anti-fabrication, and regeneration rules, so the two
+// prompts cannot drift apart again.
+type conclusionDirectiveProfile struct {
+	// StopCommand opens the conclude directive, e.g. "Stop security testing".
+	StopCommand string
+	// RepairCommand opens the repair directive, e.g. "Stop exploratory work".
+	RepairCommand string
+	// BoardName names the owner's Blackboard, e.g. "Session Blackboard".
+	BoardName string
+	// FinishClause forbids closing the owner, e.g. "finish the Task".
+	FinishClause string
+	// WorkNoun names the completed source work in the conclude example,
+	// e.g. "Session work".
+	WorkNoun string
+	// ChangedLead opens the regeneration directive, e.g.
+	// "The Project Blackboard changed".
+	ChangedLead string
+}
+
+var taskConclusionDirectiveProfile = conclusionDirectiveProfile{
+	StopCommand:   "Stop security testing",
+	RepairCommand: "Stop security testing",
+	BoardName:     "Blackboard",
+	FinishClause:  "finish the Task",
+	WorkNoun:      "work",
+	ChangedLead:   "The Project Blackboard changed",
+}
+
+var sessionConclusionDirectiveProfile = conclusionDirectiveProfile{
+	StopCommand:   "Stop the Session's exploratory work",
+	RepairCommand: "Stop exploratory work",
+	BoardName:     "Session Blackboard",
+	FinishClause:  "finish the Session",
+	WorkNoun:      "Session work",
+	ChangedLead:   "The Session Blackboard changed",
+}
+
+// concludeDirective builds the Conclude Runtime Turn directive for one owner.
+// The Turn must return one closed JSON Attempt result bound to baseRevision
+// without further testing.
+func concludeDirective(profile conclusionDirectiveProfile, baseRevision int) string {
+	return fmt.Sprintf(`%s and perform only the Harness conclusion below.
+Return exactly one JSON object (no markdown fences, no prose) with this shape and base_revision %d:
+{"schema":"runtime-attempt-result/v1","base_revision":%d,"attempt":{"key":"attempt/example","create":true,"summary":"One sentence outcome of the completed %s.","outcome":"inconclusive"},"tested_targets":[{"key":"objective/example","create_objective":{"objective":"What was tested."}}],"produced_targets":[]}
+Conclude only the current source Work Turn. Do not restate an older terminal Attempt.
+Use only existing %s Keys and versions already present in the conversation from the completed source Work Turn. Copy them exactly; never change punctuation or switch between ':' and '/'. If an exact existing key and version are not already known, do not guess or look them up. Create a new descriptive slash-style Attempt or Objective key and use an inconclusive, failed, or blocked outcome without produced targets. A new key must not be a punctuation alias of a current or historical key.
+Replace example keys and summaries with this Turn's real semantic targets.
+Rules: outcome must be one of succeeded, failed, blocked, or inconclusive. Use inconclusive/failed/blocked when the Turn did not create durable produced graph targets. succeeded requires at least one produced_targets entry that references an already-existing %s key with expected_version; do not invent produced_targets on an empty board.
+Describe one Attempt and at least one tested target. Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, %s, or write the %s directly.`,
+		profile.StopCommand, baseRevision, baseRevision, profile.WorkNoun, profile.BoardName, profile.BoardName, profile.FinishClause, profile.BoardName)
+}
+
+// repairDirective builds the repair directive for one rejected closed result.
+// The bounded validation reason from conclusionValidationRepairLine leads the
+// directive; the owner-neutral fallback and example keep the repaired result
+// from inventing produced targets.
+func repairDirective(profile conclusionDirectiveProfile, baseRevision int, detail owner.ConclusionValidationDetail) string {
+	directive := fmt.Sprintf(`Your previous %s conclusion result was invalid.
+%s and correct only that semantic result.
+Return exactly one JSON object (no markdown fences, no prose) with schema runtime-attempt-result/v1 and base_revision %d.
+If the board has no existing produced targets, use outcome "inconclusive" (or failed/blocked) with produced_targets [].
+Example:
+{"schema":"runtime-attempt-result/v1","base_revision":%d,"attempt":{"key":"attempt/example","create":true,"summary":"One sentence outcome of the completed work.","outcome":"inconclusive"},"tested_targets":[{"key":"objective/example","create_objective":{"objective":"What was tested."}}],"produced_targets":[]}
+Conclude only the current source Work Turn. Use only existing %s Keys and versions already present in the conversation. Copy them exactly; never change punctuation or switch between ':' and '/'. If an exact existing key and version are not already known, do not guess or look them up. Create a new descriptive slash-style Attempt or Objective key and use an inconclusive, failed, or blocked outcome without produced targets. Do not restate an older terminal Attempt.
+Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, %s, or write the %s directly.`,
+		profile.BoardName, profile.RepairCommand, baseRevision, baseRevision, profile.BoardName, profile.FinishClause, profile.BoardName)
+	return conclusionValidationRepairLine(detail) + "\n" + directive
+}
+
+// regenerateDirective rebuilds the semantic result against a synchronized
+// baseRevision after an external Blackboard change invalidated the prior one.
+func regenerateDirective(profile conclusionDirectiveProfile, baseRevision int) string {
+	return fmt.Sprintf(`%s after your previous semantic result was produced.
+Regenerate the semantic result against base_revision %d. Use only exact %s Keys and versions already present in the conversation. If a required current version is not already known, create new descriptive slash-style Attempt and Objective keys and use an inconclusive, failed, or blocked outcome with no produced targets. Do not guess or look up current state.
+Return exactly one JSON object with schema runtime-attempt-result/v1.
+Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, %s, or write the %s directly.`,
+		profile.ChangedLead, baseRevision, profile.BoardName, profile.FinishClause, profile.BoardName)
+}

--- a/internal/daemon/conclusion_retry_http.go
+++ b/internal/daemon/conclusion_retry_http.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"pentest/internal/owner"
+	"pentest/internal/owner/conclusion"
+)
+
+// conclusionRetrySpec binds one Runtime Owner to the shared Blackboard
+// conclusion Retry ladder. The ladder is owner-neutral (ADR 0021): one
+// idempotent operator retry per obligation through the shared engine, never
+// resent after an acceptance-ambiguous delivery, and the winning caller
+// schedules exactly one follow-up dispatch.
+type conclusionRetrySpec struct {
+	// latest returns the latest receipt's recovery reason for the owner.
+	latest func() (recoveryReason string, found bool, err error)
+	// retry performs the idempotent retry and reports whether this caller won
+	// and whether the retried obligation is back in the pending conclude state.
+	retry func(idempotencyKey string) (won, pending bool, err error)
+	// dispatchPending schedules the initial conclude dispatch of a retried
+	// pending obligation; dispatchRepair schedules its repair dispatch.
+	dispatchPending func()
+	dispatchRepair  func()
+	// detail renders the owner's detail response payload.
+	detail func() (any, error)
+	// writeOwnerError renders owner-local lookup errors.
+	writeOwnerError func(http.ResponseWriter, error)
+}
+
+func (server *Server) serveBlackboardConclusionRetry(response http.ResponseWriter, request *http.Request, spec conclusionRetrySpec) {
+	idempotencyKey := strings.TrimSpace(request.Header.Get("Idempotency-Key"))
+	if idempotencyKey == "" {
+		writeError(response, http.StatusBadRequest, "Idempotency-Key is required")
+		return
+	}
+	recoveryReason, found, err := spec.latest()
+	if err != nil {
+		spec.writeOwnerError(response, err)
+		return
+	}
+	if !found {
+		writeError(response, http.StatusNotFound, "Blackboard conclusion not found")
+		return
+	}
+	if recoveryReason == string(owner.ConclusionRecoveryAcceptanceAmbiguous) {
+		// An acceptance-ambiguous provider delivery is never resent: a generic
+		// Retry could duplicate a request the provider already accepted.
+		writeError(response, http.StatusConflict, "Blackboard conclusion cannot be retried after an acceptance-ambiguous delivery")
+		return
+	}
+	won, pending, retryErr := spec.retry(idempotencyKey)
+	if retryErr != nil {
+		if errors.Is(retryErr, conclusion.ErrBlackboardConclusionRetryCooldown) {
+			writeError(response, http.StatusConflict, "Blackboard conclusion retry is not yet available")
+			return
+		}
+		writeError(response, http.StatusConflict, "Blackboard conclusion cannot be retried")
+		return
+	}
+	if won {
+		if pending {
+			spec.dispatchPending()
+		} else {
+			spec.dispatchRepair()
+		}
+	}
+	payload, err := spec.detail()
+	if err != nil {
+		spec.writeOwnerError(response, err)
+		return
+	}
+	status := http.StatusOK
+	if won {
+		status = http.StatusAccepted
+	}
+	writeJSON(response, status, payload)
+}

--- a/internal/daemon/launch_plan_tail.go
+++ b/internal/daemon/launch_plan_tail.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+
+	"pentest/internal/runner"
+	"pentest/internal/runtime"
+	"pentest/internal/runtimeprofile"
+	"pentest/internal/task"
+)
+
+// The launch-plan tail below is the owner-neutral part of every Runtime
+// launch: the sandbox Pi bootstrap rule, the Pi session tailer, the native
+// session metadata collector, and the container stop confirmation. Task and
+// Session launch plans share these steps verbatim (ADR 0020); owners keep only
+// their plan middles (Project binding, Scope, captured replay).
+
+// sandboxPiRuntimeCommand applies the one-shot Pi bootstrap wrapper unless this
+// launch will open a persistent provider session: the provider-session bridge
+// rewrites the image command itself and needs a bare "pi" token in the docker
+// create argv.
+func (server *Server) sandboxPiRuntimeCommand(providerCommand []string, profile runtimeprofile.Profile, run task.Runner) ([]string, error) {
+	usePersistentSession := server.providerSessionFactory != nil &&
+		supportsPersistentProviderSession(run, profile.Provider)
+	if usePersistentSession {
+		return providerCommand, nil
+	}
+	return runner.WrapSandboxPiCommand(providerCommand, profile.Fields.Env)
+}
+
+// withPiSessionTail wraps a sandboxed Pi adapter with the session-file tailer.
+// Pi writes its real-time progress to a session jsonl file instead of stdout,
+// so a sandboxed Pi timeline is empty until exit; the tailer re-emits appended
+// lines as runtime_output events the transcript parser already understands.
+func withPiSessionTail(adapter runtime.Adapter, sandbox bool, provider runtimeprofile.Provider, layout runner.Layout) runtime.Adapter {
+	if sandbox && provider == runtimeprofile.ProviderPi {
+		return runtime.NewPiSessionTailAdapter(adapter, filepath.Join(layout.ProviderHome, "agent", "sessions"))
+	}
+	return adapter
+}
+
+// providerNativeSessionMetadata builds the post-launch native session metadata
+// collector: the sandbox container id plus the provider-native session
+// discovery for runtimes that keep one.
+func providerNativeSessionMetadata(sandbox bool, provider runtimeprofile.Provider, layout runner.Layout, containerIDFile string) func() (runtime.NativeSessionMetadata, error) {
+	if !sandbox && provider != runtimeprofile.ProviderCodex && provider != runtimeprofile.ProviderPi && provider != runtimeprofile.ProviderHermes {
+		return nil
+	}
+	return func() (runtime.NativeSessionMetadata, error) {
+		collected := runtime.NativeSessionMetadata{}
+		if containerIDFile != "" {
+			containerID, err := runtime.ReadContainerIDFile(containerIDFile)
+			if err != nil && !os.IsNotExist(err) {
+				return runtime.NativeSessionMetadata{}, err
+			}
+			collected.ContainerID = containerID
+		}
+		switch provider {
+		case runtimeprofile.ProviderCodex:
+			native, err := runtime.DiscoverCodexSession(layout.ProviderHome)
+			if err != nil {
+				return runtime.NativeSessionMetadata{}, err
+			}
+			collected.NativeSessionID, collected.NativeSessionPath = native.NativeSessionID, native.NativeSessionPath
+		case runtimeprofile.ProviderPi:
+			native, err := runtime.DiscoverPiSession(layout.ProviderHome)
+			if err != nil {
+				return runtime.NativeSessionMetadata{}, err
+			}
+			collected.NativeSessionID, collected.NativeSessionPath = native.NativeSessionID, native.NativeSessionPath
+		}
+		return collected, nil
+	}
+}
+
+// dockerStopConfirmation confirms a sandbox container stopped before the
+// Runtime is declared terminal. It matches the launch-selected CLI
+// (podman/docker), not only the daemon flag.
+func dockerStopConfirmation(ownerContainerCLI, daemonContainerCLI, containerIDFile string) runtime.StopConfirmation {
+	if containerIDFile == "" {
+		return nil
+	}
+	return runtime.DockerContainerStopConfirmation(
+		task.ResolveContainerCLI(ownerContainerCLI, daemonContainerCLI), containerIDFile,
+	)
+}

--- a/internal/daemon/permission_ladder.go
+++ b/internal/daemon/permission_ladder.go
@@ -1,0 +1,131 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"pentest/internal/runtime"
+	"pentest/internal/task"
+)
+
+// The provider permission-response ladder is one owner-neutral protocol
+// (ADR 0020): both Task and Session owners derive the response identity the
+// same way, scan the same idempotency status, persist the same bounded event
+// shapes, and classify delivery failures through one code table. Owners keep
+// only their gating rules, persistence sinks, and provider-control discipline.
+
+// normalizePermissionDecision folds common decision spellings onto the closed
+// allow/deny vocabulary.
+func normalizePermissionDecision(decision string) string {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "allow", "approve", "approved", "yes":
+		return "allow"
+	case "deny", "reject", "rejected", "no":
+		return "deny"
+	default:
+		return ""
+	}
+}
+
+// derivePermissionResponseRequestID fills the idempotent response identity:
+// the body's request_id, else the Idempotency-Key header, else a stable
+// permission-scoped default.
+func derivePermissionResponseRequestID(request *http.Request, input *providerPermissionResponseRequest) {
+	input.RequestID = strings.TrimSpace(input.RequestID)
+	if input.RequestID == "" {
+		input.RequestID = strings.TrimSpace(request.Header.Get("Idempotency-Key"))
+	}
+	if input.RequestID == "" {
+		input.RequestID = "permission-" + request.PathValue("permission_id") + "-" + input.Decision
+	}
+}
+
+// permissionResponseRequestedPayload builds the pending intent event both
+// owners persist before dispatching the response.
+func permissionResponseRequestedPayload(input providerPermissionResponseRequest, permissionID, providerSessionID string) task.EventPayload {
+	return task.EventPayload{
+		"phase": "provider_permission_response_requested", "mode": string(runtime.ProviderSessionModePermissionResponse),
+		"outcome": "pending", "request_id": input.RequestID, "permission_request_id": permissionID,
+		"permission_decision": input.Decision, "session_id": providerSessionID,
+	}
+}
+
+// newPermissionResponseEmit builds the redacting sink for provider callbacks
+// during one permission response. Fixed correlation allowlist only: raw
+// protocol payload never reaches the owner Timeline.
+func newPermissionResponseEmit(input providerPermissionResponseRequest, permissionID string, persist func(task.EventKind, task.EventPayload)) func(task.EventKind, task.EventPayload) {
+	return func(kind task.EventKind, payload task.EventPayload) {
+		redacted := task.EventPayload{}
+		for _, key := range []string{"provider", "request_id", "session_id", "provider_turn_id", "mode", "outcome", "permission_request_id", "permission_decision", "error_code", "phase"} {
+			if value, ok := payload[key]; ok {
+				redacted[key] = value
+			}
+		}
+		if redacted["request_id"] == nil {
+			redacted["request_id"] = input.RequestID
+		}
+		redacted["permission_request_id"] = permissionID
+		if redacted["mode"] == nil {
+			redacted["mode"] = string(runtime.ProviderSessionModePermissionResponse)
+		}
+		switch redacted["outcome"] {
+		case "requested":
+			redacted["phase"] = "provider_permission_response_requested"
+		case "acknowledged":
+			redacted["phase"] = "provider_permission_response_acknowledged"
+		case "failed":
+			redacted["phase"] = "provider_permission_response_failed"
+		}
+		persist(kind, redacted)
+	}
+}
+
+// deliverPermissionResponse executes the bounded provider RespondPermission
+// call and projects its terminal outcome: a classified failure event through
+// the redacting sink, or the applied result event through persist.
+func deliverPermissionResponse(ctx context.Context, provider runtime.ProviderSession, input providerPermissionResponseRequest, permissionID string, emit, persist func(task.EventKind, task.EventPayload)) {
+	result, operationErr := provider.RespondPermission(ctx, runtime.ProviderSessionRequest{
+		RequestID: input.RequestID, PermissionRequestID: permissionID, PermissionDecision: input.Decision,
+	}, emit)
+	if operationErr != nil {
+		emit(task.EventKindLifecycle, task.EventPayload{
+			"outcome": "failed", "phase": "provider_permission_response_failed",
+			"error_code": permissionResponseErrorCode(operationErr),
+		})
+		return
+	}
+	payload := result.Payload()
+	payload["phase"] = "provider_permission_response_applied"
+	payload["outcome"] = "applied"
+	payload["permission_request_id"] = permissionID
+	persist(task.EventKindLifecycle, payload)
+}
+
+// writePermissionResponseAccepted answers the operator with the idempotent
+// acceptance (or prior-outcome replay) envelope.
+func writePermissionResponseAccepted(response http.ResponseWriter, input providerPermissionResponseRequest, permissionID, providerSessionID, outcome string) {
+	writeJSON(response, http.StatusAccepted, map[string]any{
+		"request_id": input.RequestID, "permission_request_id": permissionID,
+		"session_id": providerSessionID, "decision": input.Decision, "outcome": outcome,
+	})
+}
+
+// permissionResponseErrorCode maps a provider permission-response failure to
+// the stable error_code both owner kinds persist, so task and session
+// permission handling share one classification.
+func permissionResponseErrorCode(operationErr error) string {
+	switch {
+	case errors.Is(operationErr, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(operationErr, context.Canceled):
+		return "server_closing"
+	case errors.Is(operationErr, runtime.ErrProviderSessionClosed):
+		return "session_closed"
+	case errors.Is(operationErr, runtime.ErrProviderSessionControlConflict):
+		return "control_conflict"
+	default:
+		return "provider_rejected"
+	}
+}

--- a/internal/daemon/session_blackboard_conclusion.go
+++ b/internal/daemon/session_blackboard_conclusion.go
@@ -129,35 +129,11 @@ func (server *Server) dispatchSessionBlackboardConclusion(ctx context.Context, p
 	if !won {
 		return nil
 	}
-	return server.sendSessionBlackboardConclusionTurn(ctx, receipt, concludeSessionBlackboardDirective(snapshot.Revision))
+	return server.sendSessionBlackboardConclusionTurn(ctx, receipt, concludeDirective(sessionConclusionDirectiveProfile, snapshot.Revision))
 }
 
-func concludeSessionBlackboardDirective(baseRevision int) string {
-	return fmt.Sprintf(`Stop the Session's exploratory work and perform only the Harness conclusion below.
-Return exactly one JSON object (no markdown fences, no prose) with this shape and base_revision %d:
-{"schema":"runtime-attempt-result/v1","base_revision":%d,"attempt":{"key":"attempt/example","create":true,"summary":"One sentence outcome of the completed Session work.","outcome":"inconclusive"},"tested_targets":[{"key":"objective/example","create_objective":{"objective":"What was tested."}}],"produced_targets":[]}
-Conclude only the current source Work Turn. Do not restate an older terminal Attempt.
-Use only existing Session Blackboard Keys and versions already present in the conversation from the completed source Work Turn. Copy them exactly; never change punctuation or switch between ':' and '/'. If an exact existing key and version are not already known, do not guess or look them up. Create a new descriptive slash-style Attempt or Objective key and use an inconclusive, failed, or blocked outcome without produced targets. A new key must not be a punctuation alias of a current or historical key.
-Replace example keys and summaries with this Turn's real semantic targets.
-Rules: outcome must be one of succeeded, failed, blocked, or inconclusive. Describe one Attempt and at least one tested target. Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, finish the Session, or write the Session Blackboard directly.`, baseRevision, baseRevision)
-}
-
-func repairSessionBlackboardDirective(baseRevision int, detail owner.ConclusionValidationDetail) string {
-	directive := fmt.Sprintf(`Your previous Session Blackboard conclusion result was invalid.
-Stop exploratory work and correct only that semantic result.
-Return exactly one JSON object (no markdown fences, no prose) with schema runtime-attempt-result/v1 and base_revision %d.
-Use outcome inconclusive, failed, or blocked with produced_targets [] when no existing produced target is available.
-Conclude only the current source Work Turn. Use only existing Session Blackboard Keys and versions already present in the conversation. Copy them exactly; never change punctuation or switch between ':' and '/'. If an exact existing key and version are not already known, do not guess or look them up. Create a new descriptive slash-style Attempt or Objective key and use an inconclusive, failed, or blocked outcome without produced targets. Do not restate an older terminal Attempt.
-Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, finish the Session, or write the Session Blackboard directly.`, baseRevision)
-	return conclusionValidationRepairLine(detail) + "\n" + directive
-}
-
-func regenerateSessionBlackboardDirective(baseRevision int) string {
-	return fmt.Sprintf(`The Session Blackboard changed after your previous semantic result was produced.
-Regenerate the semantic result against base_revision %d. Use only exact Session Blackboard Keys and versions already present in the conversation. If a required current version is not already known, create new descriptive slash-style Attempt and Objective keys and use an inconclusive, failed, or blocked outcome with no produced targets. Do not guess or look up current state.
-Return exactly one JSON object with schema runtime-attempt-result/v1.
-Do not read files. Do not call tools, continue testing, include raw tool output or reasoning, finish the Session, or write the Session Blackboard directly.`, baseRevision)
-}
+// conclusionDetailFromSessionReceipt maps one Session receipt onto the shared
+// conclusion validation detail view.
 
 func (server *Server) sessionBlackboardConclusionCoordinator(sessionID string) runtime.AssistedConclusionCoordinator {
 	return runtime.AssistedConclusionCoordinator{
@@ -217,7 +193,7 @@ func (server *Server) handleSessionBlackboardConclusionFailure(sessionID, reques
 	}
 	if dispatchRepair && receipt.InternalState == session.BlackboardConclusionReceiptRepairDispatchRequested {
 		queued := server.enqueueProviderTaskControl(sessionID, func(ctx context.Context) {
-			if err := server.sendSessionBlackboardConclusionTurn(ctx, receipt, repairSessionBlackboardDirective(pointerValue(receipt.BaseRevision), conclusionDetailFromSessionReceipt(receipt))); err != nil {
+			if err := server.sendSessionBlackboardConclusionTurn(ctx, receipt, repairDirective(sessionConclusionDirectiveProfile, pointerValue(receipt.BaseRevision), conclusionDetailFromSessionReceipt(receipt))); err != nil {
 				server.requireSessionBlackboardConclusionRecovery(receipt, session.ConclusionRecoveryDispatchFailed, err)
 			}
 		})
@@ -379,7 +355,7 @@ func (server *Server) regenerateSessionBlackboardConclusionAfterVersionConflict(
 		return nil
 	}
 	queued := server.enqueueProviderTaskControl(regeneration.SessionID, func(dispatchCtx context.Context) {
-		if dispatchErr := server.sendSessionBlackboardConclusionTurn(dispatchCtx, regeneration, regenerateSessionBlackboardDirective(pointerValue(regeneration.BaseRevision))); dispatchErr != nil {
+		if dispatchErr := server.sendSessionBlackboardConclusionTurn(dispatchCtx, regeneration, regenerateDirective(sessionConclusionDirectiveProfile, pointerValue(regeneration.BaseRevision))); dispatchErr != nil {
 			server.requireSessionBlackboardConclusionRecovery(regeneration, session.ConclusionRecoveryDispatchFailed, dispatchErr)
 		}
 	})
@@ -496,58 +472,44 @@ func (server *Server) handleRetrySessionBlackboardConclusion(response http.Respo
 		writeSessionError(response, err)
 		return
 	}
-	idempotencyKey := strings.TrimSpace(request.Header.Get("Idempotency-Key"))
-	if idempotencyKey == "" {
-		writeError(response, http.StatusBadRequest, "Idempotency-Key is required")
-		return
-	}
-	latest, err := server.sessions.LatestBlackboardConclusion(sessionID)
-	if err != nil || latest == nil {
-		writeSessionError(response, err)
-		return
-	}
-	if latest.RecoveryReason == string(session.ConclusionRecoveryAcceptanceAmbiguous) {
-		// An acceptance-ambiguous provider delivery is never resent: a generic
-		// Retry could duplicate a request the provider already accepted.
-		writeError(response, http.StatusConflict, "Session Blackboard conclusion cannot be retried after an acceptance-ambiguous delivery")
-		return
-	}
-	retried, won, err := server.sessions.RetryLatestBlackboardConclusion(sessionID, idempotencyKey, time.Now().UTC())
-	if err != nil {
-		if errors.Is(err, session.ErrBlackboardConclusionRetryCooldown) {
-			writeError(response, http.StatusConflict, "Session Blackboard conclusion retry is not yet available")
-			return
-		}
-		writeError(response, http.StatusConflict, "Session Blackboard conclusion cannot be retried")
-		return
-	}
-	if won {
-		if retried.InternalState == session.BlackboardConclusionReceiptPending {
-			server.scheduleSessionBlackboardConclusionDispatch(retried)
-		} else {
+	var retried session.BlackboardConclusionReceipt
+	server.serveBlackboardConclusionRetry(response, request, conclusionRetrySpec{
+		latest: func() (string, bool, error) {
+			latest, err := server.sessions.LatestBlackboardConclusion(sessionID)
+			if err != nil || latest == nil {
+				return "", false, err
+			}
+			return latest.RecoveryReason, true, nil
+		},
+		retry: func(idempotencyKey string) (bool, bool, error) {
+			var won bool
+			var err error
+			retried, won, err = server.sessions.RetryLatestBlackboardConclusion(sessionID, idempotencyKey, time.Now().UTC())
+			if err != nil {
+				return false, false, err
+			}
+			return won, retried.InternalState == session.BlackboardConclusionReceiptPending, nil
+		},
+		dispatchPending: func() { server.scheduleSessionBlackboardConclusionDispatch(retried) },
+		dispatchRepair: func() {
 			queued := server.enqueueProviderTaskControl(sessionID, func(ctx context.Context) {
-				if err := server.sendSessionBlackboardConclusionTurn(ctx, retried, repairSessionBlackboardDirective(pointerValue(retried.BaseRevision), conclusionDetailFromSessionReceipt(retried))); err != nil {
+				if err := server.sendSessionBlackboardConclusionTurn(ctx, retried, repairDirective(sessionConclusionDirectiveProfile, pointerValue(retried.BaseRevision), conclusionDetailFromSessionReceipt(retried))); err != nil {
 					server.requireSessionBlackboardConclusionRecovery(retried, session.ConclusionRecoveryDispatchFailed, err)
 				}
 			})
 			if !queued {
 				server.requireSessionBlackboardConclusionRecovery(retried, session.ConclusionRecoveryDispatchFailed, fmt.Errorf("provider control queue is closed"))
 			}
-		}
-	}
-	found, err := server.sessions.Get(sessionID)
-	if err != nil {
-		writeSessionError(response, err)
-		return
-	}
-	detailed, err := server.decorateSession(found)
-	if err != nil {
-		writeSessionError(response, err)
-		return
-	}
-	status := http.StatusOK
-	if won {
-		status = http.StatusAccepted
-	}
-	writeJSON(response, status, detailed)
+		},
+		detail: func() (any, error) {
+			found, err := server.sessions.Get(sessionID)
+			if err != nil {
+				return nil, err
+			}
+			return server.decorateSession(found)
+		},
+		writeOwnerError: func(response http.ResponseWriter, err error) {
+			writeSessionError(response, err)
+		},
+	})
 }

--- a/internal/daemon/session_blackboard_conclusion_recovery.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery.go
@@ -117,15 +117,15 @@ func (server *Server) resumeLiveSessionBlackboardConclusionObligation(ctx contex
 		},
 		Dispatch: func(state string, baseRevision int, explicitRetryCount int) {
 			server.enqueueRecoveredSessionBlackboardConclusion(obligation, func(controlCtx context.Context) error {
-				directive := concludeSessionBlackboardDirective(baseRevision)
+				directive := concludeDirective(sessionConclusionDirectiveProfile, baseRevision)
 				switch session.BlackboardConclusionReceiptState(state) {
 				case session.BlackboardConclusionReceiptRepairDispatchRequested:
-					directive = repairSessionBlackboardDirective(baseRevision, conclusionDetailFromSessionReceipt(obligation))
+					directive = repairDirective(sessionConclusionDirectiveProfile, baseRevision, conclusionDetailFromSessionReceipt(obligation))
 				case session.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
-					directive = regenerateSessionBlackboardDirective(baseRevision)
+					directive = regenerateDirective(sessionConclusionDirectiveProfile, baseRevision)
 				default:
 					if explicitRetryCount > 0 {
-						directive = repairSessionBlackboardDirective(baseRevision, conclusionDetailFromSessionReceipt(obligation))
+						directive = repairDirective(sessionConclusionDirectiveProfile, baseRevision, conclusionDetailFromSessionReceipt(obligation))
 					}
 				}
 				return server.sendSessionBlackboardConclusionTurn(controlCtx, obligation, directive)
@@ -177,15 +177,15 @@ func (server *Server) scheduleRecoveredSessionConclusionDispatch(view session.Bl
 }
 
 func (server *Server) dispatchRecoveredSessionConclusionDispatch(ctx context.Context, view session.BlackboardConclusionReceipt) error {
-	directive := concludeSessionBlackboardDirective(pointerValue(view.BaseRevision))
+	directive := concludeDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	switch view.InternalState {
 	case session.BlackboardConclusionReceiptRepairDispatchRequested:
-		directive = repairSessionBlackboardDirective(pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
+		directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
 	case session.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
-		directive = regenerateSessionBlackboardDirective(pointerValue(view.BaseRevision))
+		directive = regenerateDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	default:
 		if view.ExplicitRetryCount > 0 {
-			directive = repairSessionBlackboardDirective(pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
+			directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
 		}
 	}
 	return server.sendSessionBlackboardConclusionTurn(ctx, view, directive)

--- a/internal/daemon/session_runtime_handlers.go
+++ b/internal/daemon/session_runtime_handlers.go
@@ -361,13 +361,9 @@ func (server *Server) buildSessionRuntimePlan(found session.Session, goal string
 		}
 		sandboxRuntime := providerCommand
 		if profile.Provider == runtimeprofile.ProviderPi {
-			usePersistentSession := server.providerSessionFactory != nil &&
-				supportsPersistentProviderSession(task.Runner(run), profile.Provider)
-			if !usePersistentSession {
-				sandboxRuntime, err = runner.WrapSandboxPiCommand(providerCommand, launchProfile.Fields.Env)
-				if err != nil {
-					return sessionRuntimePlan{}, err
-				}
+			sandboxRuntime, err = server.sandboxPiRuntimeCommand(providerCommand, launchProfile, task.Runner(run))
+			if err != nil {
+				return sessionRuntimePlan{}, err
 			}
 		}
 		containerCLI := task.ResolveContainerCLI(input.ContainerCLI, server.containerCLI)
@@ -396,44 +392,10 @@ func (server *Server) buildSessionRuntimePlan(found session.Session, goal string
 			Workdir: found.Workdir, Env: processEnv,
 		})
 	}
-	if run == session.RunnerSandbox && profile.Provider == runtimeprofile.ProviderPi {
-		adapter = runtime.NewPiSessionTailAdapter(adapter, filepath.Join(layout.ProviderHome, "agent", "sessions"))
-	}
+	adapter = withPiSessionTail(adapter, run == session.RunnerSandbox, profile.Provider, layout)
 
-	var metadata func() (runtime.NativeSessionMetadata, error)
-	if run == session.RunnerSandbox || profile.Provider == runtimeprofile.ProviderCodex || profile.Provider == runtimeprofile.ProviderPi || profile.Provider == runtimeprofile.ProviderHermes {
-		metadata = func() (runtime.NativeSessionMetadata, error) {
-			collected := runtime.NativeSessionMetadata{}
-			if containerIDFile != "" {
-				containerID, err := runtime.ReadContainerIDFile(containerIDFile)
-				if err != nil && !os.IsNotExist(err) {
-					return runtime.NativeSessionMetadata{}, err
-				}
-				collected.ContainerID = containerID
-			}
-			switch profile.Provider {
-			case runtimeprofile.ProviderCodex:
-				native, err := runtime.DiscoverCodexSession(layout.ProviderHome)
-				if err != nil {
-					return runtime.NativeSessionMetadata{}, err
-				}
-				collected.NativeSessionID, collected.NativeSessionPath = native.NativeSessionID, native.NativeSessionPath
-			case runtimeprofile.ProviderPi:
-				native, err := runtime.DiscoverPiSession(layout.ProviderHome)
-				if err != nil {
-					return runtime.NativeSessionMetadata{}, err
-				}
-				collected.NativeSessionID, collected.NativeSessionPath = native.NativeSessionID, native.NativeSessionPath
-			}
-			return collected, nil
-		}
-	}
-	var stopConfirmation runtime.StopConfirmation
-	if containerIDFile != "" {
-		// Match the launch-selected CLI (podman/docker), not only the daemon flag.
-		containerCLI := task.ResolveContainerCLI(input.ContainerCLI, server.containerCLI)
-		stopConfirmation = runtime.DockerContainerStopConfirmation(containerCLI, containerIDFile)
-	}
+	metadata := providerNativeSessionMetadata(run == session.RunnerSandbox, profile.Provider, layout, containerIDFile)
+	stopConfirmation := dockerStopConfirmation(input.ContainerCLI, server.containerCLI, containerIDFile)
 	return sessionRuntimePlan{
 		Adapter: adapter, Profile: launchProfile, Runner: run, LaunchGoal: launchGoal, RuntimeConfig: config, Selection: selection,
 		Metadata: metadata, StopConfirmation: stopConfirmation, ProviderHome: layout.ProviderHome,
@@ -1347,40 +1309,17 @@ func (server *Server) enqueueSessionProviderTurn(sessionID string, provider runt
 		if mode != runtime.ProviderSessionModeSendTurn {
 			selection.TurnKind = runtime.RuntimeTurnKindControl
 		}
-		var continuationMu sync.Mutex
-		currentContinuationID := continuationID
-		var transitionErr error
-		currentID := func() string {
-			continuationMu.Lock()
-			defer continuationMu.Unlock()
-			return currentContinuationID
-		}
-		emit := func(kind task.EventKind, payload task.EventPayload) {
-			continuationMu.Lock()
-			current := currentContinuationID
-			server.persistSessionProviderEventForContinuation(sessionID, current, kind, payload)
-			if transitionErr == nil && mode == runtime.ProviderSessionModeInterruptThenReplace && kind == task.EventKindSteering && payloadOutcome(payload) == "settled" && current != "" {
-				transitionErr = server.advanceSessionRuntimeContinuation(ctx, sessionID, provider, current, &currentContinuationID)
-				if transitionErr == nil {
-					server.persistSessionProviderEventForContinuation(sessionID, currentContinuationID, task.EventKindLifecycle, task.EventPayload{
-						"phase": "continuation_replaced", "previous_continuation_id": current,
-					})
-				} else {
-					server.persistSessionProviderEventForContinuation(sessionID, current, task.EventKindLifecycle, task.EventPayload{
-						"phase": "continuation_replace_failed", "outcome": "failed",
-					})
-				}
-			}
-			continuationMu.Unlock()
-		}
-		result, err := operation(ctx, selection, emit)
-		if err != nil || transitionErr != nil {
-			server.persistSessionProviderEventForContinuation(sessionID, currentID(), task.EventKindLifecycle, task.EventPayload{
+		spec := server.sessionSteerEmitSpec(ctx, sessionID, provider)
+		spec.mode = mode
+		protocol := newSteerEmitProtocol(continuationID, spec)
+		result, err := operation(ctx, selection, protocol.emit)
+		if err != nil || protocol.transitionErr() != nil {
+			server.persistSessionProviderEventForContinuation(sessionID, protocol.currentID(), task.EventKindLifecycle, task.EventPayload{
 				"phase": "provider_turn_failed", "request_id": requestID, "mode": string(mode), "outcome": "failed",
 			})
-			if transitionErr != nil {
+			if transitionErr := protocol.transitionErr(); transitionErr != nil {
 				_ = server.closeSessionProviderSession(sessionID)
-				if current := currentID(); current != "" {
+				if current := protocol.currentID(); current != "" {
 					_, _ = server.sessions.UpdateContinuationStatus(current, session.RuntimeStatusFailed)
 				}
 			}
@@ -1392,8 +1331,39 @@ func (server *Server) enqueueSessionProviderTurn(sessionID string, provider runt
 		// The provider result is a structured Runtime turn result, not a
 		// transcript message. Conversation contains only explicit user/runtime
 		// messages; provider control/result data stays on the Session Timeline.
-		server.persistSessionProviderEventForContinuation(sessionID, currentID(), task.EventKindConversation, payload)
+		server.persistSessionProviderEventForContinuation(sessionID, protocol.currentID(), task.EventKindConversation, payload)
 	})
+}
+
+// sessionSteerEmitSpec is the Session owner's adapter into the shared steer
+// emit protocol: provider events persist bound to the current Session
+// Continuation and an interrupt_then_replace settlement advances it with the
+// Session's boundary lifecycle events.
+func (server *Server) sessionSteerEmitSpec(ctx context.Context, sessionID string, provider runtime.ProviderSession) steerEmitProtocolSpec {
+	return steerEmitProtocolSpec{
+		advanceOnSettled: true,
+		persistEvent: func(current string, kind task.EventKind, payload task.EventPayload) {
+			server.persistSessionProviderEventForContinuation(sessionID, current, kind, payload)
+		},
+		advance: func(current string) (string, error) {
+			next := current
+			if err := server.advanceSessionRuntimeContinuation(ctx, sessionID, provider, current, &next); err != nil {
+				return "", err
+			}
+			return next, nil
+		},
+		onAdvanceSettled: func(current, replacement string, advanceErr error) {
+			if advanceErr == nil {
+				server.persistSessionProviderEventForContinuation(sessionID, replacement, task.EventKindLifecycle, task.EventPayload{
+					"phase": "continuation_replaced", "previous_continuation_id": current,
+				})
+				return
+			}
+			server.persistSessionProviderEventForContinuation(sessionID, current, task.EventKindLifecycle, task.EventPayload{
+				"phase": "continuation_replace_failed", "outcome": "failed",
+			})
+		},
+	}
 }
 
 // executeSessionNativeSteerOperation sends one accepted native steer Turn on a
@@ -1401,67 +1371,26 @@ func (server *Server) enqueueSessionProviderTurn(sessionID string, provider runt
 // outcome events. The caller runs under the Session provider control queue.
 // The returned execution is the durable terminal outcome.
 func (server *Server) executeSessionNativeSteerOperation(ctx context.Context, sessionID string, provider runtime.ProviderSession, mode runtime.ProviderSessionMode, operation nativeSteerOperationFunc, providerRequest runtime.ProviderSessionRequest, continuationID string) steeringExecution {
-	selection := providerRequest
-	selection.TurnKind = runtime.RuntimeTurnKindControl
-	var continuationMu sync.Mutex
-	currentContinuationID := continuationID
-	var transitionErr error
-	currentID := func() string {
-		continuationMu.Lock()
-		defer continuationMu.Unlock()
-		return currentContinuationID
-	}
-	emit := func(kind task.EventKind, payload task.EventPayload) {
-		continuationMu.Lock()
-		current := currentContinuationID
-		server.persistSessionProviderEventForContinuation(sessionID, current, kind, payload)
-		if transitionErr == nil && mode == runtime.ProviderSessionModeInterruptThenReplace && kind == task.EventKindSteering && payloadOutcome(payload) == "settled" && current != "" {
-			transitionErr = server.advanceSessionRuntimeContinuation(ctx, sessionID, provider, current, &currentContinuationID)
-			if transitionErr == nil {
-				server.persistSessionProviderEventForContinuation(sessionID, currentContinuationID, task.EventKindLifecycle, task.EventPayload{
-					"phase": "continuation_replaced", "previous_continuation_id": current,
-				})
-			} else {
-				server.persistSessionProviderEventForContinuation(sessionID, current, task.EventKindLifecycle, task.EventPayload{
-					"phase": "continuation_replace_failed", "outcome": "failed",
-				})
-			}
-		}
-		continuationMu.Unlock()
-	}
-	result, err := operation(ctx, selection, emit)
-	if err != nil || transitionErr != nil {
-		if transitionErr != nil {
+	spec := server.sessionSteerEmitSpec(ctx, sessionID, provider)
+	spec.mode = mode
+	return runNativeSteerTurn(ctx, steerExecutionSpec{
+		operation:             operation,
+		request:               providerRequest,
+		mode:                  mode,
+		providerSessionID:     provider.SessionID(),
+		initialContinuationID: continuationID,
+		advanceOnSettled:      spec.advanceOnSettled,
+		vocabulary:            sessionSteerEventVocabulary,
+		persistEvent:          spec.persistEvent,
+		advance:               spec.advance,
+		onAdvanceSettled:      spec.onAdvanceSettled,
+		failClosed: func(current string) {
 			_ = server.closeSessionProviderSession(sessionID)
-			if current := currentID(); current != "" {
+			if current != "" {
 				_, _ = server.sessions.UpdateContinuationStatus(current, session.RuntimeStatusFailed)
 			}
-			return steeringExecution{state: owner.SteeringFailed, reason: owner.SteeringReasonContinuationUnavailable, message: transitionErr.Error()}
-		}
-		errorCode, errorMessage := nativeSteerFailurePresentation(err)
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Post-fence with no provider outcome: delivery is ambiguous. The
-			// request is never replayed automatically.
-			server.persistSessionProviderEventForContinuation(sessionID, currentID(), task.EventKindLifecycle, task.EventPayload{
-				"phase": "provider_turn_failed", "request_id": providerRequest.RequestID, "mode": string(mode),
-				"outcome": "action_required", "error_code": string(owner.SteeringReasonDeliveryAmbiguous), "error": errorMessage,
-			})
-			return steeringExecution{state: owner.SteeringActionRequired, reason: owner.SteeringReasonDeliveryAmbiguous, message: errorMessage}
-		}
-		server.persistSessionProviderEventForContinuation(sessionID, currentID(), task.EventKindLifecycle, task.EventPayload{
-			"phase": "provider_turn_failed", "request_id": providerRequest.RequestID, "mode": string(mode),
-			"outcome": "failed", "error_code": errorCode, "error": errorMessage,
-		})
-		return steeringExecution{state: owner.SteeringFailed, reason: steerReasonFromFailureCode(errorCode), message: errorMessage}
-	}
-	payload := result.Payload()
-	payload["phase"] = "provider_turn_applied"
-	payload["outcome"] = "applied"
-	// The provider result is a structured Runtime turn result, not a
-	// transcript message. Conversation contains only explicit user/runtime
-	// messages; provider control/result data stays on the Session Timeline.
-	server.persistSessionProviderEventForContinuation(sessionID, currentID(), task.EventKindConversation, payload)
-	return steeringExecution{state: owner.SteeringApplied, result: result.Payload()}
+		},
+	})
 }
 
 func payloadOutcome(payload task.EventPayload) string {
@@ -1812,13 +1741,7 @@ func (server *Server) handleSessionProviderPermissionResponse(response http.Resp
 		writeError(response, http.StatusBadRequest, "permission decision must be allow or deny")
 		return
 	}
-	input.RequestID = strings.TrimSpace(input.RequestID)
-	if input.RequestID == "" {
-		input.RequestID = strings.TrimSpace(request.Header.Get("Idempotency-Key"))
-	}
-	if input.RequestID == "" {
-		input.RequestID = "permission-" + permissionID + "-" + input.Decision
-	}
+	derivePermissionResponseRequestID(request, &input)
 	events, err := server.sessions.Events(id)
 	if err != nil {
 		writeSessionError(response, err)
@@ -1830,10 +1753,7 @@ func (server *Server) handleSessionProviderPermissionResponse(response http.Resp
 		return
 	}
 	if priorOutcome != "" {
-		writeJSON(response, http.StatusAccepted, map[string]any{
-			"request_id": input.RequestID, "permission_request_id": permissionID,
-			"session_id": provider.SessionID(), "decision": input.Decision, "outcome": priorOutcome,
-		})
+		writePermissionResponseAccepted(response, input, permissionID, provider.SessionID(), priorOutcome)
 		return
 	}
 	if !pending {
@@ -1853,42 +1773,16 @@ func (server *Server) handleSessionProviderPermissionResponse(response http.Resp
 		writeError(response, http.StatusConflict, "provider permission requires an active Session Runtime")
 		return
 	}
-	requested := task.EventPayload{
-		"phase": "provider_permission_response_requested", "mode": string(runtime.ProviderSessionModePermissionResponse),
-		"outcome": "pending", "request_id": input.RequestID, "permission_request_id": permissionID,
-		"permission_decision": input.Decision, "session_id": provider.SessionID(),
+	server.persistSessionProviderEventForContinuation(id, active.ID, task.EventKindLifecycle,
+		permissionResponseRequestedPayload(input, permissionID, provider.SessionID()))
+	persistLadderEvent := func(kind task.EventKind, payload task.EventPayload) {
+		server.persistSessionProviderEventForContinuation(id, active.ID, kind, payload)
 	}
-	server.persistSessionProviderEventForContinuation(id, active.ID, task.EventKindLifecycle, requested)
+	emit := newPermissionResponseEmit(input, permissionID, persistLadderEvent)
 	queued := server.enqueueProviderTaskControlAfterSettlement(id, server.sessionBlackboardConclusionSettlement(id, true), func(ctx context.Context) {
 		operationCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		emit := func(kind task.EventKind, payload task.EventPayload) {
-			if payload == nil {
-				payload = task.EventPayload{}
-			}
-			payload["request_id"] = input.RequestID
-			payload["permission_request_id"] = permissionID
-			if _, ok := payload["mode"]; !ok {
-				payload["mode"] = string(runtime.ProviderSessionModePermissionResponse)
-			}
-			server.persistSessionProviderEventForContinuation(id, active.ID, kind, payload)
-		}
-		result, operationErr := provider.RespondPermission(operationCtx, runtime.ProviderSessionRequest{
-			RequestID: input.RequestID, PermissionRequestID: permissionID, PermissionDecision: input.Decision,
-		}, emit)
-		if operationErr != nil {
-			server.persistSessionProviderEventForContinuation(id, active.ID, task.EventKindLifecycle, task.EventPayload{
-				"phase": "provider_permission_response_failed", "outcome": "failed", "request_id": input.RequestID,
-				"permission_request_id": permissionID, "mode": string(runtime.ProviderSessionModePermissionResponse),
-				"error_code": permissionResponseErrorCode(operationErr),
-			})
-			return
-		}
-		payload := result.Payload()
-		payload["phase"] = "provider_permission_response_applied"
-		payload["outcome"] = "applied"
-		payload["permission_request_id"] = permissionID
-		server.persistSessionProviderEventForContinuation(id, active.ID, task.EventKindLifecycle, payload)
+		deliverPermissionResponse(operationCtx, provider, input, permissionID, emit, persistLadderEvent)
 	})
 	if !queued {
 		server.persistSessionProviderEventForContinuation(id, active.ID, task.EventKindLifecycle, task.EventPayload{
@@ -1898,10 +1792,7 @@ func (server *Server) handleSessionProviderPermissionResponse(response http.Resp
 		writeError(response, http.StatusConflict, "Session Runtime control operation is unavailable")
 		return
 	}
-	writeJSON(response, http.StatusAccepted, map[string]any{
-		"request_id": input.RequestID, "permission_request_id": permissionID,
-		"session_id": provider.SessionID(), "decision": input.Decision, "outcome": "accepted",
-	})
+	writePermissionResponseAccepted(response, input, permissionID, provider.SessionID(), "accepted")
 }
 
 // sessionEventsAsTimeline projects session events into the neutral event shape

--- a/internal/daemon/steer_executor.go
+++ b/internal/daemon/steer_executor.go
@@ -1,0 +1,202 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"pentest/internal/owner"
+	"pentest/internal/runtime"
+	"pentest/internal/task"
+)
+
+// steerEventVocabulary names the owner-local Timeline projection of the shared
+// steer protocol. Owners differ only in event kind and phase; the payloads and
+// control flow are shared.
+type steerEventVocabulary struct {
+	failureKind    task.EventKind
+	failurePhase   string
+	ambiguousPhase string
+	appliedKind    task.EventKind
+	appliedPhase   string
+}
+
+var taskSteerEventVocabulary = steerEventVocabulary{
+	failureKind:    task.EventKindSteering,
+	failurePhase:   "steering_failed",
+	ambiguousPhase: "steering_action_required",
+	appliedKind:    task.EventKindSteering,
+	appliedPhase:   "steering_applied",
+}
+
+var sessionSteerEventVocabulary = steerEventVocabulary{
+	failureKind:    task.EventKindLifecycle,
+	failurePhase:   "provider_turn_failed",
+	ambiguousPhase: "provider_turn_failed",
+	appliedKind:    task.EventKindConversation,
+	appliedPhase:   "provider_turn_applied",
+}
+
+// steerEmitProtocolSpec binds one Runtime Owner to the shared emit protocol:
+// provider events persist bound to the current Runtime Continuation, and an
+// interrupt_then_replace steering settlement advances the Continuation under
+// the same mutex so the next provider event lands on the replacement.
+type steerEmitProtocolSpec struct {
+	mode runtime.ProviderSessionMode
+	// advanceOnSettled is false when the Continuation was created fresh by this
+	// dispatch and must not be advanced again.
+	advanceOnSettled bool
+	// persistEvent stores one event bound to the given Continuation id. The
+	// empty id means the owner has no Continuation.
+	persistEvent func(continuationID string, kind task.EventKind, payload task.EventPayload)
+	// persistOwnerEvent stores one owner-level event when no Continuation is
+	// bound (legacy owners without continuation authority).
+	persistOwnerEvent func(kind task.EventKind, payload task.EventPayload)
+	// advance settles the old Continuation and returns the replacement id.
+	advance func(currentID string) (string, error)
+	// onAdvanceSettled projects the owner's replacement boundary events; it
+	// runs under the emit mutex with the outcome of advance.
+	onAdvanceSettled func(currentID, replacementID string, advanceErr error)
+}
+
+type steerEmitProtocol struct {
+	emit          func(kind task.EventKind, payload task.EventPayload)
+	currentID     func() string
+	transitionErr func() error
+}
+
+func newSteerEmitProtocol(initialContinuationID string, spec steerEmitProtocolSpec) steerEmitProtocol {
+	var continuationMu sync.Mutex
+	currentContinuationID := initialContinuationID
+	var transitionErr error
+	currentID := func() string {
+		continuationMu.Lock()
+		defer continuationMu.Unlock()
+		return currentContinuationID
+	}
+	emit := func(kind task.EventKind, payload task.EventPayload) {
+		continuationMu.Lock()
+		current := currentContinuationID
+		spec.persistEvent(current, kind, payload)
+		if transitionErr == nil && spec.advanceOnSettled &&
+			spec.mode == runtime.ProviderSessionModeInterruptThenReplace &&
+			kind == task.EventKindSteering && payloadOutcome(payload) == "settled" && current != "" {
+			next, advanceErr := spec.advance(current)
+			if advanceErr != nil {
+				transitionErr = advanceErr
+			} else {
+				currentContinuationID = next
+			}
+			if spec.onAdvanceSettled != nil {
+				spec.onAdvanceSettled(current, next, advanceErr)
+			}
+		}
+		continuationMu.Unlock()
+		if current == "" && spec.persistOwnerEvent != nil {
+			spec.persistOwnerEvent(kind, payload)
+		}
+	}
+	return steerEmitProtocol{
+		emit: emit, currentID: currentID,
+		transitionErr: func() error {
+			continuationMu.Lock()
+			defer continuationMu.Unlock()
+			return transitionErr
+		},
+	}
+}
+
+// steerExecutionSpec binds one Runtime Owner to the shared native steer
+// executor. The executor owns the owner-neutral delivery protocol: the request
+// is always lineage-assigned as a Harness Control Turn (ADR 0018), events
+// persist through the owner sink, a lost Continuation transition fails closed,
+// and a post-fence cancellation settles action_required instead of replaying.
+type steerExecutionSpec struct {
+	operation             nativeSteerOperationFunc
+	request               runtime.ProviderSessionRequest
+	mode                  runtime.ProviderSessionMode
+	providerSessionID     string
+	initialContinuationID string
+	advanceOnSettled      bool
+	vocabulary            steerEventVocabulary
+	// persistEvent stores one event bound to the given Continuation; an empty
+	// id falls back to persistOwnerEvent.
+	persistEvent      func(continuationID string, kind task.EventKind, payload task.EventPayload)
+	persistOwnerEvent func(kind task.EventKind, payload task.EventPayload)
+	advance           func(currentID string) (string, error)
+	onAdvanceSettled  func(currentID, replacementID string, advanceErr error)
+	// failClosed closes the owner's provider session and fails the Continuation
+	// (and the owner itself when it has a lifecycle status) after a transition
+	// failure.
+	failClosed func(currentID string)
+	// failOwnerExecution drains the owner failure through the Accepted
+	// Steering dispatcher (Task owners fail their owner status).
+	failOwnerExecution bool
+}
+
+// runNativeSteerTurn delivers one native steer operation under the shared
+// owner-neutral protocol and returns the durable terminal outcome. The caller
+// owns provider control for the whole operation.
+func runNativeSteerTurn(ctx context.Context, spec steerExecutionSpec) steeringExecution {
+	// The Harness owns the closed work|control Runtime Turn kind and assigns it
+	// from request lineage; provider payloads cannot choose or override it
+	// (ADR 0018).
+	request := spec.request
+	request.TurnKind = runtime.RuntimeTurnKindControl
+
+	protocol := newSteerEmitProtocol(spec.initialContinuationID, steerEmitProtocolSpec{
+		mode:              spec.mode,
+		advanceOnSettled:  spec.advanceOnSettled,
+		persistEvent:      spec.persistEvent,
+		persistOwnerEvent: spec.persistOwnerEvent,
+		advance:           spec.advance,
+		onAdvanceSettled:  spec.onAdvanceSettled,
+	})
+	result, operationErr := spec.operation(ctx, request, protocol.emit)
+	// A failed Continuation transition is fail-closed even when the provider
+	// operation also failed: the delivery authority for later events is gone.
+	if transitionErr := protocol.transitionErr(); transitionErr != nil {
+		if spec.failClosed != nil {
+			spec.failClosed(protocol.currentID())
+		}
+		return steeringExecution{
+			state: owner.SteeringFailed, reason: owner.SteeringReasonContinuationUnavailable,
+			message: transitionErr.Error(), failOwner: spec.failOwnerExecution,
+		}
+	}
+	if operationErr != nil {
+		errorCode, errorMessage := nativeSteerFailurePresentation(operationErr)
+		if errors.Is(operationErr, context.Canceled) || errors.Is(operationErr, context.DeadlineExceeded) {
+			// Post-fence with no provider outcome: delivery is ambiguous. The
+			// request is never replayed automatically; it settles
+			// action_required with a reason-specific recovery path.
+			protocol.emit(spec.vocabulary.failureKind, task.EventPayload{
+				"request_id": request.RequestID, "session_id": spec.providerSessionID, "mode": string(spec.mode),
+				"outcome": "action_required", "phase": spec.vocabulary.ambiguousPhase,
+				"error_code": string(owner.SteeringReasonDeliveryAmbiguous), "error": errorMessage,
+				"model_provider_id": request.ModelProviderID, "model": request.Model,
+				"requested_reasoning_effort": request.RequestedReasoningEffort,
+			})
+			return steeringExecution{state: owner.SteeringActionRequired, reason: owner.SteeringReasonDeliveryAmbiguous, message: errorMessage}
+		}
+		// Public Events carry only redacted, stable failure fields. Raw
+		// provider text stays out of the conversation surface; each owner's
+		// persistence sink applies its own allowlist.
+		protocol.emit(spec.vocabulary.failureKind, task.EventPayload{
+			"request_id": request.RequestID, "session_id": spec.providerSessionID, "mode": string(spec.mode),
+			"outcome": "failed", "phase": spec.vocabulary.failurePhase, "error_code": errorCode,
+			"error":             errorMessage,
+			"model_provider_id": request.ModelProviderID, "model": request.Model,
+			"requested_reasoning_effort": request.RequestedReasoningEffort,
+		})
+		return steeringExecution{state: owner.SteeringFailed, reason: steerReasonFromFailureCode(errorCode), message: errorMessage}
+	}
+	payload := result.Payload()
+	payload["outcome"] = "applied"
+	payload["phase"] = spec.vocabulary.appliedPhase
+	// The provider result is a structured Runtime turn result, not a
+	// transcript message. Conversation contains only explicit user/runtime
+	// messages; provider control/result data stays on the owner Timeline.
+	protocol.emit(spec.vocabulary.appliedKind, payload)
+	return steeringExecution{state: owner.SteeringApplied, result: result.Payload()}
+}

--- a/internal/daemon/steer_executor_turn_kind_test.go
+++ b/internal/daemon/steer_executor_turn_kind_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"pentest/internal/project"
+	"pentest/internal/runtime"
+	"pentest/internal/runtimeplugin"
+	"pentest/internal/task"
+)
+
+// A native steer delivery is a Harness Control Turn. The executor assigns the
+// kind from request lineage for both owners so a steer can never be
+// lineage-classified as operator work (ADR 0018).
+func TestNativeSteerSendsHarnessControlTurnKind(t *testing.T) {
+	server, err := NewServer(Config{DBPath: filepath.Join(t.TempDir(), "pentest.db"), DisableBuiltinSkills: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	projectRecord, err := server.projects.Create("Project", "", project.Scope{}, project.Defaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := createTestRuntimeProfile(t, server)
+	created, err := server.tasks.Create(task.CreateRequest{ProjectID: projectRecord.ID, Type: task.TypePentest, Goal: "inspect target", RuntimeProfileID: profile.ID, Runner: task.RunnerSandbox})
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation, err := server.tasks.CreateContinuation(created.ID, profile.ID, "fake", task.RunnerSandbox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateStatus(created.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(continuation.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID:    "session-1",
+		ActiveTurnID: "turn-1",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InterruptThenReplace: true},
+	})
+	if err := server.BindProviderSession(created.ID, session); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectRecord.ID+"/tasks/"+created.ID+"/steer", bytes.NewBufferString(`{"request_id":"req-kind","message":"focus on admin"}`))
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("steer status = %d, body=%s", response.Code, response.Body.String())
+	}
+
+	waitForProviderRequests(t, session, 1)
+	for _, sent := range session.LastRequests() {
+		if sent.TurnKind != runtime.RuntimeTurnKindControl {
+			t.Fatalf("steer request %q TurnKind = %q, want %q", sent.RequestID, sent.TurnKind, runtime.RuntimeTurnKindControl)
+		}
+	}
+}

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"pentest/internal/adapters"
@@ -905,14 +904,9 @@ func (server *Server) buildTaskLaunchPlanWithBinding(created task.Task, goal str
 		// bridge and therefore needs a bare "pi" token in docker create argv.
 		// Skip the wrapper whenever this launch will open a provider session.
 		if profile.Provider == runtimeprofile.ProviderPi {
-			usePersistentSession := server.providerSessionFactory != nil &&
-				supportsPersistentProviderSession(created.Runner, profile.Provider)
-			if !usePersistentSession {
-				wrapped, err := runner.WrapSandboxPiCommand(runtimeCommand, launchProfile.Fields.Env)
-				if err != nil {
-					return taskLaunchPlan{}, err
-				}
-				sandboxRuntime = wrapped
+			sandboxRuntime, err = server.sandboxPiRuntimeCommand(runtimeCommand, launchProfile, created.Runner)
+			if err != nil {
+				return taskLaunchPlan{}, err
 			}
 		}
 		var readOnlyTaskFiles, readOnlyTaskDirs []string
@@ -1020,50 +1014,13 @@ func (server *Server) buildTaskLaunchPlanWithBinding(created task.Task, goal str
 	}
 
 	// Pi writes its real-time progress to a session jsonl file instead of
-	// stdout, so a sandboxed Pi task's timeline is empty until it exits. Wrap
-	// the adapter with a session-file tailer that re-emits appended lines as
-	// runtime_output events the transcript parser already understands.
-	if sandbox && profile.Provider == runtimeprofile.ProviderPi {
-		sessionDir := filepath.Join(layout.ProviderHome, "agent", "sessions")
-		adapter = runtime.NewPiSessionTailAdapter(adapter, sessionDir)
-	}
+	// stdout, so a sandboxed Pi task's timeline is empty until it exits. The
+	// shared tailer re-emits appended lines as runtime_output events the
+	// transcript parser already understands.
+	adapter = withPiSessionTail(adapter, sandbox, profile.Provider, layout)
 
-	var metadata func() (runtime.NativeSessionMetadata, error)
-	if sandbox || profile.Provider == runtimeprofile.ProviderCodex || profile.Provider == runtimeprofile.ProviderPi || profile.Provider == runtimeprofile.ProviderHermes {
-		metadata = func() (runtime.NativeSessionMetadata, error) {
-			var collected runtime.NativeSessionMetadata
-			if containerIDFile != "" {
-				containerID, err := runtime.ReadContainerIDFile(containerIDFile)
-				if err != nil && !os.IsNotExist(err) {
-					return runtime.NativeSessionMetadata{}, err
-				}
-				collected.ContainerID = containerID
-			}
-			switch profile.Provider {
-			case runtimeprofile.ProviderCodex:
-				session, err := runtime.DiscoverCodexSession(layout.ProviderHome)
-				if err != nil {
-					return runtime.NativeSessionMetadata{}, err
-				}
-				collected.NativeSessionID = session.NativeSessionID
-				collected.NativeSessionPath = session.NativeSessionPath
-			case runtimeprofile.ProviderPi:
-				session, err := runtime.DiscoverPiSession(layout.ProviderHome)
-				if err != nil {
-					return runtime.NativeSessionMetadata{}, err
-				}
-				collected.NativeSessionID = session.NativeSessionID
-				collected.NativeSessionPath = session.NativeSessionPath
-			}
-			return collected, nil
-		}
-	}
-	var stopConfirmation runtime.StopConfirmation
-	if containerIDFile != "" {
-		// Match the launch-selected CLI (podman/docker), not only the daemon flag.
-		containerCLI := task.ResolveContainerCLI(created.RunControls.ContainerCLI, server.containerCLI)
-		stopConfirmation = runtime.DockerContainerStopConfirmation(containerCLI, containerIDFile)
-	}
+	metadata := providerNativeSessionMetadata(sandbox, profile.Provider, layout, containerIDFile)
+	stopConfirmation := dockerStopConfirmation(created.RunControls.ContainerCLI, server.containerCLI, containerIDFile)
 
 	return taskLaunchPlan{
 		Adapter:                     adapter,
@@ -3325,76 +3282,50 @@ func (server *Server) taskConclusionSettlement(found task.Task) providerControlS
 // correct Runtime Continuation. The caller owns Task control for the whole
 // operation. The returned execution is the durable terminal outcome.
 func (server *Server) executeNativeSteerOperation(ctx context.Context, found task.Task, session runtime.ProviderSession, mode runtime.ProviderSessionMode, operation nativeSteerOperationFunc, providerRequest runtime.ProviderSessionRequest, conversation task.Event, continuationID string, freshContinuation bool) steeringExecution {
-	var continuationMu sync.Mutex
-	var continuationTransitionErr error
-	emit := func(kind task.EventKind, payload task.EventPayload) {
-		payload["conversation_event_id"] = conversation.ID
-		continuationMu.Lock()
-		currentContinuationID := continuationID
-		if currentContinuationID != "" {
-			_, _ = server.tasks.AppendContinuationEvent(found.ID, currentContinuationID, kind, payload)
-		}
-		if mode == runtime.ProviderSessionModeInterruptThenReplace && kind == task.EventKindSteering && payload["outcome"] == "settled" && currentContinuationID != "" && !freshContinuation {
-			if transitionErr := server.advanceNativeSteerContinuation(currentContinuationID, session, &continuationID); transitionErr != nil {
-				continuationTransitionErr = transitionErr
-				failure := task.EventPayload{
-					"request_id": payload["request_id"], "session_id": payload["session_id"],
-					"mode": string(mode), "outcome": "failed", "phase": "replacement_continuation_failed",
-					"error_code": "continuation_transition_failed",
-				}
-				_, _ = server.tasks.AppendContinuationEvent(found.ID, currentContinuationID, task.EventKindSteering, failure)
+	return runNativeSteerTurn(ctx, steerExecutionSpec{
+		operation:             operation,
+		request:               providerRequest,
+		mode:                  mode,
+		providerSessionID:     session.SessionID(),
+		initialContinuationID: continuationID,
+		advanceOnSettled:      !freshContinuation,
+		vocabulary:            taskSteerEventVocabulary,
+		persistEvent: func(current string, kind task.EventKind, payload task.EventPayload) {
+			payload["conversation_event_id"] = conversation.ID
+			if current != "" {
+				_, _ = server.tasks.AppendContinuationEvent(found.ID, current, kind, payload)
 			}
-		}
-		continuationMu.Unlock()
-		if currentContinuationID == "" {
+		},
+		persistOwnerEvent: func(kind task.EventKind, payload task.EventPayload) {
+			payload["conversation_event_id"] = conversation.ID
 			_, _ = server.tasks.AppendEvent(found.ID, kind, payload)
-		}
-	}
-	result, operationErr := operation(ctx, providerRequest, emit)
-	if operationErr != nil {
-		errorCode, errorMessage := nativeSteerFailurePresentation(operationErr)
-		if errors.Is(operationErr, context.Canceled) || errors.Is(operationErr, context.DeadlineExceeded) {
-			// Post-fence with no provider outcome: delivery is ambiguous. The
-			// request is never replayed automatically; it settles
-			// action_required with a reason-specific recovery path.
-			ambiguous := task.EventPayload{
-				"request_id": providerRequest.RequestID, "session_id": session.SessionID(), "mode": string(mode),
-				"outcome": "action_required", "phase": "steering_action_required",
-				"error_code": string(owner.SteeringReasonDeliveryAmbiguous), "error": errorMessage,
-				"model_provider_id": providerRequest.ModelProviderID, "model": providerRequest.Model,
-				"requested_reasoning_effort": providerRequest.RequestedReasoningEffort,
+		},
+		advance: func(current string) (string, error) {
+			next := current
+			if err := server.advanceNativeSteerContinuation(current, session, &next); err != nil {
+				return "", err
 			}
-			emit(task.EventKindSteering, ambiguous)
-			return steeringExecution{state: owner.SteeringActionRequired, reason: owner.SteeringReasonDeliveryAmbiguous, message: errorMessage}
-		}
-		// Public Task Events carry only redacted, stable failure fields.
-		// Raw provider text stays out of the conversation surface.
-		failure := task.EventPayload{
-			"request_id": providerRequest.RequestID, "session_id": session.SessionID(), "mode": string(mode),
-			"outcome": "failed", "phase": "steering_failed", "error_code": errorCode,
-			"error":             errorMessage,
-			"model_provider_id": providerRequest.ModelProviderID, "model": providerRequest.Model,
-			"requested_reasoning_effort": providerRequest.RequestedReasoningEffort,
-		}
-		emit(task.EventKindSteering, failure)
-		return steeringExecution{state: owner.SteeringFailed, reason: steerReasonFromFailureCode(errorCode), message: errorMessage}
-	}
-	continuationMu.Lock()
-	transitionErr := continuationTransitionErr
-	continuationMu.Unlock()
-	if transitionErr != nil {
-		_ = server.closeProviderSession(found.ID)
-		if current, _ := server.tasks.ActiveContinuation(found.ID); current != nil {
-			_, _ = server.tasks.UpdateContinuationStatus(current.ID, task.StatusFailed)
-		}
-		_, _ = server.tasks.UpdateStatus(found.ID, task.StatusFailed)
-		return steeringExecution{state: owner.SteeringFailed, reason: owner.SteeringReasonContinuationUnavailable, message: transitionErr.Error(), failOwner: true}
-	}
-	payload := result.Payload()
-	payload["outcome"] = "applied"
-	payload["phase"] = "steering_applied"
-	emit(task.EventKindSteering, payload)
-	return steeringExecution{state: owner.SteeringApplied, result: result.Payload()}
+			return next, nil
+		},
+		onAdvanceSettled: func(current, _ string, advanceErr error) {
+			if advanceErr == nil {
+				return
+			}
+			_, _ = server.tasks.AppendContinuationEvent(found.ID, current, task.EventKindSteering, task.EventPayload{
+				"request_id": providerRequest.RequestID, "session_id": session.SessionID(),
+				"mode": string(mode), "outcome": "failed", "phase": "replacement_continuation_failed",
+				"error_code": "continuation_transition_failed",
+			})
+		},
+		failClosed: func(string) {
+			_ = server.closeProviderSession(found.ID)
+			if current, _ := server.tasks.ActiveContinuation(found.ID); current != nil {
+				_, _ = server.tasks.UpdateContinuationStatus(current.ID, task.StatusFailed)
+			}
+			_, _ = server.tasks.UpdateStatus(found.ID, task.StatusFailed)
+		},
+		failOwnerExecution: true,
+	})
 }
 
 // steerReasonFromFailureCode maps the redacted provider failure presentation
@@ -3451,13 +3382,7 @@ func (server *Server) handleProviderPermissionResponse(response http.ResponseWri
 		writeError(response, http.StatusBadRequest, "permission decision must be allow or deny")
 		return
 	}
-	input.RequestID = strings.TrimSpace(input.RequestID)
-	if input.RequestID == "" {
-		input.RequestID = strings.TrimSpace(request.Header.Get("Idempotency-Key"))
-	}
-	if input.RequestID == "" {
-		input.RequestID = "permission-" + permissionID + "-" + input.Decision
-	}
+	derivePermissionResponseRequestID(request, &input)
 
 	events, err := server.tasks.Events(found.ID)
 	if err != nil {
@@ -3470,10 +3395,7 @@ func (server *Server) handleProviderPermissionResponse(response http.ResponseWri
 		return
 	}
 	if priorOutcome != "" {
-		writeJSON(response, http.StatusAccepted, map[string]any{
-			"request_id": input.RequestID, "permission_request_id": permissionID,
-			"session_id": session.SessionID(), "decision": input.Decision, "outcome": priorOutcome,
-		})
+		writePermissionResponseAccepted(response, input, permissionID, session.SessionID(), priorOutcome)
 		return
 	}
 	if !pending {
@@ -3502,11 +3424,7 @@ func (server *Server) handleProviderPermissionResponse(response http.ResponseWri
 	if active != nil {
 		continuationID = active.ID
 	}
-	requestedPayload := task.EventPayload{
-		"phase": "provider_permission_response_requested", "mode": string(runtime.ProviderSessionModePermissionResponse),
-		"outcome": "pending", "request_id": input.RequestID, "permission_request_id": permissionID,
-		"permission_decision": input.Decision, "session_id": session.SessionID(),
-	}
+	requestedPayload := permissionResponseRequestedPayload(input, permissionID, session.SessionID())
 	if continuationID != "" {
 		_, err = server.tasks.AppendContinuationEvent(found.ID, continuationID, task.EventKindLifecycle, requestedPayload)
 	} else {
@@ -3518,91 +3436,21 @@ func (server *Server) handleProviderPermissionResponse(response http.ResponseWri
 		return
 	}
 	taskCtx := server.providerTaskContext(found.ID)
-	emit := func(kind task.EventKind, payload task.EventPayload) {
-		redacted := task.EventPayload{}
-		// Fixed correlation allowlist shared with the Session provider event
-		// projection (provider_session_control.go): raw protocol payload never
-		// reaches the Task Conversation.
-		for _, key := range []string{"provider", "request_id", "session_id", "provider_turn_id", "mode", "outcome", "permission_request_id", "permission_decision", "error_code", "phase"} {
-			if value, ok := payload[key]; ok {
-				redacted[key] = value
-			}
-		}
-		if redacted["request_id"] == nil {
-			redacted["request_id"] = input.RequestID
-		}
-		redacted["permission_request_id"] = permissionID
-		if redacted["mode"] == nil {
-			redacted["mode"] = string(runtime.ProviderSessionModePermissionResponse)
-		}
-		switch redacted["outcome"] {
-		case "requested":
-			redacted["phase"] = "provider_permission_response_requested"
-		case "acknowledged":
-			redacted["phase"] = "provider_permission_response_acknowledged"
-		case "failed":
-			redacted["phase"] = "provider_permission_response_failed"
-		}
+	persistLadderEvent := func(kind task.EventKind, payload task.EventPayload) {
 		if continuationID != "" {
-			_, _ = server.tasks.AppendContinuationEvent(found.ID, continuationID, kind, redacted)
+			_, _ = server.tasks.AppendContinuationEvent(found.ID, continuationID, kind, payload)
 		} else {
-			_, _ = server.tasks.AppendEvent(found.ID, kind, redacted)
+			_, _ = server.tasks.AppendEvent(found.ID, kind, payload)
 		}
 	}
+	emit := newPermissionResponseEmit(input, permissionID, persistLadderEvent)
 	go func() {
 		defer server.releaseProviderTaskControl(found.ID)
 		ctx, cancel := context.WithTimeout(taskCtx, 30*time.Second)
 		defer cancel()
-		result, operationErr := session.RespondPermission(ctx, runtime.ProviderSessionRequest{
-			RequestID: input.RequestID, PermissionRequestID: permissionID, PermissionDecision: input.Decision,
-		}, emit)
-		if operationErr != nil {
-			emit(task.EventKindLifecycle, task.EventPayload{"outcome": "failed", "phase": "provider_permission_response_failed", "error_code": permissionResponseErrorCode(operationErr)})
-			return
-		}
-		payload := result.Payload()
-		payload["phase"] = "provider_permission_response_applied"
-		payload["outcome"] = "applied"
-		payload["permission_request_id"] = permissionID
-		if continuationID != "" {
-			_, _ = server.tasks.AppendContinuationEvent(found.ID, continuationID, task.EventKindLifecycle, payload)
-		} else {
-			_, _ = server.tasks.AppendEvent(found.ID, task.EventKindLifecycle, payload)
-		}
+		deliverPermissionResponse(ctx, session, input, permissionID, emit, persistLadderEvent)
 	}()
-	writeJSON(response, http.StatusAccepted, map[string]any{
-		"request_id": input.RequestID, "permission_request_id": permissionID,
-		"session_id": session.SessionID(), "decision": input.Decision, "outcome": "accepted",
-	})
-}
-
-func normalizePermissionDecision(decision string) string {
-	switch strings.ToLower(strings.TrimSpace(decision)) {
-	case "allow", "approve", "approved", "yes":
-		return "allow"
-	case "deny", "reject", "rejected", "no":
-		return "deny"
-	default:
-		return ""
-	}
-}
-
-// permissionResponseErrorCode maps a provider permission-response failure to
-// the stable error_code both owner kinds persist, so task and session
-// permission handling share one classification.
-func permissionResponseErrorCode(operationErr error) string {
-	switch {
-	case errors.Is(operationErr, context.DeadlineExceeded):
-		return "timeout"
-	case errors.Is(operationErr, context.Canceled):
-		return "server_closing"
-	case errors.Is(operationErr, runtime.ErrProviderSessionClosed):
-		return "session_closed"
-	case errors.Is(operationErr, runtime.ErrProviderSessionControlConflict):
-		return "control_conflict"
-	default:
-		return "provider_rejected"
-	}
+	writePermissionResponseAccepted(response, input, permissionID, session.SessionID(), "accepted")
 }
 
 // providerPermissionStatus scans either owner's event stream for the state of

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1454,8 +1454,20 @@ func (s *Service) UpdateContinuationStatus(id string, status RuntimeStatus) (Con
 	if err != nil {
 		return Continuation{}, fmt.Errorf("update Session continuation status: %w", err)
 	}
-	if changed, _ := result.RowsAffected(); changed != 1 {
-		return s.Continuation(id)
+	// A lost compare-and-swap race must surface the conflict so the caller can
+	// distinguish its own transition from a concurrent observer's write (the
+	// same contract as the Task twin).
+	if changed, err := result.RowsAffected(); err != nil {
+		return Continuation{}, fmt.Errorf("count Session continuation status update: %w", err)
+	} else if changed != 1 {
+		current, readErr := s.Continuation(id)
+		if readErr != nil {
+			return Continuation{}, readErr
+		}
+		if current.Status == status {
+			return current, nil
+		}
+		return current, ErrContinuationStatusConflict
 	}
 	found.Status, found.UpdatedAt = status, now
 	if isTerminalRuntimeStatus(status) {

--- a/internal/session/session_continuation_race_test.go
+++ b/internal/session/session_continuation_race_test.go
@@ -1,0 +1,149 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"modernc.org/sqlite"
+
+	"pentest/internal/store"
+)
+
+// The racing driver inserts one status write between a caller's pre-read and
+// its guarded UPDATE, which is the exact interleaving of a lost
+// compare-and-swap race between two continuation observers.
+var (
+	raceDriverOnce sync.Once
+	raceMu         sync.Mutex
+	raceSabotage   *raceUpdate
+)
+
+type raceUpdate struct {
+	query string
+	args  []driver.NamedValue
+}
+
+type racingDriver struct{ inner driver.Driver }
+
+func (d *racingDriver) Open(name string) (driver.Conn, error) {
+	conn, err := d.inner.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &racingConn{Conn: conn}, nil
+}
+
+type racingConn struct{ driver.Conn }
+
+func (c *racingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	raceMu.Lock()
+	sabotage := raceSabotage
+	raceSabotage = nil
+	raceMu.Unlock()
+	if sabotage != nil && strings.HasPrefix(query, "UPDATE session_continuations SET status=") {
+		if _, err := c.exec(ctx, sabotage.query, sabotage.args); err != nil {
+			return nil, err
+		}
+	}
+	return c.exec(ctx, query, args)
+}
+
+func (c *racingConn) exec(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	type execer interface {
+		ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error)
+	}
+	inner, ok := c.Conn.(execer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return inner.ExecContext(ctx, query, args)
+}
+
+// armContinuationStatusRace changes one continuation's status through the
+// wrapped connection immediately before the next guarded status UPDATE runs.
+func armContinuationStatusRace(t *testing.T, status, continuationID string) {
+	t.Helper()
+	raceMu.Lock()
+	defer raceMu.Unlock()
+	raceSabotage = &raceUpdate{
+		query: "UPDATE session_continuations SET status='" + status + "' WHERE id=?",
+		args:  []driver.NamedValue{{Value: continuationID, Ordinal: 1}},
+	}
+}
+
+func openRacingSessionService(t *testing.T, path, workdir string) *Service {
+	t.Helper()
+	raceDriverOnce.Do(func() {
+		sql.Register("sqlite-session-race", &racingDriver{inner: &sqlite.Driver{}})
+	})
+	db, err := sql.Open("sqlite-session-race", path)
+	if err != nil {
+		t.Fatalf("open racing store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewService(&store.DB{DB: db}, workdir)
+}
+
+func newRunningRaceContinuation(t *testing.T) (*Service, Continuation) {
+	t.Helper()
+	dataRoot := t.TempDir()
+	path := filepath.Join(dataRoot, "pentest.db")
+	seed, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("open seed store: %v", err)
+	}
+	seedService := NewService(seed, filepath.Join(dataRoot, "workdirs"))
+	created, err := seedService.Create(CreateRequest{Input: "probe"})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	continuation, err := seedService.CreateContinuation(created.ID, "profile", "fake", RunnerSandbox, map[string]any{})
+	if err != nil {
+		t.Fatalf("create continuation: %v", err)
+	}
+	if _, err := seedService.UpdateContinuationStatus(continuation.ID, RuntimeStatusRunning); err != nil {
+		t.Fatalf("start continuation: %v", err)
+	}
+	workdir := seedService.workdirRoot
+	if err := seed.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+	return openRacingSessionService(t, path, workdir), continuation
+}
+
+// A lost race must surface the conflict: the caller learns another observer
+// changed the continuation, instead of silently receiving that newer state as
+// its own successful transition (parity with the Task twin).
+func TestUpdateContinuationStatusReportsLostRaceConflict(t *testing.T) {
+	service, continuation := newRunningRaceContinuation(t)
+
+	armContinuationStatusRace(t, string(RuntimeStatusCompleted), continuation.ID)
+	current, err := service.UpdateContinuationStatus(continuation.ID, RuntimeStatusStopped)
+	if !errors.Is(err, ErrContinuationStatusConflict) {
+		t.Fatalf("lost race error = %v, want ErrContinuationStatusConflict", err)
+	}
+	if current.Status != RuntimeStatusCompleted {
+		t.Fatalf("lost race returned status %q, want the winning status %q", current.Status, RuntimeStatusCompleted)
+	}
+}
+
+// A lost race to the same requested status stays idempotent, matching the
+// pre-check terminal path.
+func TestUpdateContinuationStatusLostRaceToSameStatusIsIdempotent(t *testing.T) {
+	service, continuation := newRunningRaceContinuation(t)
+
+	armContinuationStatusRace(t, string(RuntimeStatusStopped), continuation.ID)
+	current, err := service.UpdateContinuationStatus(continuation.ID, RuntimeStatusStopped)
+	if err != nil {
+		t.Fatalf("same-status lost race error = %v, want nil", err)
+	}
+	if current.Status != RuntimeStatusStopped {
+		t.Fatalf("same-status lost race status = %q, want %q", current.Status, RuntimeStatusStopped)
+	}
+}

--- a/internal/task/task_continuation_race_test.go
+++ b/internal/task/task_continuation_race_test.go
@@ -1,0 +1,129 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"modernc.org/sqlite"
+
+	"pentest/internal/project"
+	"pentest/internal/store"
+)
+
+// The racing driver inserts one status write between a caller's pre-read and
+// its guarded UPDATE, which is the exact interleaving of a lost
+// compare-and-swap race between two continuation observers. Task and Session
+// must keep the same contract here (ADR 0020): a lost race surfaces
+// ErrContinuationStatusConflict unless the winner wrote the requested status.
+var (
+	taskRaceDriverOnce sync.Once
+	taskRaceMu         sync.Mutex
+	taskRaceSabotage   *taskRaceUpdate
+)
+
+type taskRaceUpdate struct {
+	query string
+	args  []driver.NamedValue
+}
+
+type taskRacingDriver struct{ inner driver.Driver }
+
+func (d *taskRacingDriver) Open(name string) (driver.Conn, error) {
+	conn, err := d.inner.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &taskRacingConn{Conn: conn}, nil
+}
+
+type taskRacingConn struct{ driver.Conn }
+
+func (c *taskRacingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	taskRaceMu.Lock()
+	sabotage := taskRaceSabotage
+	taskRaceSabotage = nil
+	taskRaceMu.Unlock()
+	if sabotage != nil && strings.HasPrefix(query, "UPDATE task_continuations SET status = ") {
+		if _, err := c.exec(ctx, sabotage.query, sabotage.args); err != nil {
+			return nil, err
+		}
+	}
+	return c.exec(ctx, query, args)
+}
+
+func (c *taskRacingConn) exec(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	type execer interface {
+		ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error)
+	}
+	inner, ok := c.Conn.(execer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return inner.ExecContext(ctx, query, args)
+}
+
+func armTaskContinuationStatusRace(t *testing.T, status, continuationID string) {
+	t.Helper()
+	taskRaceMu.Lock()
+	defer taskRaceMu.Unlock()
+	taskRaceSabotage = &taskRaceUpdate{
+		query: "UPDATE task_continuations SET status = '" + status + "' WHERE id = ?",
+		args:  []driver.NamedValue{{Value: continuationID, Ordinal: 1}},
+	}
+}
+
+// TestLostContinuationStatusRaceSurfacesConflict locks the Task twin of the
+// lost-race contract asserted for Sessions.
+func TestLostContinuationStatusRaceSurfacesConflict(t *testing.T) {
+	dataRoot := t.TempDir()
+	path := filepath.Join(dataRoot, "pentest.db")
+	seed, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("open seed store: %v", err)
+	}
+	projects := project.NewService(seed)
+	svc := NewService(seed, projects)
+	createdProject, err := projects.Create("Race parity", "", project.Scope{}, project.Defaults{})
+	if err != nil {
+		t.Fatalf("create Project: %v", err)
+	}
+	created, err := svc.Create(CreateRequest{ProjectID: createdProject.ID, Type: TypePentest, Goal: "race", Runner: RunnerSandbox})
+	if err != nil {
+		t.Fatalf("create Task: %v", err)
+	}
+	continuation, err := svc.CreateContinuation(created.ID, "profile", "codex", RunnerSandbox)
+	if err != nil {
+		t.Fatalf("create Continuation: %v", err)
+	}
+	if _, err := svc.UpdateContinuationStatus(continuation.ID, StatusRunning); err != nil {
+		t.Fatalf("start Continuation: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+
+	taskRaceDriverOnce.Do(func() {
+		sql.Register("sqlite-task-race", &taskRacingDriver{inner: &sqlite.Driver{}})
+	})
+	racing, err := sql.Open("sqlite-task-race", path)
+	if err != nil {
+		t.Fatalf("open racing store: %v", err)
+	}
+	defer func() { _ = racing.Close() }()
+	racingService := NewService(&store.DB{DB: racing}, project.NewService(&store.DB{DB: racing}))
+
+	armTaskContinuationStatusRace(t, string(StatusCompleted), continuation.ID)
+	current, err := racingService.UpdateContinuationStatus(continuation.ID, StatusStopped)
+	if !errors.Is(err, ErrContinuationStatusConflict) {
+		t.Fatalf("lost race error = %v, want ErrContinuationStatusConflict", err)
+	}
+	if current.Status != StatusCompleted {
+		t.Fatalf("lost race returned status %q, want the winning status %q", current.Status, StatusCompleted)
+	}
+}


### PR DESCRIPTION
Consolidate the hand-copied Task and Session daemon pipelines into owner-neutral kernels with thin owner adapters, following the pattern already proven by steering.go and conclusion.Engine (ADR 0020). Aggregates and tables stay separate; no repository interfaces were introduced (ADR 0017).

Drift fixes, each locked by new tests on both owners:

- Prompt drift: the Session conclude directive lacked the Task anti-fabrication rules and its repair directive lacked the produced-targets fallback and example JSON. One directive builder with owner-wording profiles now serves both; the Task text is unchanged.
- Race drift: session.Service.UpdateContinuationStatus swallowed the conflict signal when its guarded UPDATE lost the compare-and-swap race and discarded the RowsAffected error. It now mirrors the Task twin: idempotent success on same status, ErrContinuationStatusConflict otherwise. Deterministic lost-race tests cover both owners through a wrapped SQLite driver.
- Turn-kind drift: the Task native steer never assigned the Harness control Turn kind, so steer turns were lineage-classified as work turns (ADR 0018 violation). The shared executor assigns control from request lineage for both owners.

Shared kernels added:

- steer_executor.go: one steer delivery protocol (emit/advance mutex, fail-closed transition, ambiguous-delivery classification) used by both steer executors and the Session conversation-turn path.
- permission_ladder.go: shared permission-response decision normalization, request-id derivation, redacting emit sink, and failure classification.
- launch_plan_tail.go: shared Pi bootstrap-wrapper rule, Pi session tailer, native-session metadata collector, and stop confirmation.
- conclusion_retry_http.go: shared Blackboard-conclusion retry ladder.

The launch-plan middles stay per owner: they encode genuinely different concerns (Project binding, Scope, captured replay).