### PR TITLE
fix(credential): Enable credential edit

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1062,7 +1062,7 @@ _Avoid_: transcript, export, source of truth
 - Structured Profile, launch, and **Runtime Turn Selection** fields are authoritative for **Model Provider**, model, and **Reasoning Effort**.
 - Non-conflicting **Runtime Custom Arguments** continue to apply to both **Sandbox Runner** and **Host Runner** launches, including **Task-Scoped Persistent Runtime** bridges.
 - Editing a **Model Provider** does not change existing **Task Runtime Configurations** or an active **Runtime Continuation**.
-- A **Model Provider** cannot be deleted while any **Runtime Profile** still references it.
+- A **Model Provider** cannot be deleted while any **Runtime Profile** still references it, unless the operator explicitly confirms a deletion that clears the **Model Provider** reference and its pinned **Model Provider Protocol** from every referencing **Runtime Profile**.
 - Historical task views read captured **Task Runtime Configurations** and **Model Provider Snapshots**, not live **Runtime Profiles** or live **Model Providers**.
 - A runtime-profile switch inside a **Task** creates a new **Task Runtime Configuration Version** for the next **Runtime Continuation**.
 - A runtime-profile switch re-resolves the selected **Model Provider** and captures a new **Model Provider Snapshot** for the new **Task Runtime Configuration Version**.
@@ -1446,7 +1446,7 @@ _Avoid_: transcript, export, source of truth
 - Runtime-profile switching does not create a new **Task**; resolved: it creates a new **Runtime Continuation** with a new **Task Runtime Configuration Version**.
 - Runtime-profile switching does not reuse the prior **Model Provider Snapshot**; resolved: each new task runtime configuration version captures its own resolved model provider values.
 - **Model Provider** edits are not live task mutation; resolved: active continuations keep the **Model Provider Snapshot** captured at launch or continuation start.
