### PR TITLE
fix(ci): stabilize flaky daemon tests and unblock Windows test runs

### DIFF
--- a/internal/blackboardmigration/backup.go
+++ b/internal/blackboardmigration/backup.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"pentest/internal/store"
@@ -276,6 +277,11 @@ func syncDirectory(path string) error {
 		return fmt.Errorf("open backup directory for fsync: %w", err)
 	}
 	defer directory.Close()
+	// Windows cannot fsync a directory handle (golang/go#47366); the migration
+	// files are already visible after write, so skip the durability sync.
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	if err := directory.Sync(); err != nil {
 		return fmt.Errorf("fsync backup directory: %w", err)
 	}

--- a/internal/blackboardv2/evidence.go
+++ b/internal/blackboardv2/evidence.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -1944,12 +1945,14 @@ func syncEvidenceDirectory(root *os.Root) error {
 	if err != nil {
 		return fmt.Errorf("open managed Evidence directory for sync: %w", err)
 	}
-	if err := directory.Sync(); err != nil {
-		_ = directory.Close()
-		return fmt.Errorf("sync managed Evidence directory: %w", err)
+	defer directory.Close()
+	// Windows cannot fsync a directory handle (golang/go#47366); the rename
+	// already made the published file visible, so skip the durability sync.
+	if runtime.GOOS == "windows" {
+		return nil
 	}
-	if err := directory.Close(); err != nil {
-		return fmt.Errorf("close managed Evidence directory: %w", err)
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync managed Evidence directory: %w", err)
 	}
 	return nil
 }

--- a/internal/blackboardv2/evidence.go
+++ b/internal/blackboardv2/evidence.go
@@ -1945,14 +1945,18 @@ func syncEvidenceDirectory(root *os.Root) error {
 	if err != nil {
 		return fmt.Errorf("open managed Evidence directory for sync: %w", err)
 	}
-	defer directory.Close()
 	// Windows cannot fsync a directory handle (golang/go#47366); the rename
 	// already made the published file visible, so skip the durability sync.
 	if runtime.GOOS == "windows" {
+		_ = directory.Close()
 		return nil
 	}
 	if err := directory.Sync(); err != nil {
+		_ = directory.Close()
 		return fmt.Errorf("sync managed Evidence directory: %w", err)
+	}
+	if err := directory.Close(); err != nil {
+		return fmt.Errorf("close managed Evidence directory: %w", err)
 	}
 	return nil
 }

--- a/internal/daemon/assisted_conclusion_test.go
+++ b/internal/daemon/assisted_conclusion_test.go
@@ -2510,7 +2510,10 @@ func newAssistedConclusionFixtureAtWithDecorator(t *testing.T, root string, repo
 
 func waitForAssistedProviderRequests(t *testing.T, session *runtime.FakeProviderSession, count int) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	// Match waitForBlackboardConclusionState's 5s budget: the conclusion
+	// dispatch chain is multi-hop and asynchronous, and a 2s window flaked on
+	// loaded CI runners before the last provider request was recorded.
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if len(session.LastRequests()) >= count {
 			return

--- a/internal/daemon/provider_session_control_test.go
+++ b/internal/daemon/provider_session_control_test.go
@@ -619,7 +619,10 @@ func TestStopClosesProviderSessionBeforeWaitingForRuntimeResources(t *testing.T)
 		t.Fatal(err)
 	}
 	defer server.Close()
-	server.runtimeStopTimeout = 50 * time.Millisecond
+	// A load-safe budget: CI runners stretched a 50ms deadline past its bound
+	// and flaked with "runtime did not stop in time". The assertions here guard
+	// the close ordering, not the stop latency bound.
+	server.runtimeStopTimeout = 5 * time.Second
 
 	projectRecord, err := server.projects.Create("Project", "", project.Scope{}, project.Defaults{})
 	if err != nil {
@@ -690,7 +693,11 @@ func TestStopWaitsForActiveProviderControlBeforeClosingSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer server.Close()
-	server.runtimeStopTimeout = 100 * time.Millisecond
+	// Load-safe stop budget: the delayed provider close (cancel wake-up plus the
+	// fake's 20ms settle) must finish inside the stop deadline; 100ms flaked on
+	// loaded CI runners. The test asserts the wait-for-control ORDER, not a
+	// latency bound.
+	server.runtimeStopTimeout = 5 * time.Second
 
 	projectRecord, err := server.projects.Create("Project", "", project.Scope{}, project.Defaults{})
 	if err != nil {

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -1051,7 +1051,20 @@ func TestSandboxResumeRebuildsContainerWithPersistentTaskMountAndRuntimeHome(t *
 	if resp.Code != http.StatusAccepted {
 		t.Fatalf("expected resume status 202, got %d with body %s", resp.Code, resp.Body.String())
 	}
-	waitForTaskStatus(t, server, projectID, taskID, "completed")
+	// Wait for the second container creation directly: the task status may
+	// still read "completed" from the first run while the resume launch is
+	// still in flight, and reading the log before the second create races.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		rawCount, err := os.ReadFile(countPath)
+		if err == nil && strings.TrimSpace(string(rawCount)) == "2" {
+			break
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("timed out waiting for second container creation")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 
 	rawLog, err := os.ReadFile(logPath)
 	if err != nil {

--- a/internal/runner/blackboard_v2.go
+++ b/internal/runner/blackboard_v2.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"pentest/internal/blackboardv2"
@@ -209,5 +210,11 @@ func writeRootFileAtomically(root *os.Root, name string, data []byte) error {
 		return err
 	}
 	defer directory.Close()
+	// Windows cannot fsync a directory handle: FlushFileBuffers(ERROR_ACCESS_DENIED)
+	// (golang/go#47366). The rename above already made the file visible, so the
+	// durability sync is a Linux/macOS-only ordering guarantee.
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	return directory.Sync()
 }


### PR DESCRIPTION
## 背景

CI 扫描(2026-08-10 至 08-23)发现 3 个反复出现或未修复的测试不稳定项,以及 1 个阻塞 Windows 本地测试运行的真实 bug。

## 改动

1. **TestSandboxResumeRebuildsContainerWithPersistentTaskMountAndRuntimeHome 竞态**(08-21 失败):resume 后轮询任务状态会读到第一次运行的 `completed` 旧值,日志断言与第二次容器创建竞争。改为直接等待容器创建计数(与 #227 acac7ef 的修复一致)。
2. **Stop 测试族超时预算**(08-12、08-21 两次失败):`runtimeStopTimeout` 50-100ms 在 CI 负载下超时,返回 409 `runtime did not stop in time`。提高到 5s;测试断言的是关闭顺序而非延迟上界。
3. **Windows 目录 fsync**(golang/go#47366):`os.Root` 目录句柄在 Windows 上无法 fsync(`ERROR_ACCESS_DENIED`),导致所有任务启动类 daemon 测试在 Windows 上失败。三处(writeRootFileAtomically、syncEvidenceDirectory、syncDirectory)在 Windows 上跳过目录同步;Linux 上为 no-op。

## 验证

- steering 测试族 -count=10、stop 测试族 -count=10、合计 -count=8 全部通过
- go build ./... 与 go vet 通过
- daemon 包全量测试通过数不受影响(剩余失败均为预先存在的 Windows 环境性问题)

## 说明

Accepted Steering 竞态(TestAcceptedSteeringPreFenceRestartResumesDispatchAfterResume)已于 #225 合入 main,无需本 PR 处理。