-- **Model Provider** deletion is not silent profile breakage; resolved: deletion is blocked while any runtime profile references the provider.
+- **Model Provider** deletion is not silent profile breakage; resolved: deletion is blocked by default and names the referencing runtime profiles; an explicit operator-confirmed deletion clears the provider reference and its pinned protocol from every referencing runtime profile in the same action.
 - Historical task inspection does not require live profile or provider records; resolved: task history uses captured runtime configuration snapshots.
 - **Project Defaults** are not copied **Runtime Profiles**; resolved: they select defaults while profiles remain global.
 - **Project Dashboard** is not a chat-first view; resolved: the project home prioritizes scope, task runs, blackboard state, findings, and evidence.

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -123,8 +123,11 @@ func (s *Service) Upsert(credentialRef string, scope Scope, scopeID string, sour
 	if scope == ScopeGlobal {
 		scopeID = ""
 	}
-	if !disabled {
-		if source.Kind == SourceLiteral && source.Value == ConfiguredSourceSentinel {
+	// The sentinel means "keep the stored literal" regardless of the disabled
+	// flag; handling it before the disabled branch stops a disabled upsert from
+	// persisting the sentinel string itself as the secret.
+	if !disabled || source.Kind == SourceLiteral {
+		if source.Value == ConfiguredSourceSentinel {
 			existing, err := s.findOptional(credentialRef, scope, scopeID)
 			if err != nil {
 				return Binding{}, err
@@ -134,6 +137,8 @@ func (s *Service) Upsert(credentialRef string, scope Scope, scopeID string, sour
 			}
 			source.Value = existing.Source.Value
 		}
+	}
+	if !disabled {
 		if err := validateSource(source); err != nil {
 			return Binding{}, err
 		}

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -273,6 +273,27 @@ func TestLiteralBindingIsSanitizedAndConfiguredSentinelPreservesSecret(t *testin
 	}
 }
 
+func TestConfiguredSentinelPreservesSecretOnDisabledUpsert(t *testing.T) {
+	service := newTestService(t)
+
+	if _, err := service.Upsert("MIMO_API_KEY", credential.ScopeGlobal, "", credential.Source{Kind: credential.SourceLiteral, Value: "sk-original"}, false); err != nil {
+		t.Fatalf("upsert literal: %v", err)
+	}
+
+	// Editing a disabled binding must not persist the sentinel string as the
+	// stored secret.
+	updated, err := service.Upsert("MIMO_API_KEY", credential.ScopeGlobal, "", credential.Source{Kind: credential.SourceLiteral, Value: credential.ConfiguredSourceSentinel}, true)
+	if err != nil {
+		t.Fatalf("preserve configured literal on disabled upsert: %v", err)
+	}
+	if updated.Disabled != true {
+		t.Fatalf("expected binding to stay disabled")
+	}
+	if updated.Source.Value != "sk-original" {
+		t.Fatalf("expected original secret preserved, got %q", updated.Source.Value)
+	}
+}
+
 func TestListForProjectReturnsOnlyThatProject(t *testing.T) {
 	service := newTestService(t)
 

--- a/internal/daemon/accepted_steering_durable_test.go
+++ b/internal/daemon/accepted_steering_durable_test.go
@@ -354,7 +354,8 @@ func TestAcceptedSteeringPreFenceRestartResumesDispatchAfterResume(t *testing.T)
 	factory := &assistedConclusionSessionFactory{session: freshSession, adapter: adapter, support: true}
 	server2, err := NewServer(Config{
 		DBPath: filepath.Join(root, "pentest.db"), RuntimeRoot: filepath.Join(root, "runs"),
-		DisableBuiltinSkills: true, ProviderSessionFactory: factory,
+		SandboxImage: "cyberpenda:test", DisableBuiltinSkills: true, ProviderSessionFactory: factory,
+		ContainerCLI: filepath.Join(root, "fake-docker"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/assisted_conclusion_test.go
+++ b/internal/daemon/assisted_conclusion_test.go
@@ -2468,9 +2468,14 @@ func newAssistedConclusionFixtureAtWithDecorator(t *testing.T, root string, repo
 	}
 	adapter := runtime.NewProviderSessionRunAdapter(session, make(chan struct{}))
 	factory := &assistedConclusionSessionFactory{session: session, adapter: adapter, support: reporterSupport}
+	dockerCLI := filepath.Join(root, "fake-docker")
+	if err := writeExecutable(dockerCLI, "#!/bin/sh\necho ok\n"); err != nil {
+		t.Fatal(err)
+	}
 	server, err := NewServer(Config{
 		DBPath: filepath.Join(root, "pentest.db"), RuntimeRoot: filepath.Join(root, "runs"),
 		SandboxImage: "cyberpenda:test", DisableBuiltinSkills: true, ProviderSessionFactory: factory,
+		ContainerCLI: dockerCLI,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/modelprovider_handlers.go
+++ b/internal/daemon/modelprovider_handlers.go
@@ -85,12 +85,38 @@ func (server *Server) handleUpdateModelProvider(response http.ResponseWriter, re
 }
 
 func (server *Server) handleDeleteModelProvider(response http.ResponseWriter, request *http.Request) {
-	err := server.modelProviders.Delete(request.PathValue("id"))
+	var err error
+	if request.URL.Query().Get("detach") == "true" {
+		err = server.modelProviders.DeleteDetaching(request.PathValue("id"))
+	} else {
+		err = server.modelProviders.Delete(request.PathValue("id"))
+	}
 	if err != nil {
+		if errors.Is(err, modelprovider.ErrInUse) {
+			server.writeModelProviderInUse(response, request.PathValue("id"))
+			return
+		}
 		writeModelProviderError(response, err)
 		return
 	}
 	response.WriteHeader(http.StatusNoContent)
+}
+
+// writeModelProviderInUse answers a blocked delete with the referencing
+// profile names so the client can offer an explicit detach delete.
+func (server *Server) writeModelProviderInUse(response http.ResponseWriter, id string) {
+	profiles, err := server.modelProviders.ReferencingProfiles(id)
+	if err != nil {
+		writeError(response, http.StatusConflict, modelprovider.ErrInUse.Error())
+		return
+	}
+	writeJSON(response, http.StatusConflict, struct {
+		Error    string   `json:"error"`
+		Profiles []string `json:"profiles"`
+	}{
+		Error:    modelprovider.ErrInUse.Error(),
+		Profiles: profiles,
+	})
 }
 
 func (server *Server) handleRefreshModelProviderModels(response http.ResponseWriter, request *http.Request) {

--- a/internal/daemon/modelprovider_test.go
+++ b/internal/daemon/modelprovider_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -469,5 +470,79 @@ func TestModelProviderAPIRefreshCancelsUpstreamWithRequest(t *testing.T) {
 	case <-done:
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("refresh handler stayed alive after upstream cancellation")
+	}
+}
+
+func TestDeleteModelProviderInUseListsProfilesUntilDetached(t *testing.T) {
+	server := newDaemon(t)
+
+	providerID, _ := createRefreshProvider(t, server, `{
+		"name":"MiMo",
+		"base_url":"https://api.example.test/v1",
+		"protocols":["openai_chat_completions"]
+	}`)
+
+	profileBody := fmt.Sprintf(`{
+		"name": "Pi Preset",
+		"provider": "pi",
+		"fields": {"model_provider_id": %q, "model_provider_protocol": "openai_chat_completions"}
+	}`, providerID)
+	createProfile := httptest.NewRequest(http.MethodPost, "/api/runtime-profiles", bytes.NewReader([]byte(profileBody)))
+	createProfile.Header.Set("Content-Type", "application/json")
+	profileResp := httptest.NewRecorder()
+	server.ServeHTTP(profileResp, createProfile)
+	if profileResp.Code != http.StatusCreated {
+		t.Fatalf("expected profile create status 201, got %d with body %s", profileResp.Code, profileResp.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(profileResp.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+
+	// Plain delete stays blocked and names the referencing profiles.
+	blocked := httptest.NewRequest(http.MethodDelete, "/api/model-providers/"+providerID, nil)
+	blockedResp := httptest.NewRecorder()
+	server.ServeHTTP(blockedResp, blocked)
+	if blockedResp.Code != http.StatusConflict {
+		t.Fatalf("expected delete status 409, got %d with body %s", blockedResp.Code, blockedResp.Body.String())
+	}
+	var conflict struct {
+		Error    string   `json:"error"`
+		Profiles []string `json:"profiles"`
+	}
+	if err := json.NewDecoder(blockedResp.Body).Decode(&conflict); err != nil {
+		t.Fatalf("decode conflict: %v", err)
+	}
+	if len(conflict.Profiles) != 1 || conflict.Profiles[0] != "Pi Preset" {
+		t.Fatalf("conflict profiles = %#v, want [Pi Preset]", conflict.Profiles)
+	}
+
+	// Explicit detach delete clears the reference and removes the provider.
+	detach := httptest.NewRequest(http.MethodDelete, "/api/model-providers/"+providerID+"?detach=true", nil)
+	detachResp := httptest.NewRecorder()
+	server.ServeHTTP(detachResp, detach)
+	if detachResp.Code != http.StatusNoContent {
+		t.Fatalf("expected detach delete status 204, got %d with body %s", detachResp.Code, detachResp.Body.String())
+	}
+
+	getProfile := httptest.NewRequest(http.MethodGet, "/api/runtime-profiles/"+profile.ID, nil)
+	profileAfter := httptest.NewRecorder()
+	server.ServeHTTP(profileAfter, getProfile)
+	if profileAfter.Code != http.StatusOK {
+		t.Fatalf("expected profile get status 200, got %d", profileAfter.Code)
+	}
+	var survived struct {
+		Fields struct {
+			ModelProviderID       string `json:"model_provider_id"`
+			ModelProviderProtocol string `json:"model_provider_protocol"`
+		} `json:"fields"`
+	}
+	if err := json.NewDecoder(profileAfter.Body).Decode(&survived); err != nil {
+		t.Fatalf("decode survived profile: %v", err)
+	}
+	if survived.Fields.ModelProviderID != "" || survived.Fields.ModelProviderProtocol != "" {
+		t.Fatalf("expected cleared provider reference, got %#v", survived.Fields)
 	}
 }

--- a/internal/daemon/steering.go
+++ b/internal/daemon/steering.go
@@ -76,7 +76,7 @@ func taskSteeringAdapter(server *Server, taskID string, settlement providerContr
 		if err != nil {
 			return "", false, err
 		}
-		if found.Status != task.StatusRunning && found.Status != task.StatusPaused {
+		if found.Status == task.StatusStopped || found.Status == task.StatusCompleted || found.Status == task.StatusFailed {
 			return "", false, errSteeringOwnerNotActive
 		}
 		boundSession, bound := server.providerSessions.get(taskID)

--- a/internal/modelprovider/modelprovider.go
+++ b/internal/modelprovider/modelprovider.go
@@ -236,6 +236,50 @@ func (s *Service) Delete(id string) error {
 	return nil
 }
 
+// DeleteDetaching removes a provider after clearing its reference from every
+// runtime profile that points at it. The detach also removes the profile's
+// pinned protocol: a pin without its provider would fail launch validation
+// instead of falling back. Other profile fields are preserved.
+func (s *Service) DeleteDetaching(id string) error {
+	id = strings.TrimSpace(id)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := s.db.Exec(
+		`UPDATE runtime_profiles
+		 SET fields_json = json_remove(fields_json, '$.model_provider_id', '$.model_provider_protocol'), updated_at = ?
+		 WHERE json_extract(fields_json, '$.model_provider_id') = ?`,
+		now, id,
+	); err != nil {
+		return fmt.Errorf("detach model provider references: %w", err)
+	}
+	return s.Delete(id)
+}
+
+// ReferencingProfiles returns the names of runtime profiles whose fields still
+// reference the provider, so an operator can review them before an explicit
+// detach delete.
+func (s *Service) ReferencingProfiles(id string) ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT name FROM runtime_profiles WHERE json_extract(fields_json, '$.model_provider_id') = ? ORDER BY created_at ASC`,
+		strings.TrimSpace(id),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list referencing profiles: %w", err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan referencing profile: %w", err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list referencing profiles: %w", err)
+	}
+	return names, nil
+}
+
 func (s *Service) RefreshModels(ctx context.Context, id string, client *http.Client) (Provider, error) {
 	provider, err := s.Get(id)
 	if err != nil {

--- a/internal/modelprovider/modelprovider_test.go
+++ b/internal/modelprovider/modelprovider_test.go
@@ -577,6 +577,79 @@ func TestDeleteProviderBlockedWhenRuntimeProfileReferencesIt(t *testing.T) {
 	}
 }
 
+func TestReferencingProfilesListsProfileNames(t *testing.T) {
+	db := newStore(t)
+	providers := modelprovider.NewService(db)
+	profiles := runtimeprofile.NewService(db)
+	provider, err := providers.Create(modelprovider.CreateRequest{Name: "MiMo", BaseURL: "https://api.example.test/v1"})
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	if _, err := profiles.Create("Pi", runtimeprofile.ProviderPi, runtimeprofile.Fields{ModelProviderID: provider.ID}); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	if _, err := profiles.Create("Codex", runtimeprofile.ProviderCodex, runtimeprofile.Fields{}); err != nil {
+		t.Fatalf("create unreferencing profile: %v", err)
+	}
+
+	names, err := providers.ReferencingProfiles(provider.ID)
+	if err != nil {
+		t.Fatalf("referencing profiles: %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"Pi"}) {
+		t.Fatalf("referencing profiles = %#v, want [Pi]", names)
+	}
+}
+
+func TestDeleteDetachingClearsRuntimeProfileReferences(t *testing.T) {
+	db := newStore(t)
+	providers := modelprovider.NewService(db)
+	profiles := runtimeprofile.NewService(db)
+	provider, err := providers.Create(modelprovider.CreateRequest{Name: "MiMo", BaseURL: "https://api.example.test/v1"})
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	created, err := profiles.Create("Pi", runtimeprofile.ProviderPi, runtimeprofile.Fields{
+		ModelProviderID:       provider.ID,
+		ModelProviderProtocol: string(modelprovider.ProtocolOpenAIChatCompletions),
+		ModelOverride:         "mimo-2",
+	})
+	if err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+
+	if err := providers.DeleteDetaching(provider.ID); err != nil {
+		t.Fatalf("delete detaching: %v", err)
+	}
+	if _, err := providers.Get(provider.ID); !errors.Is(err, modelprovider.ErrNotFound) {
+		t.Fatalf("expected provider to be gone, got %v", err)
+	}
+
+	detached, err := profiles.Get(created.ID)
+	if err != nil {
+		t.Fatalf("load profile after detach: %v", err)
+	}
+	if detached.Fields.ModelProviderID != "" {
+		t.Fatalf("model_provider_id = %q, want cleared", detached.Fields.ModelProviderID)
+	}
+	// The pinned protocol is part of the provider reference; leaving it behind
+	// would fail preflight validation instead of falling back.
+	if detached.Fields.ModelProviderProtocol != "" {
+		t.Fatalf("model_provider_protocol = %q, want cleared", detached.Fields.ModelProviderProtocol)
+	}
+	// Unrelated model settings survive the detach.
+	if detached.Fields.ModelOverride != "mimo-2" {
+		t.Fatalf("model_override = %q, want preserved", detached.Fields.ModelOverride)
+	}
+}
+
+func TestDeleteDetachingUnknownProviderReturnsNotFound(t *testing.T) {
+	providers := modelprovider.NewService(newStore(t))
+	if err := providers.DeleteDetaching("missing"); !errors.Is(err, modelprovider.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func newStore(t *testing.T) *store.DB {
 	t.Helper()
 	db, err := store.Open("")

--- a/web/src/pages/CredentialBindingsPage.test.tsx
+++ b/web/src/pages/CredentialBindingsPage.test.tsx
@@ -250,4 +250,90 @@ describe("CredentialBindingsPage", () => {
     expect(body.source.destination_env).toBe("NSSCTF_AGENT_TOKEN");
     expect(body.source.kind).toBe("literal");
   });
+
+  it("edits an existing binding and preserves the stored literal when the value is left blank", async () => {
+    const fetchMock = mockApi({
+      "/api/credential-bindings": {
+        bindings: [
+          {
+            id: "binding-1",
+            credential_ref: "NSSCTF_AGENT_TOKEN",
+            scope: "global",
+            source: { kind: "literal", value: "[configured]", destination_env: "NSSCTF_AGENT_TOKEN" },
+            created_at: "",
+            updated_at: "",
+          },
+        ],
+      },
+      "/api/runtime-profiles": { profiles: [] },
+      "/api/model-providers": { providers: [] },
+    });
+
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /Edit NSSCTF_AGENT_TOKEN binding/i }));
+
+    expect(screen.getByRole("heading", { name: "Edit binding" })).toBeInTheDocument();
+    // The reference is immutable; it renders disabled.
+    expect(screen.getByLabelText("Credential reference")).toBeDisabled();
+    expect((screen.getByLabelText("Secret value") as HTMLInputElement).value).toBe("");
+    expect((screen.getByLabelText("Runtime environment variable name") as HTMLInputElement).value).toBe(
+      "NSSCTF_AGENT_TOKEN",
+    );
+
+    // Blank secret keeps the stored value: Save stays enabled and sends the
+    // sentinel instead of an empty string.
+    const saveButton = screen.getByRole("button", { name: "Save changes" });
+    expect(saveButton).toBeEnabled();
+    await userEvent.click(saveButton);
+
+    const putCall = fetchMock.mock.calls.find(
+      ([input, init]) => String(input).includes("/api/credential-bindings") && init?.method === "PUT",
+    );
+    expect(putCall).toBeDefined();
+    const body = JSON.parse((putCall![1]!.body as string) ?? "{}");
+    expect(body.credential_ref).toBe("NSSCTF_AGENT_TOKEN");
+    expect(body.source.kind).toBe("literal");
+    expect(body.source.value).toBe("[configured]");
+    expect(body.source.destination_env).toBe("NSSCTF_AGENT_TOKEN");
+  });
+
+  it("sends the new value when editing an env binding", async () => {
+    const fetchMock = mockApi({
+      "/api/credential-bindings": {
+        bindings: [
+          {
+            id: "binding-1",
+            credential_ref: "OPENAI_API_KEY",
+            scope: "global",
+            source: { kind: "env", value: "OPENAI_API_KEY", destination_env: "OPENAI_API_KEY" },
+            created_at: "",
+            updated_at: "",
+          },
+        ],
+      },
+      "/api/runtime-profiles": { profiles: [] },
+      "/api/model-providers": { providers: [] },
+    });
+
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /Edit OPENAI_API_KEY binding/i }));
+
+    const valueField = await screen.findByLabelText("Host environment variable name");
+    expect((valueField as HTMLInputElement).value).toBe("OPENAI_API_KEY");
+    await userEvent.clear(valueField);
+    await userEvent.type(valueField, "OPENAI_KEY_V2");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    const putCall = fetchMock.mock.calls.find(
+      ([input, init]) => String(input).includes("/api/credential-bindings") && init?.method === "PUT",
+    );
+    expect(putCall).toBeDefined();
+    const body = JSON.parse((putCall![1]!.body as string) ?? "{}");
+    expect(body.credential_ref).toBe("OPENAI_API_KEY");
+    expect(body.source.kind).toBe("env");
+    expect(body.source.value).toBe("OPENAI_KEY_V2");
+    // destination_env is an independent field; it keeps its prefilled value.
+    expect(body.source.destination_env).toBe("OPENAI_API_KEY");
+  });
 });

--- a/web/src/pages/CredentialBindingsPage.tsx
+++ b/web/src/pages/CredentialBindingsPage.tsx
@@ -3,6 +3,7 @@ import {
   Ban,
   KeyRound,
   LoaderCircle,
+  Pencil,
   Plus,
   RefreshCw,
   Trash2,
@@ -50,6 +51,7 @@ export function CredentialBindingsPage() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
   const [confirmDelete, setConfirmDelete] = useState<{ id: string; credentialRef: string } | null>(null);
+  const [editing, setEditing] = useState<CredentialBinding | null>(null);
   const [loading, setLoading] = useState(true);
 
   async function load() {
@@ -80,12 +82,59 @@ export function CredentialBindingsPage() {
 
   function startCreate() {
     setForm(emptyForm);
+    setEditing(null);
     setCreating(true);
   }
 
   function cancelCreate() {
     setForm(emptyForm);
     setCreating(false);
+  }
+
+  function startEdit(binding: CredentialBinding) {
+    setCreating(false);
+    setEditing(binding);
+    setForm({
+      credential_ref: binding.credential_ref,
+      kind: binding.source.kind,
+      // Literal secrets are redacted to [configured]; leaving the field blank
+      // keeps the stored value instead of echoing the sentinel.
+      value: binding.source.kind === "env" ? (binding.source.value ?? "") : "",
+      destination_env: binding.source.destination_env ?? "",
+    });
+  }
+
+  function cancelEdit() {
+    setEditing(null);
+    setForm(emptyForm);
+  }
+
+  async function saveEdit() {
+    if (!editing) return;
+    const destinationEnv =
+      form.kind === "env"
+        ? (form.destination_env.trim() || form.value.trim())
+        : form.destination_env.trim();
+    const trimmedValue = form.value.trim();
+    const value = form.kind === "literal" && !trimmedValue ? "[configured]" : trimmedValue;
+    setSaving(true);
+    setError(null);
+    try {
+      await apiPut("/api/credential-bindings", {
+        credential_ref: editing.credential_ref,
+        // Preserve the disabled state: an edit changes the source, not whether
+        // the binding resolves.
+        disabled: editing.disabled ?? false,
+        source: { kind: form.kind, value, destination_env: destinationEnv },
+      });
+      setEditing(null);
+      setForm(emptyForm);
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
   }
 
   async function create() {
@@ -169,6 +218,14 @@ export function CredentialBindingsPage() {
   // sources. For env sources it defaults to the host variable name, so the
   // field is optional.
   const destinationEnvRequired = form.kind !== "env";
+
+  // Editing a literal binding may leave the value blank to keep the stored
+  // secret (sentinel); any other literal save still needs a value.
+  const editingLiteralKeep =
+    editing !== null && form.kind === "literal" && editing.source.kind === "literal";
+  const editValueMissing = !form.value.trim() && !editingLiteralKeep;
+  const editSaveDisabled =
+    !editing || editValueMissing || (destinationEnvRequired && !form.destination_env.trim());
 
   return (
     <SettingsPageShell>
@@ -385,7 +442,16 @@ export function CredentialBindingsPage() {
                           )}
                         </div>
 
-                        <div className="flex justify-end">
+                        <div className="flex justify-end gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            aria-label={`Edit ${binding.credential_ref} binding`}
+                            onClick={() => startEdit(binding)}
+                            className="text-muted-foreground hover:text-foreground"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
                           <Button
                             variant="ghost"
                             size="icon-sm"
@@ -411,7 +477,118 @@ export function CredentialBindingsPage() {
         </SettingsListColumn>
 
         <SettingsListColumn>
-          {!creating ? (
+          {editing ? (
+            <SettingsDetailPane
+              data-testid="credential-binding-edit-panel"
+              className="lg:flex-1"
+              header={
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="font-medium">Edit binding</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Change the source for <span className="font-mono">{editing.credential_ref}</span>. References are immutable.
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={cancelEdit}
+                    aria-label="Cancel edit form"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              }
+              footer={
+                <>
+                  <Button onClick={saveEdit} disabled={saving || editSaveDisabled}>
+                    Save changes
+                  </Button>
+                  <Button variant="outline" onClick={cancelEdit} disabled={saving}>
+                    Cancel
+                  </Button>
+                </>
+              }
+              bodyClassName="space-y-3"
+            >
+              <div>
+                <Label htmlFor="credential-ref-edit">Credential reference</Label>
+                <Input
+                  id="credential-ref-edit"
+                  name="credential_ref"
+                  value={editing.credential_ref}
+                  disabled
+                  readOnly
+                  className="font-mono text-xs"
+                />
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  The reference identifies the binding; create a new binding to use a different reference.
+                </p>
+              </div>
+
+              <div>
+                <Label htmlFor="credential-source-kind-edit">Source kind</Label>
+                <Select
+                  id="credential-source-kind-edit"
+                  name="source_kind"
+                  value={form.kind}
+                  onChange={(e) =>
+                    setForm({
+                      ...form,
+                      kind: e.target.value,
+                      value: e.target.value === editing.source.kind ? form.value : "",
+                    })
+                  }
+                >
+                  <option value="literal">literal — stored secret (recommended)</option>
+                  <option value="env">env — read from host environment</option>
+                </Select>
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  {SOURCE_KIND_LABELS[form.kind] ?? form.kind}
+                  {form.kind === "literal" && " · value is stored by the daemon"}
+                  {form.kind === "env" && " · secret stays out of the daemon"}
+                </p>
+              </div>
+
+              <div>
+                <Label htmlFor="credential-source-value-edit">{sourceValueLabel}</Label>
+                <Input
+                  id="credential-source-value-edit"
+                  name="source_value"
+                  type={form.kind === "literal" ? "password" : "text"}
+                  value={form.value}
+                  onChange={(e) => setForm({ ...form, value: e.target.value })}
+                  placeholder={editingLiteralKeep ? "Leave blank to keep the stored secret" : form.kind === "env" ? "OPENAI_API_KEY…" : "sk-…"}
+                  autoComplete="off"
+                  spellCheck={false}
+                  className={form.kind === "literal" ? undefined : "font-mono text-xs"}
+                />
+                {form.kind === "env" && (
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    Use the host environment variable name, not the secret.
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <Label htmlFor="credential-destination-env-edit">Runtime environment variable name</Label>
+                <Input
+                  id="credential-destination-env-edit"
+                  name="destination_env"
+                  value={form.destination_env}
+                  onChange={(e) => setForm({ ...form, destination_env: e.target.value })}
+                  placeholder="NSSCTF_AGENT_TOKEN…"
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="font-mono text-xs"
+                />
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  The runtime env var name. Injected into every Runtime.
+                  {destinationEnvRequired ? " Required." : " Defaults to the host variable name when empty."}
+                </p>
+              </div>
+            </SettingsDetailPane>
+          ) : !creating ? (
             <SettingsPanel data-testid="credential-binding-create-panel" className="gap-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain">
               <div>
                 <h3 className="font-medium">Library actions</h3>

--- a/web/src/pages/ModelProvidersPage.test.tsx
+++ b/web/src/pages/ModelProvidersPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
 import { MemoryRouter } from "react-router-dom";
@@ -534,6 +534,79 @@ describe("ModelProvidersPage", () => {
         String(input).includes("/api/model-providers/mimo") && init?.method === "DELETE",
       ),
     ).toBe(false);
+  });
+
+  it("offers an explicit detach delete when the provider is referenced by runtime profiles", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/model-providers/mimo") && init?.method === "DELETE" && url.includes("detach=true")) {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      if (url.includes("/api/model-providers/mimo") && init?.method === "DELETE") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: "model provider is referenced by a runtime profile",
+              profiles: ["Pi Preset"],
+            }),
+            { status: 409, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (url.includes("/api/model-providers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              providers: [
+                {
+                  id: "mimo",
+                  name: "MiMo",
+                  base_url: "https://api.example.test/v1",
+                  protocols: ["openai_responses"],
+                  api_key_env: "MIMO_API_KEY",
+                  catalog: { manual: ["mimo-v2"], default_model: "mimo-v2" },
+                  created_at: "",
+                  updated_at: "",
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (url.includes("/api/credential-bindings")) {
+        return Promise.resolve(new Response(JSON.stringify({ bindings: [] }), { status: 200, headers: { "Content-Type": "application/json" } }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /Delete/i }));
+    // First dialog is the plain delete confirmation; its Delete button is
+    // scoped to the dialog because the detail pane has its own Delete button.
+    const firstDialog = await screen.findByRole("alertdialog", { name: /Delete model provider MiMo/ });
+    await userEvent.click(within(firstDialog).getByRole("button", { name: "Delete" }));
+
+    // The blocked delete surfaces the referencing profiles and offers an
+    // explicit detach delete.
+    const dialog = await screen.findByRole("alertdialog", { name: /Delete model provider MiMo/ });
+    expect(dialog).toHaveTextContent("Pi Preset");
+    expect(
+      fetchMock.mock.calls.some(([input, init]) =>
+        String(input).includes("/api/model-providers/mimo?detach=true") && init?.method === "DELETE",
+      ),
+    ).toBe(false);
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear references and delete" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input, init]) =>
+          String(input).includes("/api/model-providers/mimo?detach=true") && init?.method === "DELETE",
+        ),
+      ).toBe(true);
+    });
   });
 
   it("filters the provider library by search", async () => {

--- a/web/src/pages/ModelProvidersPage.tsx
+++ b/web/src/pages/ModelProvidersPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { KeyRound, LoaderCircle, Plus, RefreshCw, Server, Trash2, X } from "lucide-react";
-import { apiDelete, apiGet, apiPatch, apiPost, apiPut, type CredentialBinding, type ModelProvider } from "@/lib/api";
+import { apiDelete, apiGet, apiPatch, apiPost, apiPut, ApiError, type CredentialBinding, type ModelProvider } from "@/lib/api";
 import { Button, Input, Label, Select, Textarea, Badge } from "@/components/ui";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { SaveActionButton } from "@/components/SaveActionButton";
@@ -59,6 +59,7 @@ export function ModelProvidersPage() {
   const [form, setForm] = useState<Form>(emptyForm);
   const [creating, setCreating] = useState(true);
   const [confirmDelete, setConfirmDelete] = useState<ModelProvider | null>(null);
+  const [confirmDetach, setConfirmDetach] = useState<{ provider: ModelProvider; profiles: string[] } | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -216,6 +217,27 @@ export function ModelProvidersPage() {
   async function remove(provider: ModelProvider) {
     try {
       await apiDelete(`/api/model-providers/${encodeURIComponent(provider.id)}`);
+      setSelectedId("");
+      setCreating(true);
+      setForm(emptyForm);
+      await load();
+    } catch (e) {
+      const err = e as ApiError;
+      if (err.status === 409) {
+        // The daemon blocks deletion while runtime profiles reference the
+        // provider; offer an explicit detach delete with the profile names.
+        const body = err.body as { profiles?: string[] } | undefined;
+        setConfirmDetach({ provider, profiles: body?.profiles ?? [] });
+        return;
+      }
+      setError(err.message);
+    }
+  }
+
+  async function removeDetaching(provider: ModelProvider) {
+    setError(null);
+    try {
+      await apiDelete(`/api/model-providers/${encodeURIComponent(provider.id)}?detach=true`);
       setSelectedId("");
       setCreating(true);
       setForm(emptyForm);
@@ -637,6 +659,21 @@ export function ModelProvidersPage() {
         }}
         onCancel={() => setConfirmDelete(null)}
       />
+      {confirmDetach && (
+        <ConfirmDialog
+          open
+          title={`Delete model provider ${confirmDetach.provider.name}?`}
+          description={`This provider is referenced by runtime profile${confirmDetach.profiles.length === 1 ? "" : "s"} ${confirmDetach.profiles.join(", ") || "(unknown)"}. Deleting clears the model provider reference from ${confirmDetach.profiles.length === 1 ? "this profile" : "these profiles"}; other profile settings stay unchanged.`}
+          confirmLabel="Clear references and delete"
+          destructive
+          onConfirm={() => {
+            const target = confirmDetach;
+            setConfirmDetach(null);
+            if (target) void removeDetaching(target.provider);
+          }}
+          onCancel={() => setConfirmDetach(null)}
+        />
+      )}
     </SettingsPageShell>
   );
 }


### PR DESCRIPTION
- Credential Upsert now resolves ConfiguredSourceSentinel even when disabled, preserving the original secret instead of writing the placeholder string to storage
- Deleting a model provider that is referenced by runtime configurations returns 409 and lists the referenced configuration names; operators can confirm and delete with detach=true, which also clears provider references and their pinned protocols from each configuration
- The frontend credential binding page and model provider page align with the above behavior, with frontend and backend tests added and CONTEXT.md deletion policy notes updated