### PR TITLE
Fix conclusion runtime rebinding and recovery

### DIFF
--- a/internal/daemon/blackboard_conclusion.go
+++ b/internal/daemon/blackboard_conclusion.go
@@ -273,7 +273,9 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 			}
 			var won bool
 			var retryErr error
-			retried, won, retryErr = server.tasks.RetryLatestBlackboardConclusion(taskID, idempotencyKey, time.Now().UTC())
+			retried, won, retryErr = server.tasks.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(
+				taskID, idempotencyKey, time.Now().UTC(),
+			)
 			if retryErr != nil {
 				return false, conclusionRetryDispatchNone, retryErr
 			}

--- a/internal/daemon/blackboard_conclusion.go
+++ b/internal/daemon/blackboard_conclusion.go
@@ -237,16 +237,62 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 			}
 			return latest.RecoveryReason, true, nil
 		},
-		retry: func(idempotencyKey string) (bool, bool, error) {
-			var won bool
-			var err error
-			retried, won, err = server.tasks.RetryLatestBlackboardConclusion(taskID, idempotencyKey, time.Now().UTC())
-			if err != nil {
-				return false, false, err
+		retry: func(idempotencyKey string) (bool, conclusionRetryDispatchMode, error) {
+			latest, err := server.tasks.LatestBlackboardConclusion(taskID)
+			if err != nil || latest == nil {
+				return false, conclusionRetryDispatchNone, err
 			}
-			return won, retried.InternalState == task.BlackboardConclusionReceiptPending, nil
+			if latest.RecoveryReason == string(task.ConclusionRecoveryDispatchFailed) {
+				provider, live := server.providerSessions.get(taskID)
+				active, activeErr := server.tasks.ActiveContinuation(taskID)
+				if !live || provider == nil || activeErr != nil || active == nil ||
+					strings.TrimSpace(active.NativeSessionID) != provider.SessionID() {
+					return false, conclusionRetryDispatchNone, fmt.Errorf("Blackboard conclusion retry requires a proven live Runtime")
+				}
+				authority, authorityErr := server.blackboardV2.AuthorizeContinuationBinding(
+					request.Context(), found.ProjectID, taskID, active.ID, true,
+				)
+				if authorityErr != nil {
+					return false, conclusionRetryDispatchNone, fmt.Errorf("Blackboard conclusion retry requires a writable Continuation: %w", authorityErr)
+				}
+				var won, initial bool
+				var retryErr error
+				retried, won, initial, retryErr = server.tasks.RetryLatestBlackboardConclusionForRuntime(
+					taskID, idempotencyKey, active.ID, provider.SessionID(), authority.Sync.Revision, time.Now().UTC(),
+				)
+				if retryErr != nil {
+					return false, conclusionRetryDispatchNone, retryErr
+				}
+				if retried.InternalState == task.BlackboardConclusionReceiptPending {
+					return won, conclusionRetryDispatchPending, nil
+				}
+				if initial {
+					return won, conclusionRetryDispatchInitial, nil
+				}
+				return won, conclusionRetryDispatchRepair, nil
+			}
+			var won bool
+			var retryErr error
+			retried, won, retryErr = server.tasks.RetryLatestBlackboardConclusion(taskID, idempotencyKey, time.Now().UTC())
+			if retryErr != nil {
+				return false, conclusionRetryDispatchNone, retryErr
+			}
+			if retried.InternalState == task.BlackboardConclusionReceiptPending {
+				return won, conclusionRetryDispatchPending, nil
+			}
+			return won, conclusionRetryDispatchRepair, nil
 		},
 		dispatchPending: func() { server.scheduleBlackboardConclusionDispatch(retried) },
+		dispatchInitial: func() {
+			queued := server.enqueueProviderTaskControl(taskID, func(ctx context.Context) {
+				if err := server.dispatchRecoveredConclusionDispatch(ctx, retried); err != nil {
+					server.recoverBlackboardConclusionDispatchFailure(retried, err)
+				}
+			})
+			if !queued {
+				server.recoverBlackboardConclusionDispatchFailure(retried, fmt.Errorf("provider control queue is closed"))
+			}
+		},
 		dispatchRepair: func() {
 			queued := server.enqueueProviderTaskControl(taskID, func(ctx context.Context) {
 				if err := server.dispatchBlackboardConclusionRepair(ctx, retried); err != nil {
@@ -314,6 +360,10 @@ func (server *Server) scheduleRecoveredConclusionDispatch(view task.BlackboardCo
 }
 
 func (server *Server) dispatchRecoveredConclusionDispatch(ctx context.Context, view task.BlackboardConclusionReceipt) error {
+	return server.sendBlackboardConclusionTurn(ctx, view, taskConclusionDispatchDirective(view))
+}
+
+func taskConclusionDispatchDirective(view task.BlackboardConclusionReceipt) string {
 	directive := concludeDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	switch view.InternalState {
 	case task.BlackboardConclusionReceiptRepairDispatchRequested:
@@ -321,11 +371,11 @@ func (server *Server) dispatchRecoveredConclusionDispatch(ctx context.Context, v
 	case task.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
 		directive = regenerateDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	default:
-		if view.ExplicitRetryCount > 0 {
+		if view.DispatchKind != task.ConclusionDispatchKindInitial && view.ExplicitRetryCount > 0 {
 			directive = repairDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromTaskReceipt(view))
 		}
 	}
-	return server.sendBlackboardConclusionTurn(ctx, view, directive)
+	return directive
 }
 
 func (server *Server) reconcileValidatedBlackboardConclusionApplies() {

--- a/internal/daemon/blackboard_conclusion.go
+++ b/internal/daemon/blackboard_conclusion.go
@@ -369,6 +369,16 @@ func (server *Server) dispatchRecoveredConclusionDispatch(ctx context.Context, v
 
 func taskConclusionDispatchDirective(view task.BlackboardConclusionReceipt) string {
 	directive := concludeDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision))
+	switch view.DirectiveKind {
+	case task.ConclusionDirectiveKindInitial:
+		return directive
+	case task.ConclusionDirectiveKindRepair:
+		return repairDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromTaskReceipt(view))
+	case task.ConclusionDirectiveKindVersionRegeneration:
+		return regenerateDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision))
+	}
+	// Legacy dispatches created before directive_kind use the durable protocol
+	// state and attempt counters as a compatibility fallback.
 	switch view.InternalState {
 	case task.BlackboardConclusionReceiptRepairDispatchRequested:
 		directive = repairDirective(taskConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromTaskReceipt(view))

--- a/internal/daemon/blackboard_conclusion.go
+++ b/internal/daemon/blackboard_conclusion.go
@@ -238,11 +238,25 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 			return latest.RecoveryReason, true, nil
 		},
 		retry: func(idempotencyKey string) (bool, conclusionRetryDispatchMode, error) {
+			var won bool
+			var retryErr error
+			retried, won, retryErr = server.tasks.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(
+				taskID, idempotencyKey, time.Now().UTC(),
+			)
+			if retryErr == nil {
+				if retried.InternalState == task.BlackboardConclusionReceiptPending {
+					return won, conclusionRetryDispatchPending, nil
+				}
+				return won, conclusionRetryDispatchRepair, nil
+			}
+			if !errors.Is(retryErr, task.ErrInvalidBlackboardConclusionReceipt) {
+				return false, conclusionRetryDispatchNone, retryErr
+			}
 			latest, err := server.tasks.LatestBlackboardConclusion(taskID)
 			if err != nil || latest == nil {
 				return false, conclusionRetryDispatchNone, err
 			}
-			if latest.RecoveryReason == string(task.ConclusionRecoveryDispatchFailed) {
+			if owner.ConclusionRecoveryRequiresRuntimeBinding(owner.ConclusionRecoveryReason(latest.RecoveryReason)) {
 				provider, live := server.providerSessions.get(taskID)
 				active, activeErr := server.tasks.ActiveContinuation(taskID)
 				if !live || provider == nil || activeErr != nil || active == nil ||
@@ -255,8 +269,7 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 				if authorityErr != nil {
 					return false, conclusionRetryDispatchNone, fmt.Errorf("Blackboard conclusion retry requires a writable Continuation: %w", authorityErr)
 				}
-				var won, initial bool
-				var retryErr error
+				var initial bool
 				retried, won, initial, retryErr = server.tasks.RetryLatestBlackboardConclusionForRuntime(
 					taskID, idempotencyKey, active.ID, provider.SessionID(), authority.Sync.Revision, time.Now().UTC(),
 				)
@@ -271,18 +284,7 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 				}
 				return won, conclusionRetryDispatchRepair, nil
 			}
-			var won bool
-			var retryErr error
-			retried, won, retryErr = server.tasks.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(
-				taskID, idempotencyKey, time.Now().UTC(),
-			)
-			if retryErr != nil {
-				return false, conclusionRetryDispatchNone, retryErr
-			}
-			if retried.InternalState == task.BlackboardConclusionReceiptPending {
-				return won, conclusionRetryDispatchPending, nil
-			}
-			return won, conclusionRetryDispatchRepair, nil
+			return false, conclusionRetryDispatchNone, retryErr
 		},
 		dispatchPending: func() { server.scheduleBlackboardConclusionDispatch(retried) },
 		dispatchInitial: func() {

--- a/internal/daemon/blackboard_conclusion.go
+++ b/internal/daemon/blackboard_conclusion.go
@@ -240,7 +240,7 @@ func (server *Server) handleRetryBlackboardConclusion(response http.ResponseWrit
 		retry: func(idempotencyKey string) (bool, conclusionRetryDispatchMode, error) {
 			var won bool
 			var retryErr error
-			retried, won, retryErr = server.tasks.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(
+			retried, won, retryErr = server.tasks.RetryLatestBlackboardConclusion(
 				taskID, idempotencyKey, time.Now().UTC(),
 			)
 			if retryErr == nil {

--- a/internal/daemon/blackboard_conclusion_recovery.go
+++ b/internal/daemon/blackboard_conclusion_recovery.go
@@ -140,20 +140,9 @@ func (server *Server) resumeLiveBlackboardConclusionObligation(ctx context.Conte
 				return server.dispatchBlackboardConclusion(controlCtx, obligation)
 			})
 		},
-		Dispatch: func(state string, baseRevision int, explicitRetryCount int) {
+		Dispatch: func(_ string, _ int, _ int) {
 			server.enqueueRecoveredBlackboardConclusion(obligation, func(controlCtx context.Context) error {
-				switch task.BlackboardConclusionReceiptState(state) {
-				case task.BlackboardConclusionReceiptRepairDispatchRequested:
-					return server.dispatchBlackboardConclusionRepair(controlCtx, obligation)
-				case task.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
-					return server.dispatchBlackboardConclusionVersionRegeneration(controlCtx, obligation)
-				default:
-					directive := concludeDirective(taskConclusionDirectiveProfile, baseRevision)
-					if explicitRetryCount > 0 {
-						directive = repairDirective(taskConclusionDirectiveProfile, baseRevision, conclusionDetailFromTaskReceipt(obligation))
-					}
-					return server.sendBlackboardConclusionTurn(controlCtx, obligation, directive)
-				}
+				return server.dispatchRecoveredConclusionDispatch(controlCtx, obligation)
 			})
 		},
 		VersionSync: func() {

--- a/internal/daemon/blackboard_conclusion_recovery_test.go
+++ b/internal/daemon/blackboard_conclusion_recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -294,6 +295,72 @@ func TestAssistedConclusionPendingRecoveryRetryDispatchesInitialTurnIdempotently
 	var continuations int
 	if err := restarted.db.QueryRow(`SELECT COUNT(*) FROM task_continuations WHERE task_id=?`, seed.task.ID).Scan(&continuations); err != nil || continuations != 2 {
 		t.Fatalf("replacement continuation count=%d err=%v", continuations, err)
+	}
+}
+
+func TestAssistedConclusionMigrationPreservesInitialDirectiveForActiveRecovery(t *testing.T) {
+	root := t.TempDir()
+	seed := seedConclusionRecoveryReceipt(t, root)
+	now := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	if _, changed, err := seed.server.tasks.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
+		seed.receipt.ID, task.ConclusionRecoveryDispatchFailed, now, 0,
+	); err != nil || !changed {
+		t.Fatalf("mark recovery: changed=%v err=%v", changed, err)
+	}
+	original, err := seed.server.tasks.LatestContinuation(seed.task.ID)
+	if err != nil || original == nil {
+		t.Fatalf("load source Continuation: %#v err=%v", original, err)
+	}
+	retried, won, initial, err := seed.server.tasks.RetryLatestBlackboardConclusionForRuntime(
+		seed.task.ID, "legacy-task-initial", original.ID, original.NativeSessionID, 0, now,
+	)
+	if err != nil || !won || !initial || retried.DirectiveKind != task.ConclusionDirectiveKindInitial {
+		t.Fatalf("persist initial retry=%#v won=%v initial=%v err=%v", retried, won, initial, err)
+	}
+	replacement, err := seed.server.tasks.CreateReplacementContinuation(*original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.server.blackboardV2Continuity.RebindContinuationForNativeSteer(
+		context.Background(), original.ID, replacement.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err = seed.server.tasks.UpdateContinuationRuntimeMetadata(
+		replacement.ID, "", "assisted-session", "/sessions/assisted-session.jsonl",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.server.tasks.UpdateContinuationStatus(original.ID, task.StatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.server.tasks.UpdateContinuationStatus(replacement.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	rebound, created, err := seed.server.tasks.CreateRecoveryConclusionDispatch(
+		retried.ID, replacement.ID, replacement.NativeSessionID, now.Add(time.Second),
+	)
+	if err != nil || !created || rebound.DispatchKind != task.ConclusionDispatchKindRecovery ||
+		rebound.DirectiveKind != task.ConclusionDirectiveKindInitial {
+		t.Fatalf("rebind initial retry=%#v created=%v err=%v", rebound, created, err)
+	}
+	if _, err := seed.server.db.Exec(`UPDATE conclusion_dispatches SET directive_kind='' WHERE id=?`, rebound.ActiveDispatchID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.server.db.Exec(`DELETE FROM schema_migrations WHERE version=60`); err != nil {
+		t.Fatal(err)
+	}
+	closeSeedServer(t, seed.server)
+
+	provider := newConclusionRecoverySession()
+	factory := &conclusionRecoveryFactory{session: provider, liveness: ProviderSessionRecoveryLive}
+	restarted := openConclusionRecoveryServer(t, root, factory)
+	restarted.providerControlWG.Wait()
+	requests := provider.LastRequests()
+	if len(requests) != 1 || !strings.Contains(requests[0].Message, "perform only the Harness conclusion below") ||
+		strings.Contains(requests[0].Message, "previous Blackboard conclusion result was invalid") {
+		t.Fatalf("migrated initial Task directive=%#v", requests)
 	}
 }
 

--- a/internal/daemon/blackboard_conclusion_recovery_test.go
+++ b/internal/daemon/blackboard_conclusion_recovery_test.go
@@ -239,6 +239,28 @@ func TestAssistedConclusionPendingRecoveryRetryDispatchesInitialTurnIdempotently
 		action.DispatchRequestID != "" || action.ApplyIdempotencyKey != "" {
 		t.Fatalf("pending recovery action = %#v, err=%v", action, err)
 	}
+	original, err := restarted.tasks.LatestContinuation(seed.task.ID)
+	if err != nil || original == nil {
+		t.Fatalf("load interrupted Continuation: %#v err=%v", original, err)
+	}
+	replacement, err := restarted.tasks.CreateReplacementContinuation(*original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.blackboardV2Continuity.RebindContinuationForNativeSteer(
+		context.Background(), original.ID, replacement.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err = restarted.tasks.UpdateContinuationRuntimeMetadata(
+		replacement.ID, "", "assisted-session", "/sessions/assisted-session.jsonl",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := restarted.tasks.UpdateContinuationStatus(replacement.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
 
 	session := newConclusionRecoverySession()
 	if err := restarted.BindProviderSession(seed.task.ID, session); err != nil {
@@ -265,7 +287,14 @@ func TestAssistedConclusionPendingRecoveryRetryDispatchesInitialTurnIdempotently
 		requests[0].TurnKind != runtime.RuntimeTurnKindControl {
 		t.Fatalf("pending retry provider requests = %#v", requests)
 	}
-	assertConclusionRecoveryDidNotLaunch(t, restarted, factory, seed.task.ID)
+	opens, recovers := factory.counts()
+	if opens != 0 || recovers != 1 || restarted.harness.IsActive(seed.task.ID) {
+		t.Fatalf("restart launched Runtime: opens=%d recovers=%d harness_active=%v", opens, recovers, restarted.harness.IsActive(seed.task.ID))
+	}
+	var continuations int
+	if err := restarted.db.QueryRow(`SELECT COUNT(*) FROM task_continuations WHERE task_id=?`, seed.task.ID).Scan(&continuations); err != nil || continuations != 2 {
+		t.Fatalf("replacement continuation count=%d err=%v", continuations, err)
+	}
 }
 
 func TestAssistedConclusionRestartRecoversUnsentFollowupGenerationOnce(t *testing.T) {

--- a/internal/daemon/conclusion_receipt_rebind_test.go
+++ b/internal/daemon/conclusion_receipt_rebind_test.go
@@ -104,7 +104,7 @@ func newAuthorizedAssistedConclusionRecoveryServer(t *testing.T) (*Server, task.
 	return server, created, continuation
 }
 
-func prepareDispatchFailedReplacement(t *testing.T, providerSessionID string) (*Server, task.Task, task.BlackboardConclusionReceipt) {
+func prepareRuntimeRebindRecovery(t *testing.T, reason task.ConclusionRecoveryReason, providerSessionID string) (*Server, task.Task, task.BlackboardConclusionReceipt) {
 	t.Helper()
 	server, created, original := newAuthorizedAssistedConclusionRecoveryServer(t)
 	receipt, _, err := server.tasks.RecordBlackboardConclusionCheckpoint(
@@ -116,7 +116,7 @@ func prepareDispatchFailedReplacement(t *testing.T, providerSessionID string) (*
 		t.Fatal(err)
 	}
 	if _, changed, err := server.tasks.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
-		receipt.ID, task.ConclusionRecoveryDispatchFailed, time.Now().UTC(), 0,
+		receipt.ID, reason, time.Now().UTC(), 0,
 	); err != nil || !changed {
 		t.Fatalf("mark action_required: changed=%v err=%v", changed, err)
 	}
@@ -154,34 +154,42 @@ func prepareDispatchFailedReplacement(t *testing.T, providerSessionID string) (*
 }
 
 func TestRetryDispatchFailedConclusionRequiresMatchingLiveRuntime(t *testing.T) {
-	for _, test := range []struct {
-		name              string
-		providerSessionID string
-	}{
-		{name: "provider missing"},
-		{name: "native session mismatch", providerSessionID: "session-other"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			server, created, receipt := prepareDispatchFailedReplacement(t, test.providerSessionID)
-			request := httptest.NewRequest(http.MethodPost,
-				"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
-				bytes.NewBufferString(`{}`))
-			request.Header.Set("Idempotency-Key", "retry-without-runtime-proof")
-			response := httptest.NewRecorder()
-			server.ServeHTTP(response, request)
+	reasons := []task.ConclusionRecoveryReason{
+		task.ConclusionRecoveryRuntimeOwnershipNotProven,
+		task.ConclusionRecoveryWritableReplacementUnavailable,
+		task.ConclusionRecoveryDispatchFailed,
+		task.ConclusionRecoveryLegacyCorrelationUnproven,
+	}
+	for _, reason := range reasons {
+		for _, test := range []struct {
+			name              string
+			providerSessionID string
+		}{
+			{name: "provider missing"},
+			{name: "native session mismatch", providerSessionID: "session-other"},
+		} {
+			t.Run(string(reason)+"/"+test.name, func(t *testing.T) {
+				server, created, receipt := prepareRuntimeRebindRecovery(t, reason, test.providerSessionID)
+				request := httptest.NewRequest(http.MethodPost,
+					"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
+					bytes.NewBufferString(`{}`))
+				request.Header.Set("Idempotency-Key", "retry-without-runtime-proof")
+				response := httptest.NewRecorder()
+				server.ServeHTTP(response, request)
 
-			if response.Code != http.StatusConflict {
-				t.Fatalf("retry status=%d body=%s, want conflict", response.Code, response.Body.String())
-			}
-			latest, err := server.tasks.LatestBlackboardConclusion(created.ID)
-			if err != nil || latest == nil || latest.ExplicitRetryCount != 0 ||
-				latest.InternalState != task.BlackboardConclusionReceiptActionRequired {
-				t.Fatalf("failed-closed conclusion=%#v err=%v", latest, err)
-			}
-			if history, err := server.tasks.ConclusionDispatches(receipt.ID); err != nil || len(history) != 0 {
-				t.Fatalf("failed-closed dispatch history=%#v err=%v", history, err)
-			}
-		})
+				if response.Code != http.StatusConflict {
+					t.Fatalf("retry status=%d body=%s, want conflict", response.Code, response.Body.String())
+				}
+				latest, err := server.tasks.LatestBlackboardConclusion(created.ID)
+				if err != nil || latest == nil || latest.ExplicitRetryCount != 0 ||
+					latest.InternalState != task.BlackboardConclusionReceiptActionRequired {
+					t.Fatalf("failed-closed conclusion=%#v err=%v", latest, err)
+				}
+				if history, err := server.tasks.ConclusionDispatches(receipt.ID); err != nil || len(history) != 0 {
+					t.Fatalf("failed-closed dispatch history=%#v err=%v", history, err)
+				}
+			})
+		}
 	}
 }
 
@@ -344,6 +352,27 @@ func TestRetryDispatchFailedConclusionBindsProvenLiveReplacementRuntime(t *testi
 	}
 	if !foundInitial {
 		t.Fatalf("initial dispatch missing from history: %#v", history)
+	}
+	if _, changed, err := server.tasks.MarkBlackboardConclusionRecoveryActionRequired(
+		latest.DispatchRequestID, task.ConclusionRecoveryDispatchFailed, time.Now().UTC(), 0,
+	); err != nil || !changed {
+		t.Fatalf("mark replacement dispatch_failed: changed=%v err=%v", changed, err)
+	}
+	_ = server.providerSessions.remove(created.ID)
+	lostResponseReplay := httptest.NewRequest(http.MethodPost,
+		"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
+		bytes.NewBufferString(`{}`))
+	lostResponseReplay.Header.Set("Idempotency-Key", "retry-on-live-replacement")
+	lostResponseReplayResponse := httptest.NewRecorder()
+	server.ServeHTTP(lostResponseReplayResponse, lostResponseReplay)
+	if lostResponseReplayResponse.Code != http.StatusOK {
+		t.Fatalf("retry replay after Runtime loss status=%d body=%s, want OK",
+			lostResponseReplayResponse.Code, lostResponseReplayResponse.Body.String())
+	}
+	afterReplay, err := server.tasks.LatestBlackboardConclusion(created.ID)
+	if err != nil || afterReplay == nil || afterReplay.ExplicitRetryCount != 1 ||
+		afterReplay.InternalState != task.BlackboardConclusionReceiptActionRequired {
+		t.Fatalf("retry replay after Runtime loss=%#v err=%v", afterReplay, err)
 	}
 }
 

--- a/internal/daemon/conclusion_receipt_rebind_test.go
+++ b/internal/daemon/conclusion_receipt_rebind_test.go
@@ -1,12 +1,20 @@
 package daemon
 
 import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"pentest/internal/blackboardv2"
 	"pentest/internal/project"
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeplugin"
+	"pentest/internal/runtimeprofile"
 	"pentest/internal/task"
 )
 
@@ -46,6 +54,293 @@ func newAssistedConclusionRecoveryServer(t *testing.T) (*Server, task.Task, task
 		t.Fatal(err)
 	}
 	return server, created, continuation
+}
+
+func newAuthorizedAssistedConclusionRecoveryServer(t *testing.T) (*Server, task.Task, task.TaskContinuation) {
+	t.Helper()
+	root := t.TempDir()
+	server, err := NewServer(Config{
+		DBPath: filepath.Join(root, "pentest.db"), RuntimeRoot: filepath.Join(root, "runs"),
+		DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+	projectRecord, err := server.projects.Create("AuthorizedRecoveryDispatch", "", project.Scope{Domains: []string{"example.com"}}, project.Defaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, err := server.profiles.Create("Recovery Codex", runtimeprofile.ProviderCodex, runtimeprofile.Fields{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := server.tasks.Create(task.CreateRequest{
+		ProjectID: projectRecord.ID,
+		Type:      task.TypePentest, Goal: "recover assisted conclusion", RuntimeProfileID: profile.ID, Runner: task.RunnerSandbox,
+		RunControls: task.RunControls{BlackboardConclusionMode: task.BlackboardConclusionModeAssisted},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	launch, err := server.blackboardV2Continuity.CreateContinuation(context.Background(), blackboardv2.ContinuationLaunchRequest{
+		ProjectID: projectRecord.ID, TaskID: created.ID, RuntimeProfileID: profile.ID,
+		RuntimeProvider: string(runtimeprofile.ProviderCodex), Runner: task.RunnerSandbox,
+		RuntimeConfig: map[string]any{"provider": "codex"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation, err := server.tasks.UpdateContinuationRuntimeMetadata(launch.Continuation.ID, "", "session-original", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateStatus(created.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(continuation.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	return server, created, continuation
+}
+
+func TestRetryDispatchFailedConclusionWithoutBlackboardAuthorityFailsClosed(t *testing.T) {
+	server, created, original := newAssistedConclusionRecoveryServer(t)
+
+	obligation, _, err := server.tasks.RecordBlackboardConclusionCheckpoint(
+		created.ID, original.ID, "work-request-no-authority", "session-original", "turn-no-authority",
+		task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		task.SemanticDebtWatermarks{SourceWork: 1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, changed, err := server.tasks.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
+		obligation.ID, task.ConclusionRecoveryDispatchFailed, time.Now().UTC(), 0,
+	); err != nil || !changed {
+		t.Fatalf("mark action_required: changed=%v err=%v", changed, err)
+	}
+
+	replacement, err := server.tasks.CreateReplacementContinuation(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const replacementSessionID = "session-without-blackboard-authority"
+	if _, err := server.tasks.UpdateContinuationRuntimeMetadata(replacement.ID, "", replacementSessionID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(original.ID, task.StatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(replacement.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	provider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: replacementSessionID,
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, AssistedConclusion: true,
+		},
+	})
+	if err := server.providerSessions.bind(created.ID, provider); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost,
+		"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
+		bytes.NewBufferString(`{}`))
+	request.Header.Set("Idempotency-Key", "retry-without-blackboard-authority")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusConflict {
+		t.Fatalf("retry status=%d body=%s, want conflict", response.Code, response.Body.String())
+	}
+	latest, err := server.tasks.LatestBlackboardConclusion(created.ID)
+	if err != nil || latest == nil || latest.ExplicitRetryCount != 0 || latest.InternalState != task.BlackboardConclusionReceiptActionRequired {
+		t.Fatalf("failed-closed conclusion=%#v err=%v", latest, err)
+	}
+	if history, err := server.tasks.ConclusionDispatches(obligation.ID); err != nil || len(history) != 0 {
+		t.Fatalf("failed-closed dispatch history=%#v err=%v", history, err)
+	}
+}
+
+func TestRetryDispatchFailedConclusionBindsProvenLiveReplacementRuntime(t *testing.T) {
+	server, created, original := newAuthorizedAssistedConclusionRecoveryServer(t)
+
+	obligation, _, err := server.tasks.RecordBlackboardConclusionCheckpoint(
+		created.ID, original.ID, "work-request-rebind", "session-original", "turn-rebind",
+		task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		task.SemanticDebtWatermarks{SourceWork: 2},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, won, err := server.tasks.ClaimBlackboardConclusionDispatch(obligation.ID, 0)
+	if err != nil || !won {
+		t.Fatalf("claim initial dispatch: %#v won=%v err=%v", initial, won, err)
+	}
+	if _, changed, err := server.tasks.MarkBlackboardConclusionRecoveryActionRequired(
+		initial.DispatchRequestID, task.ConclusionRecoveryDispatchFailed, time.Now().UTC(), 0,
+	); err != nil || !changed {
+		t.Fatalf("mark action_required: changed=%v err=%v", changed, err)
+	}
+
+	replacement, err := server.tasks.CreateReplacementContinuation(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.blackboardV2Continuity.RebindContinuationForNativeSteer(
+		context.Background(), original.ID, replacement.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	const replacementSessionID = "session-replacement"
+	if _, err := server.tasks.UpdateContinuationRuntimeMetadata(replacement.ID, "", replacementSessionID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(original.ID, task.StatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(replacement.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	provider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: replacementSessionID,
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, AssistedConclusion: true,
+		},
+	})
+	if err := server.providerSessions.bind(created.ID, provider); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost,
+		"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
+		bytes.NewBufferString(`{}`))
+	request.Header.Set("Idempotency-Key", "retry-on-live-replacement")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("retry status=%d body=%s, want accepted", response.Code, response.Body.String())
+	}
+	replay := httptest.NewRequest(http.MethodPost,
+		"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
+		bytes.NewBufferString(`{}`))
+	replay.Header.Set("Idempotency-Key", "retry-on-live-replacement")
+	replayResponse := httptest.NewRecorder()
+	server.ServeHTTP(replayResponse, replay)
+	if replayResponse.Code != http.StatusOK {
+		t.Fatalf("retry replay status=%d body=%s, want OK", replayResponse.Code, replayResponse.Body.String())
+	}
+	server.providerControlWG.Wait()
+
+	latest, err := server.tasks.LatestBlackboardConclusion(created.ID)
+	if err != nil || latest == nil {
+		t.Fatalf("latest conclusion=%#v err=%v", latest, err)
+	}
+	if latest.InternalState != task.BlackboardConclusionReceiptAwaitingResult ||
+		latest.ContinuationID != replacement.ID || latest.SourceSessionID != replacementSessionID {
+		t.Fatalf("replacement retry=%#v", latest)
+	}
+	if requests := provider.LastRequests(); len(requests) != 1 || requests[0].RequestID != latest.DispatchRequestID {
+		t.Fatalf("replacement Runtime requests=%#v, want one idempotent retry", requests)
+	}
+	history, err := server.tasks.ConclusionDispatches(obligation.ID)
+	if err != nil || len(history) != 2 {
+		t.Fatalf("dispatch history=%#v err=%v", history, err)
+	}
+	foundInitial := false
+	for _, dispatch := range history {
+		if dispatch.DispatchRequestID == initial.DispatchRequestID {
+			foundInitial = true
+			if dispatch.ContinuationID != original.ID || dispatch.SourceSessionID != "session-original" {
+				t.Fatalf("historical dispatch binding changed: %#v", dispatch)
+			}
+			if dispatch.DeliveryState != task.ConclusionDispatchSuperseded {
+				t.Fatalf("historical dispatch state=%s, want superseded", dispatch.DeliveryState)
+			}
+		}
+	}
+	if !foundInitial {
+		t.Fatalf("initial dispatch missing from history: %#v", history)
+	}
+}
+
+func TestRetryUndispatchedConclusionUsesInitialDirectiveOnProvenLiveReplacement(t *testing.T) {
+	server, created, original := newAuthorizedAssistedConclusionRecoveryServer(t)
+
+	obligation, _, err := server.tasks.RecordBlackboardConclusionCheckpoint(
+		created.ID, original.ID, "work-request-undispatched", "session-original", "turn-undispatched",
+		task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		task.SemanticDebtWatermarks{SourceWork: 1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, changed, err := server.tasks.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
+		obligation.ID, task.ConclusionRecoveryDispatchFailed, time.Now().UTC(), 0,
+	); err != nil || !changed {
+		t.Fatalf("mark action_required: changed=%v err=%v", changed, err)
+	}
+
+	replacement, err := server.tasks.CreateReplacementContinuation(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.blackboardV2Continuity.RebindContinuationForNativeSteer(
+		context.Background(), original.ID, replacement.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	const replacementSessionID = "session-replacement-undispatched"
+	if _, err := server.tasks.UpdateContinuationRuntimeMetadata(replacement.ID, "", replacementSessionID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(original.ID, task.StatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(replacement.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	provider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: replacementSessionID,
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, AssistedConclusion: true,
+		},
+	})
+	if err := server.providerSessions.bind(created.ID, provider); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost,
+		"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
+		bytes.NewBufferString(`{}`))
+	request.Header.Set("Idempotency-Key", "retry-undispatched-on-live-replacement")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("retry status=%d body=%s, want accepted", response.Code, response.Body.String())
+	}
+	server.providerControlWG.Wait()
+
+	requests := provider.LastRequests()
+	if len(requests) != 1 {
+		t.Fatalf("replacement Runtime requests=%#v, want one initial Conclude Turn", requests)
+	}
+	if !strings.Contains(requests[0].Message, "perform only the Harness conclusion below") {
+		t.Fatalf("initial Conclude directive missing: %q", requests[0].Message)
+	}
+	if strings.Contains(requests[0].Message, "previous Blackboard conclusion result was invalid") {
+		t.Fatalf("undispatched retry used repair directive: %q", requests[0].Message)
+	}
+	latest, err := server.tasks.LatestBlackboardConclusion(created.ID)
+	if err != nil || latest == nil || latest.InternalState != task.BlackboardConclusionReceiptAwaitingResult ||
+		latest.ContinuationID != replacement.ID || latest.SourceSessionID != replacementSessionID {
+		t.Fatalf("undispatched replacement retry=%#v err=%v", latest, err)
+	}
+	if latest.DispatchKind != task.ConclusionDispatchKindInitial {
+		t.Fatalf("undispatched replacement dispatch kind=%s, want initial for restart-safe Conclude recovery", latest.DispatchKind)
+	}
 }
 
 func TestRecoveryConclusionDispatchBindsReplacementContinuation(t *testing.T) {

--- a/internal/daemon/conclusion_receipt_rebind_test.go
+++ b/internal/daemon/conclusion_receipt_rebind_test.go
@@ -104,6 +104,87 @@ func newAuthorizedAssistedConclusionRecoveryServer(t *testing.T) (*Server, task.
 	return server, created, continuation
 }
 
+func prepareDispatchFailedReplacement(t *testing.T, providerSessionID string) (*Server, task.Task, task.BlackboardConclusionReceipt) {
+	t.Helper()
+	server, created, original := newAuthorizedAssistedConclusionRecoveryServer(t)
+	receipt, _, err := server.tasks.RecordBlackboardConclusionCheckpoint(
+		created.ID, original.ID, "work-request-runtime-proof", "session-original", "turn-runtime-proof",
+		task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		task.SemanticDebtWatermarks{SourceWork: 1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, changed, err := server.tasks.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
+		receipt.ID, task.ConclusionRecoveryDispatchFailed, time.Now().UTC(), 0,
+	); err != nil || !changed {
+		t.Fatalf("mark action_required: changed=%v err=%v", changed, err)
+	}
+	replacement, err := server.tasks.CreateReplacementContinuation(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.blackboardV2Continuity.RebindContinuationForNativeSteer(
+		context.Background(), original.ID, replacement.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	const replacementSessionID = "session-replacement-proof"
+	if _, err := server.tasks.UpdateContinuationRuntimeMetadata(replacement.ID, "", replacementSessionID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(original.ID, task.StatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateContinuationStatus(replacement.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	if providerSessionID != "" {
+		provider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+			SessionID: providerSessionID,
+			Capabilities: runtimeplugin.Capabilities{
+				PersistentSession: true, SendTurn: true, AssistedConclusion: true,
+			},
+		})
+		if err := server.providerSessions.bind(created.ID, provider); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return server, created, receipt
+}
+
+func TestRetryDispatchFailedConclusionRequiresMatchingLiveRuntime(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		providerSessionID string
+	}{
+		{name: "provider missing"},
+		{name: "native session mismatch", providerSessionID: "session-other"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, created, receipt := prepareDispatchFailedReplacement(t, test.providerSessionID)
+			request := httptest.NewRequest(http.MethodPost,
+				"/api/projects/"+created.ProjectID+"/tasks/"+created.ID+"/blackboard-conclusion/retry",
+				bytes.NewBufferString(`{}`))
+			request.Header.Set("Idempotency-Key", "retry-without-runtime-proof")
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, request)
+
+			if response.Code != http.StatusConflict {
+				t.Fatalf("retry status=%d body=%s, want conflict", response.Code, response.Body.String())
+			}
+			latest, err := server.tasks.LatestBlackboardConclusion(created.ID)
+			if err != nil || latest == nil || latest.ExplicitRetryCount != 0 ||
+				latest.InternalState != task.BlackboardConclusionReceiptActionRequired {
+				t.Fatalf("failed-closed conclusion=%#v err=%v", latest, err)
+			}
+			if history, err := server.tasks.ConclusionDispatches(receipt.ID); err != nil || len(history) != 0 {
+				t.Fatalf("failed-closed dispatch history=%#v err=%v", history, err)
+			}
+		})
+	}
+}
+
 func TestRetryDispatchFailedConclusionWithoutBlackboardAuthorityFailsClosed(t *testing.T) {
 	server, created, original := newAssistedConclusionRecoveryServer(t)
 

--- a/internal/daemon/conclusion_retry_http.go
+++ b/internal/daemon/conclusion_retry_http.go
@@ -14,15 +14,25 @@ import (
 // idempotent operator retry per obligation through the shared engine, never
 // resent after an acceptance-ambiguous delivery, and the winning caller
 // schedules exactly one follow-up dispatch.
+type conclusionRetryDispatchMode uint8
+
+const (
+	conclusionRetryDispatchNone conclusionRetryDispatchMode = iota
+	conclusionRetryDispatchPending
+	conclusionRetryDispatchInitial
+	conclusionRetryDispatchRepair
+)
+
 type conclusionRetrySpec struct {
 	// latest returns the latest receipt's recovery reason for the owner.
 	latest func() (recoveryReason string, found bool, err error)
-	// retry performs the idempotent retry and reports whether this caller won
-	// and whether the retried obligation is back in the pending conclude state.
-	retry func(idempotencyKey string) (won, pending bool, err error)
-	// dispatchPending schedules the initial conclude dispatch of a retried
-	// pending obligation; dispatchRepair schedules its repair dispatch.
+	// retry performs the idempotent retry and selects the one follow-up action
+	// owned by the winning caller.
+	retry func(idempotencyKey string) (won bool, mode conclusionRetryDispatchMode, err error)
+	// dispatchPending claims a pending obligation; dispatchInitial delivers an
+	// already-created first Conclude dispatch; dispatchRepair delivers repair.
 	dispatchPending func()
+	dispatchInitial func()
 	dispatchRepair  func()
 	// detail renders the owner's detail response payload.
 	detail func() (any, error)
@@ -51,7 +61,7 @@ func (server *Server) serveBlackboardConclusionRetry(response http.ResponseWrite
 		writeError(response, http.StatusConflict, "Blackboard conclusion cannot be retried after an acceptance-ambiguous delivery")
 		return
 	}
-	won, pending, retryErr := spec.retry(idempotencyKey)
+	won, mode, retryErr := spec.retry(idempotencyKey)
 	if retryErr != nil {
 		if errors.Is(retryErr, conclusion.ErrBlackboardConclusionRetryCooldown) {
 			writeError(response, http.StatusConflict, "Blackboard conclusion retry is not yet available")
@@ -61,10 +71,16 @@ func (server *Server) serveBlackboardConclusionRetry(response http.ResponseWrite
 		return
 	}
 	if won {
-		if pending {
+		switch mode {
+		case conclusionRetryDispatchPending:
 			spec.dispatchPending()
-		} else {
+		case conclusionRetryDispatchInitial:
+			spec.dispatchInitial()
+		case conclusionRetryDispatchRepair:
 			spec.dispatchRepair()
+		default:
+			writeError(response, http.StatusInternalServerError, "Blackboard conclusion retry dispatch mode is invalid")
+			return
 		}
 	}
 	payload, err := spec.detail()

--- a/internal/daemon/session_blackboard_conclusion.go
+++ b/internal/daemon/session_blackboard_conclusion.go
@@ -484,12 +484,52 @@ func (server *Server) handleRetrySessionBlackboardConclusion(response http.Respo
 		retry: func(idempotencyKey string) (bool, conclusionRetryDispatchMode, error) {
 			var won bool
 			var err error
-			retried, won, err = server.sessions.RetryLatestBlackboardConclusion(sessionID, idempotencyKey, time.Now().UTC())
+			retried, won, err = server.sessions.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(
+				sessionID, idempotencyKey, time.Now().UTC(),
+			)
+			if err == nil {
+				if retried.InternalState == session.BlackboardConclusionReceiptPending {
+					return won, conclusionRetryDispatchPending, nil
+				}
+				return won, conclusionRetryDispatchRepair, nil
+			}
+			if !errors.Is(err, session.ErrInvalidBlackboardConclusionReceipt) {
+				return false, conclusionRetryDispatchNone, err
+			}
+			latest, latestErr := server.sessions.LatestBlackboardConclusion(sessionID)
+			if latestErr != nil || latest == nil {
+				return false, conclusionRetryDispatchNone, latestErr
+			}
+			if !owner.ConclusionRecoveryRequiresRuntimeBinding(owner.ConclusionRecoveryReason(latest.RecoveryReason)) {
+				return false, conclusionRetryDispatchNone, err
+			}
+			provider, live := server.sessionProviderSessions.get(sessionID)
+			active, activeErr := server.sessions.ActiveContinuation(sessionID)
+			if !live || provider == nil || activeErr != nil || active == nil ||
+				strings.TrimSpace(active.NativeSessionID) != provider.SessionID() {
+				return false, conclusionRetryDispatchNone, fmt.Errorf("Session Blackboard conclusion retry requires a proven live Runtime")
+			}
+			if _, authorityErr := server.blackboardV2.AuthorizeSessionContinuation(
+				request.Context(), sessionID, active.ID,
+			); authorityErr != nil {
+				return false, conclusionRetryDispatchNone, fmt.Errorf("Session Blackboard conclusion retry requires a writable Continuation: %w", authorityErr)
+			}
+			snapshot, snapshotErr := server.blackboardV2.SessionRuntimeSnapshot(request.Context(), sessionID)
+			if snapshotErr != nil {
+				return false, conclusionRetryDispatchNone, snapshotErr
+			}
+			var initial bool
+			retried, won, initial, err = server.sessions.RetryLatestBlackboardConclusionForRuntime(
+				sessionID, idempotencyKey, active.ID, provider.SessionID(), snapshot.Revision, time.Now().UTC(),
+			)
 			if err != nil {
 				return false, conclusionRetryDispatchNone, err
 			}
 			if retried.InternalState == session.BlackboardConclusionReceiptPending {
 				return won, conclusionRetryDispatchPending, nil
+			}
+			if initial {
+				return won, conclusionRetryDispatchInitial, nil
 			}
 			return won, conclusionRetryDispatchRepair, nil
 		},

--- a/internal/daemon/session_blackboard_conclusion.go
+++ b/internal/daemon/session_blackboard_conclusion.go
@@ -481,16 +481,29 @@ func (server *Server) handleRetrySessionBlackboardConclusion(response http.Respo
 			}
 			return latest.RecoveryReason, true, nil
 		},
-		retry: func(idempotencyKey string) (bool, bool, error) {
+		retry: func(idempotencyKey string) (bool, conclusionRetryDispatchMode, error) {
 			var won bool
 			var err error
 			retried, won, err = server.sessions.RetryLatestBlackboardConclusion(sessionID, idempotencyKey, time.Now().UTC())
 			if err != nil {
-				return false, false, err
+				return false, conclusionRetryDispatchNone, err
 			}
-			return won, retried.InternalState == session.BlackboardConclusionReceiptPending, nil
+			if retried.InternalState == session.BlackboardConclusionReceiptPending {
+				return won, conclusionRetryDispatchPending, nil
+			}
+			return won, conclusionRetryDispatchRepair, nil
 		},
 		dispatchPending: func() { server.scheduleSessionBlackboardConclusionDispatch(retried) },
+		dispatchInitial: func() {
+			queued := server.enqueueProviderTaskControl(sessionID, func(ctx context.Context) {
+				if err := server.sendSessionBlackboardConclusionTurn(ctx, retried, concludeDirective(sessionConclusionDirectiveProfile, pointerValue(retried.BaseRevision))); err != nil {
+					server.requireSessionBlackboardConclusionRecovery(retried, session.ConclusionRecoveryDispatchFailed, err)
+				}
+			})
+			if !queued {
+				server.requireSessionBlackboardConclusionRecovery(retried, session.ConclusionRecoveryDispatchFailed, fmt.Errorf("provider control queue is closed"))
+			}
+		},
 		dispatchRepair: func() {
 			queued := server.enqueueProviderTaskControl(sessionID, func(ctx context.Context) {
 				if err := server.sendSessionBlackboardConclusionTurn(ctx, retried, repairDirective(sessionConclusionDirectiveProfile, pointerValue(retried.BaseRevision), conclusionDetailFromSessionReceipt(retried))); err != nil {

--- a/internal/daemon/session_blackboard_conclusion.go
+++ b/internal/daemon/session_blackboard_conclusion.go
@@ -484,7 +484,7 @@ func (server *Server) handleRetrySessionBlackboardConclusion(response http.Respo
 		retry: func(idempotencyKey string) (bool, conclusionRetryDispatchMode, error) {
 			var won bool
 			var err error
-			retried, won, err = server.sessions.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(
+			retried, won, err = server.sessions.RetryLatestBlackboardConclusion(
 				sessionID, idempotencyKey, time.Now().UTC(),
 			)
 			if err == nil {

--- a/internal/daemon/session_blackboard_conclusion_recovery.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery.go
@@ -117,18 +117,7 @@ func (server *Server) resumeLiveSessionBlackboardConclusionObligation(ctx contex
 		},
 		Dispatch: func(state string, baseRevision int, explicitRetryCount int) {
 			server.enqueueRecoveredSessionBlackboardConclusion(obligation, func(controlCtx context.Context) error {
-				directive := concludeDirective(sessionConclusionDirectiveProfile, baseRevision)
-				switch session.BlackboardConclusionReceiptState(state) {
-				case session.BlackboardConclusionReceiptRepairDispatchRequested:
-					directive = repairDirective(sessionConclusionDirectiveProfile, baseRevision, conclusionDetailFromSessionReceipt(obligation))
-				case session.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
-					directive = regenerateDirective(sessionConclusionDirectiveProfile, baseRevision)
-				default:
-					if explicitRetryCount > 0 {
-						directive = repairDirective(sessionConclusionDirectiveProfile, baseRevision, conclusionDetailFromSessionReceipt(obligation))
-					}
-				}
-				return server.sendSessionBlackboardConclusionTurn(controlCtx, obligation, directive)
+				return server.dispatchRecoveredSessionConclusionDispatch(controlCtx, obligation)
 			})
 		},
 		VersionSync: func() {

--- a/internal/daemon/session_blackboard_conclusion_recovery.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery.go
@@ -178,14 +178,22 @@ func (server *Server) scheduleRecoveredSessionConclusionDispatch(view session.Bl
 
 func (server *Server) dispatchRecoveredSessionConclusionDispatch(ctx context.Context, view session.BlackboardConclusionReceipt) error {
 	directive := concludeDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
-	switch view.InternalState {
-	case session.BlackboardConclusionReceiptRepairDispatchRequested:
+	switch view.DispatchKind {
+	case session.ConclusionDispatchKindInitial:
+	case session.ConclusionDispatchKindRepair, session.ConclusionDispatchKindRetry:
 		directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
-	case session.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
+	case session.ConclusionDispatchKindVersionRegeneration:
 		directive = regenerateDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	default:
-		if view.ExplicitRetryCount > 0 {
+		switch view.InternalState {
+		case session.BlackboardConclusionReceiptRepairDispatchRequested:
 			directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
+		case session.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
+			directive = regenerateDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
+		default:
+			if view.ExplicitRetryCount > 0 {
+				directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
+			}
 		}
 	}
 	return server.sendSessionBlackboardConclusionTurn(ctx, view, directive)

--- a/internal/daemon/session_blackboard_conclusion_recovery.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery.go
@@ -167,21 +167,31 @@ func (server *Server) scheduleRecoveredSessionConclusionDispatch(view session.Bl
 
 func (server *Server) dispatchRecoveredSessionConclusionDispatch(ctx context.Context, view session.BlackboardConclusionReceipt) error {
 	directive := concludeDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
-	switch view.DispatchKind {
-	case session.ConclusionDispatchKindInitial:
-	case session.ConclusionDispatchKindRepair, session.ConclusionDispatchKindRetry:
+	switch view.DirectiveKind {
+	case session.ConclusionDirectiveKindInitial:
+	case session.ConclusionDirectiveKindRepair:
 		directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
-	case session.ConclusionDispatchKindVersionRegeneration:
+	case session.ConclusionDirectiveKindVersionRegeneration:
 		directive = regenerateDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 	default:
-		switch view.InternalState {
-		case session.BlackboardConclusionReceiptRepairDispatchRequested:
+		// Legacy dispatches created before directive_kind use the durable
+		// protocol state and counters as a compatibility fallback.
+		switch view.DispatchKind {
+		case session.ConclusionDispatchKindInitial:
+		case session.ConclusionDispatchKindRepair, session.ConclusionDispatchKindRetry:
 			directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
-		case session.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
+		case session.ConclusionDispatchKindVersionRegeneration:
 			directive = regenerateDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
 		default:
-			if view.ExplicitRetryCount > 0 {
+			switch view.InternalState {
+			case session.BlackboardConclusionReceiptRepairDispatchRequested:
 				directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
+			case session.BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
+				directive = regenerateDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision))
+			default:
+				if view.ExplicitRetryCount > 0 {
+					directive = repairDirective(sessionConclusionDirectiveProfile, pointerValue(view.BaseRevision), conclusionDetailFromSessionReceipt(view))
+				}
 			}
 		}
 	}

--- a/internal/daemon/session_blackboard_conclusion_recovery_test.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery_test.go
@@ -270,8 +270,15 @@ func TestSessionInitialRuntimeRetryRemainsInitialAfterRestart(t *testing.T) {
 	rebound, created, err := server.sessions.CreateRecoveryConclusionDispatch(
 		retried.ID, replacement.ID, replacement.NativeSessionID, now.Add(time.Second),
 	)
-	if err != nil || !created || rebound.DispatchKind != session.ConclusionDispatchKindInitial {
+	if err != nil || !created || rebound.DispatchKind != session.ConclusionDispatchKindRecovery ||
+		rebound.DirectiveKind != session.ConclusionDirectiveKindInitial {
 		t.Fatalf("rebind initial retry=%#v created=%v err=%v", rebound, created, err)
+	}
+	if _, err := server.db.Exec(`UPDATE session_conclusion_dispatches SET directive_kind='' WHERE id=?`, rebound.ActiveDispatchID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.db.Exec(`DELETE FROM schema_migrations WHERE version=60`); err != nil {
+		t.Fatal(err)
 	}
 	if err := server.Close(); err != nil {
 		t.Fatal(err)

--- a/internal/daemon/session_blackboard_conclusion_recovery_test.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,5 +195,80 @@ func TestRetrySessionConclusionBindsProvenLiveReplacementRuntime(t *testing.T) {
 	}
 	if !foundInitial {
 		t.Fatalf("initial Session dispatch missing from history=%#v", history)
+	}
+}
+
+func TestSessionInitialRuntimeRetryRemainsInitialAfterRestart(t *testing.T) {
+	root := t.TempDir()
+	server, err := NewServer(Config{
+		Version: "test", DBPath: filepath.Join(root, "pentest.db"), RuntimeRoot: filepath.Join(root, "runs"),
+		DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found, err := server.sessions.Create(session.CreateRequest{
+		Input: "restart initial Session conclusion", BlackboardConclusionMode: session.BlackboardConclusionModeAssisted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation, err := server.sessions.CreateContinuation(found.ID, "profile-1", "codex", session.RunnerHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation, err = server.sessions.UpdateContinuationRuntimeMetadata(
+		continuation.ID, "", "assisted-session", "/sessions/assisted-session.jsonl",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.sessions.UpdateContinuationStatus(continuation.ID, session.RuntimeStatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.blackboardV2.BindSessionContinuation(context.Background(), found.ID, continuation.ID); err != nil {
+		t.Fatal(err)
+	}
+	receipt, _, err := server.sessions.RecordBlackboardConclusionCheckpoint(
+		found.ID, continuation.ID, "work-request-initial-restart", continuation.NativeSessionID, "work-turn-initial-restart",
+		session.RuntimeTurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		session.SemanticDebtWatermarks{SourceWork: 1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, changed, err := server.sessions.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
+		receipt.ID, session.ConclusionRecoveryRuntimeOwnershipNotProven, now, 0,
+	); err != nil || !changed {
+		t.Fatalf("mark recovery: changed=%v err=%v", changed, err)
+	}
+	retried, won, initial, err := server.sessions.RetryLatestBlackboardConclusionForRuntime(
+		found.ID, "session-restart-initial", continuation.ID, continuation.NativeSessionID, 0, now,
+	)
+	if err != nil || !won || !initial || retried.DispatchKind != session.ConclusionDispatchKindInitial {
+		t.Fatalf("persist initial retry=%#v won=%v initial=%v err=%v", retried, won, initial, err)
+	}
+	if err := server.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := newConclusionRecoverySession()
+	restarted, err := NewServer(Config{
+		Version: "test", DBPath: filepath.Join(root, "pentest.db"), RuntimeRoot: filepath.Join(root, "runs"),
+		DisableBuiltinSkills: true,
+		ProviderSessionFactory: &conclusionRecoveryFactory{
+			session: provider, liveness: ProviderSessionRecoveryLive,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	restarted.providerControlWG.Wait()
+	requests := provider.LastRequests()
+	if len(requests) != 1 || !strings.Contains(requests[0].Message, "perform only the Harness conclusion below") ||
+		strings.Contains(requests[0].Message, "previous Blackboard conclusion result was invalid") {
+		t.Fatalf("restarted initial Session directive=%#v", requests)
 	}
 }

--- a/internal/daemon/session_blackboard_conclusion_recovery_test.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery_test.go
@@ -1,10 +1,16 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"pentest/internal/runtime"
+	"pentest/internal/runtimeplugin"
 	"pentest/internal/session"
 )
 
@@ -56,5 +62,137 @@ func TestAssistedSessionRestartReplaysAPreSendReceiptWithProvenRuntimeOwnership(
 	requests := provider.LastRequests()
 	if len(requests) != 1 || requests[0].RequestID != recovered.DispatchRequestID {
 		t.Fatalf("recovered Session provider requests = %#v", requests)
+	}
+}
+
+func TestRetrySessionConclusionBindsProvenLiveReplacementRuntime(t *testing.T) {
+	server, err := NewServer(Config{
+		Version: "test", DBPath: filepath.Join(t.TempDir(), "pentest.db"), RuntimeRoot: t.TempDir(),
+		DisableBuiltinSkills: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+	found, err := server.sessions.Create(session.CreateRequest{
+		Input: "retry Session conclusion", BlackboardConclusionMode: session.BlackboardConclusionModeAssisted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, err := server.sessions.CreateContinuation(found.ID, "profile-1", "codex", session.RunnerSandbox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, err = server.sessions.UpdateContinuationRuntimeMetadata(original.ID, "", "session-original", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.sessions.UpdateContinuationStatus(original.ID, session.RuntimeStatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.blackboardV2.BindSessionContinuation(context.Background(), found.ID, original.ID); err != nil {
+		t.Fatal(err)
+	}
+	receipt, _, err := server.sessions.RecordBlackboardConclusionCheckpoint(
+		found.ID, original.ID, "work-request-rebind", original.NativeSessionID, "work-turn-rebind",
+		session.RuntimeTurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		session.SemanticDebtWatermarks{SourceWork: 1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, won, err := server.sessions.ClaimBlackboardConclusionDispatch(receipt.ID, 0)
+	if err != nil || !won {
+		t.Fatalf("claim initial dispatch: %#v won=%v err=%v", initial, won, err)
+	}
+	if _, changed, err := server.sessions.MarkBlackboardConclusionRecoveryActionRequired(
+		initial.DispatchRequestID, session.ConclusionRecoveryDispatchFailed, time.Now().UTC(), 0,
+	); err != nil || !changed {
+		t.Fatalf("mark dispatch_failed: changed=%v err=%v", changed, err)
+	}
+	replacement, err := server.sessions.CreateReplacementContinuation(original, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.blackboardV2.RebindSessionContinuation(context.Background(), found.ID, original.ID, replacement.ID); err != nil {
+		t.Fatal(err)
+	}
+	const replacementSessionID = "session-replacement"
+	replacement, err = server.sessions.UpdateContinuationRuntimeMetadata(replacement.ID, "", replacementSessionID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.sessions.UpdateContinuationStatus(replacement.ID, session.RuntimeStatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	missingRuntimeRequest := httptest.NewRequest(http.MethodPost,
+		"/api/sessions/"+found.ID+"/blackboard-conclusion/retry", bytes.NewBufferString(`{}`))
+	missingRuntimeRequest.Header.Set("Idempotency-Key", "session-runtime-rebind")
+	missingRuntimeResponse := httptest.NewRecorder()
+	server.ServeHTTP(missingRuntimeResponse, missingRuntimeRequest)
+	if missingRuntimeResponse.Code != http.StatusConflict {
+		t.Fatalf("missing Runtime retry status=%d body=%s, want conflict", missingRuntimeResponse.Code, missingRuntimeResponse.Body.String())
+	}
+	mismatchedProvider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-other",
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, AssistedConclusion: true,
+		},
+	})
+	if err := server.BindSessionProviderSession(found.ID, mismatchedProvider); err != nil {
+		t.Fatal(err)
+	}
+	unprovenRequest := httptest.NewRequest(http.MethodPost,
+		"/api/sessions/"+found.ID+"/blackboard-conclusion/retry", bytes.NewBufferString(`{}`))
+	unprovenRequest.Header.Set("Idempotency-Key", "session-runtime-rebind")
+	unprovenResponse := httptest.NewRecorder()
+	server.ServeHTTP(unprovenResponse, unprovenRequest)
+	if unprovenResponse.Code != http.StatusConflict {
+		t.Fatalf("mismatched Runtime retry status=%d body=%s, want conflict", unprovenResponse.Code, unprovenResponse.Body.String())
+	}
+	_ = server.sessionProviderSessions.remove(found.ID)
+	provider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: replacementSessionID,
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, AssistedConclusion: true,
+		},
+	})
+	if err := server.BindSessionProviderSession(found.ID, provider); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost,
+		"/api/sessions/"+found.ID+"/blackboard-conclusion/retry", bytes.NewBufferString(`{}`))
+	request.Header.Set("Idempotency-Key", "session-runtime-rebind")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("retry status=%d body=%s, want accepted", response.Code, response.Body.String())
+	}
+	server.providerControlWG.Wait()
+	latest, err := server.sessions.LatestBlackboardConclusion(found.ID)
+	if err != nil || latest == nil || latest.InternalState != session.BlackboardConclusionReceiptAwaitingResult ||
+		latest.ContinuationID != replacement.ID || latest.SourceSessionID != replacementSessionID {
+		t.Fatalf("replacement Session retry=%#v err=%v", latest, err)
+	}
+	if requests := provider.LastRequests(); len(requests) != 1 || requests[0].RequestID != latest.DispatchRequestID {
+		t.Fatalf("replacement Session Runtime requests=%#v", requests)
+	}
+	history, err := server.sessions.ConclusionDispatches(receipt.ID)
+	if err != nil || len(history) != 2 {
+		t.Fatalf("immutable Session dispatch history=%#v err=%v", history, err)
+	}
+	foundInitial := false
+	for _, dispatch := range history {
+		if dispatch.DispatchRequestID == initial.DispatchRequestID {
+			foundInitial = true
+			if dispatch.ContinuationID != original.ID || dispatch.SourceSessionID != "session-original" ||
+				dispatch.DeliveryState != session.ConclusionDispatchSuperseded {
+				t.Fatalf("historical Session dispatch changed=%#v", dispatch)
+			}
+		}
+	}
+	if !foundInitial {
+		t.Fatalf("initial Session dispatch missing from history=%#v", history)
 	}
 }

--- a/internal/daemon/session_blackboard_conclusion_recovery_test.go
+++ b/internal/daemon/session_blackboard_conclusion_recovery_test.go
@@ -249,6 +249,30 @@ func TestSessionInitialRuntimeRetryRemainsInitialAfterRestart(t *testing.T) {
 	if err != nil || !won || !initial || retried.DispatchKind != session.ConclusionDispatchKindInitial {
 		t.Fatalf("persist initial retry=%#v won=%v initial=%v err=%v", retried, won, initial, err)
 	}
+	replacement, err := server.sessions.CreateReplacementContinuation(continuation, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.blackboardV2.RebindSessionContinuation(
+		context.Background(), found.ID, continuation.ID, replacement.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err = server.sessions.UpdateContinuationRuntimeMetadata(
+		replacement.ID, "", "assisted-session", "/sessions/assisted-session.jsonl",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.sessions.UpdateContinuationStatus(replacement.ID, session.RuntimeStatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	rebound, created, err := server.sessions.CreateRecoveryConclusionDispatch(
+		retried.ID, replacement.ID, replacement.NativeSessionID, now.Add(time.Second),
+	)
+	if err != nil || !created || rebound.DispatchKind != session.ConclusionDispatchKindInitial {
+		t.Fatalf("rebind initial retry=%#v created=%v err=%v", rebound, created, err)
+	}
 	if err := server.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/owner/assisted_conclusion.go
+++ b/internal/owner/assisted_conclusion.go
@@ -260,6 +260,17 @@ const (
 	ConclusionDispatchKindRecovery            ConclusionDispatchKind = "recovery"
 )
 
+// ConclusionDirectiveKind is the semantic control instruction carried by one
+// Conclusion Dispatch. Runtime recovery changes the immutable delivery
+// lineage, but it does not change this instruction.
+type ConclusionDirectiveKind string
+
+const (
+	ConclusionDirectiveKindInitial             ConclusionDirectiveKind = "initial"
+	ConclusionDirectiveKindRepair              ConclusionDirectiveKind = "repair"
+	ConclusionDirectiveKindVersionRegeneration ConclusionDirectiveKind = "version_regeneration"
+)
+
 // ConclusionDispatchState is the immutable attempt's own delivery lifecycle.
 // Only dispatch_requested, awaiting_result, and validated are active: the
 // storage partial unique index permits at most one active dispatch per

--- a/internal/owner/assisted_conclusion.go
+++ b/internal/owner/assisted_conclusion.go
@@ -325,3 +325,19 @@ func ValidConclusionRecoveryReason(reason ConclusionRecoveryReason) bool {
 		return false
 	}
 }
+
+// ConclusionRecoveryRequiresRuntimeBinding reports whether an operator retry
+// must create a new dispatch on a proven live replacement Runtime. An
+// acceptance-ambiguous delivery is deliberately excluded because it cannot be
+// retried safely at all.
+func ConclusionRecoveryRequiresRuntimeBinding(reason ConclusionRecoveryReason) bool {
+	switch reason {
+	case ConclusionRecoveryRuntimeOwnershipNotProven,
+		ConclusionRecoveryWritableReplacementUnavailable,
+		ConclusionRecoveryDispatchFailed,
+		ConclusionRecoveryLegacyCorrelationUnproven:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/owner/assisted_conclusion_test.go
+++ b/internal/owner/assisted_conclusion_test.go
@@ -87,3 +87,19 @@ func TestConclusionFailureAndRetryDecisionsAreOwnerNeutral(t *testing.T) {
 		t.Fatalf("ambiguous retry decision = %q", decision)
 	}
 }
+
+func TestConclusionRecoveryRequiresRuntimeBinding(t *testing.T) {
+	for _, reason := range []ConclusionRecoveryReason{
+		ConclusionRecoveryRuntimeOwnershipNotProven,
+		ConclusionRecoveryWritableReplacementUnavailable,
+		ConclusionRecoveryDispatchFailed,
+		ConclusionRecoveryLegacyCorrelationUnproven,
+	} {
+		if !ConclusionRecoveryRequiresRuntimeBinding(reason) {
+			t.Fatalf("reason %q must require a proven replacement Runtime binding", reason)
+		}
+	}
+	if ConclusionRecoveryRequiresRuntimeBinding(ConclusionRecoveryAcceptanceAmbiguous) {
+		t.Fatal("acceptance_ambiguous must remain non-retriable, not Runtime-rebindable")
+	}
+}

--- a/internal/owner/conclusion/conclusion.go
+++ b/internal/owner/conclusion/conclusion.go
@@ -82,6 +82,7 @@ type (
 	BlackboardConclusionReceiptState = owner.BlackboardConclusionReceiptState
 	BlackboardConclusionErrorCode    = owner.BlackboardConclusionErrorCode
 	ConclusionDispatchKind           = owner.ConclusionDispatchKind
+	ConclusionDirectiveKind          = owner.ConclusionDirectiveKind
 	ConclusionDispatchState          = owner.ConclusionDispatchState
 	ConclusionRecoveryReason         = owner.ConclusionRecoveryReason
 )
@@ -113,6 +114,9 @@ const (
 	ConclusionDispatchKindRepair                                    = owner.ConclusionDispatchKindRepair
 	ConclusionDispatchKindRetry                                     = owner.ConclusionDispatchKindRetry
 	ConclusionDispatchKindVersionRegeneration                       = owner.ConclusionDispatchKindVersionRegeneration
+	ConclusionDirectiveKindInitial                                  = owner.ConclusionDirectiveKindInitial
+	ConclusionDirectiveKindRepair                                   = owner.ConclusionDirectiveKindRepair
+	ConclusionDirectiveKindVersionRegeneration                      = owner.ConclusionDirectiveKindVersionRegeneration
 	ConclusionDispatchLateTerminal                                  = owner.ConclusionDispatchLateTerminal
 	ConclusionDispatchRequested                                     = owner.ConclusionDispatchRequested
 	ConclusionDispatchSuperseded                                    = owner.ConclusionDispatchSuperseded
@@ -182,6 +186,7 @@ type ConclusionDispatch struct {
 	ID                   string
 	ObligationID         string
 	Kind                 ConclusionDispatchKind
+	DirectiveKind        ConclusionDirectiveKind
 	ContinuationID       string
 	SourceSessionID      string
 	DispatchRequestID    string
@@ -231,6 +236,7 @@ type BlackboardConclusionReceipt struct {
 	RecoveryReason                string
 	ActiveDispatchID              string
 	DispatchKind                  ConclusionDispatchKind
+	DirectiveKind                 ConclusionDirectiveKind
 	ValidationReason              string
 	ValidationFieldPath           string
 	ValidationExpected            string
@@ -248,7 +254,7 @@ func (e *Engine) obligationColumns() string {
 		validation_reason,validation_field_path,validation_expected,created_at,updated_at`
 }
 
-const conclusionDispatchColumns = `id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,control_turn_id,base_revision,
+const conclusionDispatchColumns = `id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,control_turn_id,base_revision,
 	synchronized_revision,delivery_state,send_attempt_count,send_started_at,terminal_outcome,created_at,updated_at`
 
 // RecordBlackboardConclusionCheckpoint creates the one durable Pending
@@ -372,13 +378,14 @@ func (e *Engine) ClaimBlackboardConclusionDispatch(obligationID string, baseRevi
 	now := time.Now().UTC()
 	dispatch := ConclusionDispatch{
 		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindInitial,
+		DirectiveKind:  ConclusionDirectiveKindInitial,
 		ContinuationID: obligation.SourceContinuationID, SourceSessionID: obligation.SourceSessionID,
 		DispatchRequestID: dispatchID, BaseRevision: intPointer(baseRevision),
 		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
 	}
 	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, dispatch.ID, dispatch.ObligationID, string(dispatch.Kind), dispatch.ContinuationID,
+		(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?)`, dispatch.ID, dispatch.ObligationID, string(dispatch.Kind), string(dispatch.DirectiveKind), dispatch.ContinuationID,
 		dispatch.SourceSessionID, dispatch.DispatchRequestID, baseRevision, string(dispatch.DeliveryState),
 		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
 		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store initial Conclusion Dispatch: %w", err)
@@ -396,6 +403,7 @@ func (e *Engine) ClaimBlackboardConclusionDispatch(obligationID string, baseRevi
 	view := obligationView(obligation)
 	view.ActiveDispatchID = dispatch.ID
 	view.DispatchKind = dispatch.Kind
+	view.DirectiveKind = dispatch.DirectiveKind
 	view.DispatchRequestID = dispatch.DispatchRequestID
 	view.ContinuationID = dispatch.ContinuationID
 	view.SourceSessionID = dispatch.SourceSessionID
@@ -509,6 +517,7 @@ func (e *Engine) HandleBlackboardConclusionFailure(dispatchRequestID string, cod
 		nextEligible := now.Add(cooldown)
 		nowDispatch := ConclusionDispatch{
 			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRepair,
+			DirectiveKind:  ConclusionDirectiveKindRepair,
 			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
 			DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
 			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
@@ -517,8 +526,8 @@ func (e *Engine) HandleBlackboardConclusionFailure(dispatchRequestID string, cod
 			return BlackboardConclusionReceipt{}, false, err
 		}
 		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+			(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), string(nowDispatch.DirectiveKind), nowDispatch.ContinuationID,
 			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
 			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
 			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store repair Conclusion Dispatch: %w", err)
@@ -538,6 +547,7 @@ func (e *Engine) HandleBlackboardConclusionFailure(dispatchRequestID string, cod
 		view := obligationView(obligation)
 		view.ActiveDispatchID = nowDispatch.ID
 		view.DispatchKind = nowDispatch.Kind
+		view.DirectiveKind = nowDispatch.DirectiveKind
 		view.DispatchRequestID = nowDispatch.DispatchRequestID
 		view.ContinuationID = nowDispatch.ContinuationID
 		view.SourceSessionID = nowDispatch.SourceSessionID
@@ -630,6 +640,7 @@ func (e *Engine) HandleBlackboardConclusionVersionConflict(dispatchRequestID str
 		requestID := blackboardConclusionAttemptRequestID("version", dispatch.ContinuationID, obligation.SourceTurnID, 1, fmt.Sprintf("%d", currentRevision))
 		nowDispatch := ConclusionDispatch{
 			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindVersionRegeneration,
+			DirectiveKind:  ConclusionDirectiveKindVersionRegeneration,
 			ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
 			DispatchRequestID: requestID, BaseRevision: intPointer(currentRevision),
 			SynchronizedRevision: intPointer(currentRevision), DeliveryState: ConclusionDispatchRequested,
@@ -639,8 +650,8 @@ func (e *Engine) HandleBlackboardConclusionVersionConflict(dispatchRequestID str
 			return BlackboardConclusionReceipt{}, false, err
 		}
 		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,synchronized_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+			(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,base_revision,synchronized_revision,delivery_state,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), string(nowDispatch.DirectiveKind), nowDispatch.ContinuationID,
 			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, currentRevision, currentRevision, string(nowDispatch.DeliveryState),
 			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
 			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store version regeneration Conclusion Dispatch: %w", err)
@@ -659,6 +670,7 @@ func (e *Engine) HandleBlackboardConclusionVersionConflict(dispatchRequestID str
 		view := obligationView(obligation)
 		view.ActiveDispatchID = nowDispatch.ID
 		view.DispatchKind = nowDispatch.Kind
+		view.DirectiveKind = nowDispatch.DirectiveKind
 		view.DispatchRequestID = nowDispatch.DispatchRequestID
 		view.ContinuationID = nowDispatch.ContinuationID
 		view.SourceSessionID = nowDispatch.SourceSessionID
@@ -1142,13 +1154,14 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 			_, applyKey := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
 			nowDispatch := ConclusionDispatch{
 				ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindInitial,
+				DirectiveKind:  ConclusionDirectiveKindInitial,
 				ContinuationID: binding.ContinuationID, SourceSessionID: binding.SessionID,
 				DispatchRequestID: requestID, BaseRevision: intPointer(binding.BaseRevision),
 				DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
 			}
 			if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
-				(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-				VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+				(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+				VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), string(nowDispatch.DirectiveKind), nowDispatch.ContinuationID,
 				nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, binding.BaseRevision, string(nowDispatch.DeliveryState),
 				now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
 				return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("store replacement retry Conclusion Dispatch: %w", err)
@@ -1216,6 +1229,7 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 	requestID := blackboardConclusionAttemptRequestID("retry", dispatchContinuationID, obligation.SourceTurnID, retryNumber, idempotencyKey)
 	nowDispatch := ConclusionDispatch{
 		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRetry,
+		DirectiveKind:  ConclusionDirectiveKindRepair,
 		ContinuationID: dispatchContinuationID, SourceSessionID: dispatchSessionID,
 		DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision,
 		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
@@ -1224,8 +1238,8 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 		return BlackboardConclusionReceipt{}, false, false, err
 	}
 	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+		(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), string(nowDispatch.DirectiveKind), nowDispatch.ContinuationID,
 		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
 		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
 		return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("store retry Conclusion Dispatch: %w", err)
@@ -1258,6 +1272,7 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 	view := obligationView(obligation)
 	view.ActiveDispatchID = nowDispatch.ID
 	view.DispatchKind = nowDispatch.Kind
+	view.DirectiveKind = nowDispatch.DirectiveKind
 	view.DispatchRequestID = nowDispatch.DispatchRequestID
 	view.ContinuationID = nowDispatch.ContinuationID
 	view.SourceSessionID = nowDispatch.SourceSessionID
@@ -1550,21 +1565,22 @@ func (e *Engine) CreateRecoveryConclusionDispatches(taskID, oldContinuationID, r
 				return nil, err
 			}
 		}
-		dispatchKind, kindErr := e.recoveryConclusionDispatchKindTx(tx, obligation, dispatch)
+		directiveKind, kindErr := e.recoveryConclusionDirectiveKindTx(tx, obligation, dispatch)
 		if kindErr != nil {
 			return nil, kindErr
 		}
 		number := e.conclusionDispatchSequence(tx, obligation.ID) + 1
 		requestID := blackboardConclusionAttemptRequestID("recovery", replacementContinuationID, obligation.SourceTurnID, number, "")
 		nowDispatch := ConclusionDispatch{
-			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: dispatchKind,
+			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
+			DirectiveKind:  directiveKind,
 			ContinuationID: replacementContinuationID, SourceSessionID: replacementSessionID,
 			DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
 			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
 		}
 		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
-			(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-			VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+			(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), string(nowDispatch.DirectiveKind), nowDispatch.ContinuationID,
 			nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
 			now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
 			return nil, fmt.Errorf("store recovery Conclusion Dispatch: %w", err)
@@ -1580,6 +1596,7 @@ func (e *Engine) CreateRecoveryConclusionDispatches(taskID, oldContinuationID, r
 		view := obligationView(obligation)
 		view.ActiveDispatchID = nowDispatch.ID
 		view.DispatchKind = nowDispatch.Kind
+		view.DirectiveKind = nowDispatch.DirectiveKind
 		view.DispatchRequestID = nowDispatch.DispatchRequestID
 		view.ContinuationID = nowDispatch.ContinuationID
 		view.SourceSessionID = nowDispatch.SourceSessionID
@@ -1643,21 +1660,22 @@ func (e *Engine) CreateRecoveryConclusionDispatch(obligationID, continuationID, 
 			return BlackboardConclusionReceipt{}, false, err
 		}
 	}
-	dispatchKind, err := e.recoveryConclusionDispatchKindTx(tx, obligation, dispatch)
+	directiveKind, err := e.recoveryConclusionDirectiveKindTx(tx, obligation, dispatch)
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, err
 	}
 	number := e.conclusionDispatchSequence(tx, obligation.ID) + 1
 	requestID := blackboardConclusionAttemptRequestID("recovery", continuationID, obligation.SourceTurnID, number, "")
 	nowDispatch := ConclusionDispatch{
-		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: dispatchKind,
+		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
+		DirectiveKind:  directiveKind,
 		ContinuationID: continuationID, SourceSessionID: sessionID,
 		DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
 		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
 	}
 	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
-		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+		(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), string(nowDispatch.DirectiveKind), nowDispatch.ContinuationID,
 		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
 		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
 		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store recovery Conclusion Dispatch: %w", err)
@@ -1673,6 +1691,7 @@ func (e *Engine) CreateRecoveryConclusionDispatch(obligationID, continuationID, 
 	view := obligationView(obligation)
 	view.ActiveDispatchID = nowDispatch.ID
 	view.DispatchKind = nowDispatch.Kind
+	view.DirectiveKind = nowDispatch.DirectiveKind
 	view.DispatchRequestID = nowDispatch.DispatchRequestID
 	view.ContinuationID = nowDispatch.ContinuationID
 	view.SourceSessionID = nowDispatch.SourceSessionID
@@ -1690,32 +1709,46 @@ func (e *Engine) CreateRecoveryConclusionDispatch(obligationID, continuationID, 
 	return view, true, nil
 }
 
-func (e *Engine) recoveryConclusionDispatchKindTx(tx *sql.Tx, obligation PendingBlackboardConclusion, active *ConclusionDispatch) (ConclusionDispatchKind, error) {
-	if active != nil && active.Kind != ConclusionDispatchKindRecovery {
-		return active.Kind, nil
+func (e *Engine) recoveryConclusionDirectiveKindTx(tx *sql.Tx, obligation PendingBlackboardConclusion, active *ConclusionDispatch) (ConclusionDirectiveKind, error) {
+	if active != nil && active.DirectiveKind != "" {
+		return active.DirectiveKind, nil
 	}
-	var stored string
-	err := tx.QueryRow(`SELECT kind FROM `+e.Dialect.DispatchesTable+`
-		WHERE obligation_id=? AND kind<>? ORDER BY created_at DESC,id DESC LIMIT 1`,
-		obligation.ID, string(ConclusionDispatchKindRecovery)).Scan(&stored)
+	var storedDirective, storedDispatch string
+	err := tx.QueryRow(`SELECT directive_kind,kind FROM `+e.Dialect.DispatchesTable+`
+		WHERE obligation_id=? AND (directive_kind<>'' OR kind<>?) ORDER BY created_at DESC,id DESC LIMIT 1`,
+		obligation.ID, string(ConclusionDispatchKindRecovery)).Scan(&storedDirective, &storedDispatch)
 	if err == nil {
-		return ConclusionDispatchKind(stored), nil
+		if storedDirective != "" {
+			return ConclusionDirectiveKind(storedDirective), nil
+		}
+		return directiveKindFromLegacyDispatchKind(ConclusionDispatchKind(storedDispatch)), nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("read recovery Conclusion Dispatch semantic kind: %w", err)
+		return "", fmt.Errorf("read recovery Conclusion Dispatch directive kind: %w", err)
 	}
 	switch obligation.State {
 	case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptDispatchRequested, BlackboardConclusionReceiptAwaitingResult:
 		if obligation.ExplicitRetryCount > 0 {
-			return ConclusionDispatchKindRetry, nil
+			return ConclusionDirectiveKindRepair, nil
 		}
-		return ConclusionDispatchKindInitial, nil
+		return ConclusionDirectiveKindInitial, nil
 	case BlackboardConclusionReceiptRepairDispatchRequested:
-		return ConclusionDispatchKindRepair, nil
+		return ConclusionDirectiveKindRepair, nil
 	case BlackboardConclusionReceiptVersionSyncRequested, BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
-		return ConclusionDispatchKindVersionRegeneration, nil
+		return ConclusionDirectiveKindVersionRegeneration, nil
 	default:
-		return ConclusionDispatchKindRecovery, nil
+		return ConclusionDirectiveKindInitial, nil
+	}
+}
+
+func directiveKindFromLegacyDispatchKind(kind ConclusionDispatchKind) ConclusionDirectiveKind {
+	switch kind {
+	case ConclusionDispatchKindRepair, ConclusionDispatchKindRetry:
+		return ConclusionDirectiveKindRepair
+	case ConclusionDispatchKindVersionRegeneration:
+		return ConclusionDirectiveKindVersionRegeneration
+	default:
+		return ConclusionDirectiveKindInitial
 	}
 }
 
@@ -1766,6 +1799,7 @@ func blackboardConclusionReceiptFromObligationDispatch(dispatch *ConclusionDispa
 	view.SendStartedAt = dispatch.SendStartedAt
 	view.ActiveDispatchID = dispatch.ID
 	view.DispatchKind = dispatch.Kind
+	view.DirectiveKind = dispatch.DirectiveKind
 	return view
 }
 
@@ -2049,15 +2083,16 @@ func (e *Engine) scanPendingBlackboardConclusion(row interface{ Scan(...any) err
 
 func (e *Engine) scanConclusionDispatch(row interface{ Scan(...any) error }) (ConclusionDispatch, error) {
 	var dispatch ConclusionDispatch
-	var kind, deliveryState, createdAt, updatedAt string
+	var kind, directiveKind, deliveryState, createdAt, updatedAt string
 	var dispatchRequestID, controlTurnID, sendStartedAt, terminalOutcome sql.NullString
 	var baseRevision, synchronizedRevision sql.NullInt64
-	if err := row.Scan(&dispatch.ID, &dispatch.ObligationID, &kind, &dispatch.ContinuationID, &dispatch.SourceSessionID,
+	if err := row.Scan(&dispatch.ID, &dispatch.ObligationID, &kind, &directiveKind, &dispatch.ContinuationID, &dispatch.SourceSessionID,
 		&dispatchRequestID, &controlTurnID, &baseRevision, &synchronizedRevision, &deliveryState,
 		&dispatch.SendAttemptCount, &sendStartedAt, &terminalOutcome, &createdAt, &updatedAt); err != nil {
 		return ConclusionDispatch{}, err
 	}
 	dispatch.Kind = ConclusionDispatchKind(kind)
+	dispatch.DirectiveKind = ConclusionDirectiveKind(directiveKind)
 	dispatch.DeliveryState = ConclusionDispatchState(deliveryState)
 	dispatch.DispatchRequestID = dispatchRequestID.String
 	dispatch.ControlTurnID = controlTurnID.String

--- a/internal/owner/conclusion/conclusion.go
+++ b/internal/owner/conclusion/conclusion.go
@@ -1017,7 +1017,7 @@ func (e *Engine) RetryBlackboardConclusion(obligationID, idempotencyKey string, 
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
 	}
-	receipt, won, _, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, nil, false, now)
+	receipt, won, _, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, nil, now)
 	if err != nil || !won {
 		return receipt, won, err
 	}
@@ -1030,14 +1030,7 @@ func (e *Engine) RetryBlackboardConclusion(obligationID, idempotencyKey string, 
 // RetryLatestBlackboardConclusion atomically applies an owner-scoped operator
 // retry key to the latest durable conclusion obligation.
 func (e *Engine) RetryLatestBlackboardConclusion(ownerID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	receipt, won, _, err := e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, nil, false, now)
-	return receipt, won, err
-}
-
-// RetryLatestBlackboardConclusionFailClosedOnDispatchFailure atomically
-// retries only when no daemon-proven replacement Runtime binding is required.
-func (e *Engine) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(ownerID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	receipt, won, _, err := e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, nil, true, now)
+	receipt, won, _, err := e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, nil, now)
 	return receipt, won, err
 }
 
@@ -1050,10 +1043,10 @@ func (e *Engine) RetryLatestBlackboardConclusionForRuntime(ownerID, idempotencyK
 	if binding.ContinuationID == "" || binding.SessionID == "" || binding.BaseRevision < 0 {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
-	return e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, &binding, true, now)
+	return e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, &binding, now)
 }
 
-func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string, binding *RetryRuntimeBinding, requireRuntimeBinding bool, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
+func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string, binding *RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
 	ownerID, idempotencyKey = strings.TrimSpace(ownerID), strings.TrimSpace(idempotencyKey)
 	if ownerID == "" || idempotencyKey == "" {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
@@ -1086,7 +1079,7 @@ func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string,
 			return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 		}
 	}
-	receipt, won, initial, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, binding, requireRuntimeBinding, now)
+	receipt, won, initial, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, binding, now)
 	if err != nil || !won {
 		return receipt, won, initial, err
 	}
@@ -1096,7 +1089,7 @@ func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string,
 	return receipt, true, initial, nil
 }
 
-func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, binding *RetryRuntimeBinding, requireRuntimeBinding bool, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
+func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, binding *RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
 	var priorObligationID string
 	err := tx.QueryRow(`SELECT `+e.Dialect.RetryKeysReceiptColumn+` FROM `+e.Dialect.RetryKeysTable+`
 		WHERE `+e.Dialect.RetryKeysOwnerColumn+`=? AND idempotency_key=?`, obligation.OwnerID, idempotencyKey).Scan(&priorObligationID)
@@ -1114,7 +1107,7 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 	if !errors.Is(err, sql.ErrNoRows) {
 		return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("read "+e.Dialect.Subject+" retry idempotency history: %w", err)
 	}
-	if requireRuntimeBinding && owner.ConclusionRecoveryRequiresRuntimeBinding(obligation.RecoveryReason) && binding == nil {
+	if owner.ConclusionRecoveryRequiresRuntimeBinding(obligation.RecoveryReason) && binding == nil {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	if binding != nil && !owner.ConclusionRecoveryRequiresRuntimeBinding(obligation.RecoveryReason) {

--- a/internal/owner/conclusion/conclusion.go
+++ b/internal/owner/conclusion/conclusion.go
@@ -56,6 +56,15 @@ type Engine struct {
 	Dialect Dialect
 }
 
+// RetryRuntimeBinding is a daemon-proven live Runtime target for one
+// operator-authorized retry. The Engine revalidates the durable owner,
+// Continuation, and native session binding inside the retry transaction.
+type RetryRuntimeBinding struct {
+	ContinuationID string
+	SessionID      string
+	BaseRevision   int
+}
+
 // Selection is the owner-neutral Runtime Turn Selection snapshot retained on
 // an obligation.
 type Selection struct {
@@ -1008,7 +1017,7 @@ func (e *Engine) RetryBlackboardConclusion(obligationID, idempotencyKey string, 
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
 	}
-	receipt, won, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
+	receipt, won, _, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, nil, now)
 	if err != nil || !won {
 		return receipt, won, err
 	}
@@ -1018,63 +1027,100 @@ func (e *Engine) RetryBlackboardConclusion(obligationID, idempotencyKey string, 
 	return receipt, true, nil
 }
 
-// RetryLatestBlackboardConclusion atomically applies a Task-scoped operator
+// RetryLatestBlackboardConclusion atomically applies an owner-scoped operator
 // retry key to the latest durable conclusion obligation.
 func (e *Engine) RetryLatestBlackboardConclusion(ownerID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	receipt, won, _, err := e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, nil, now)
+	return receipt, won, err
+}
+
+// RetryLatestBlackboardConclusionForRuntime atomically binds a dispatch_failed
+// retry to a daemon-proven live replacement Runtime. Initial is true only when
+// the obligation had never created a prior Conclusion Dispatch.
+func (e *Engine) RetryLatestBlackboardConclusionForRuntime(ownerID, idempotencyKey string, binding RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
+	binding.ContinuationID = strings.TrimSpace(binding.ContinuationID)
+	binding.SessionID = strings.TrimSpace(binding.SessionID)
+	if binding.ContinuationID == "" || binding.SessionID == "" || binding.BaseRevision < 0 {
+		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
+	}
+	return e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, &binding, now)
+}
+
+func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string, binding *RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
 	ownerID, idempotencyKey = strings.TrimSpace(ownerID), strings.TrimSpace(idempotencyKey)
 	if ownerID == "" || idempotencyKey == "" {
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	now = now.UTC()
 	tx, err := e.DB.Begin()
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, false, err
 	}
 	defer func() { _ = tx.Rollback() }()
 	obligation, err := e.scanPendingBlackboardConclusion(tx.QueryRow(`SELECT `+e.obligationColumns()+`
 		FROM `+e.Dialect.ObligationsTable+` WHERE `+e.Dialect.OwnerColumn+`=? ORDER BY created_at DESC,id DESC LIMIT 1`, ownerID))
 	if err != nil {
-		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
+		return BlackboardConclusionReceipt{}, false, false, e.blackboardConclusionLookupError(err)
 	}
-	receipt, won, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, now)
+	if binding != nil {
+		var activeContinuationID, continuationStatus, nativeSessionID string
+		if err := tx.QueryRow(`SELECT id,status,native_session_id FROM `+e.Dialect.ContinuationsTable+`
+			WHERE `+e.Dialect.ContinuationOwnerColumn+`=? AND status IN ('pending','running','paused')
+			ORDER BY number DESC LIMIT 1`, ownerID).
+			Scan(&activeContinuationID, &continuationStatus, &nativeSessionID); err != nil {
+			return BlackboardConclusionReceipt{}, false, false, e.blackboardConclusionLookupError(err)
+		}
+		if activeContinuationID != binding.ContinuationID || strings.TrimSpace(nativeSessionID) != binding.SessionID {
+			return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
+		}
+		switch continuationStatus {
+		case "pending", "running", "paused":
+		default:
+			return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
+		}
+	}
+	receipt, won, initial, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, binding, now)
 	if err != nil || !won {
-		return receipt, won, err
+		return receipt, won, initial, err
 	}
 	if err := tx.Commit(); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, false, err
 	}
-	return receipt, true, nil
+	return receipt, true, initial, nil
 }
 
-func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, binding *RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
 	var priorObligationID string
 	err := tx.QueryRow(`SELECT `+e.Dialect.RetryKeysReceiptColumn+` FROM `+e.Dialect.RetryKeysTable+`
 		WHERE `+e.Dialect.RetryKeysOwnerColumn+`=? AND idempotency_key=?`, obligation.OwnerID, idempotencyKey).Scan(&priorObligationID)
 	if err == nil {
 		prior, loadErr := e.loadPendingBlackboardConclusionByID(tx, priorObligationID)
 		if loadErr != nil {
-			return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(loadErr)
+			return BlackboardConclusionReceipt{}, false, false, e.blackboardConclusionLookupError(loadErr)
 		}
 		view, viewErr := e.combinedConclusionView(tx, prior)
 		if viewErr != nil {
-			return BlackboardConclusionReceipt{}, false, viewErr
+			return BlackboardConclusionReceipt{}, false, false, viewErr
 		}
-		return view, false, nil
+		return view, false, false, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("read "+e.Dialect.Subject+" retry idempotency history: %w", err)
+		return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("read "+e.Dialect.Subject+" retry idempotency history: %w", err)
+	}
+	if binding != nil && obligation.RecoveryReason != ConclusionRecoveryDispatchFailed {
+		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	switch owner.ConclusionRetryDecisionFor(obligation.State, obligation.ErrorCode, obligation.RecoveryReason, obligation.NextEligibleAt, now) {
 	case owner.ConclusionRetryInvalidState:
-		return BlackboardConclusionReceipt{}, false, ErrInvalidBlackboardConclusionReceipt
+		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	case owner.ConclusionRetryNeverSettled:
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionWorkTurnNeverSettled
+		return BlackboardConclusionReceipt{}, false, false, ErrBlackboardConclusionWorkTurnNeverSettled
 	case owner.ConclusionRetryAcceptanceAmbiguous, owner.ConclusionRetryCooldown:
-		return BlackboardConclusionReceipt{}, false, ErrBlackboardConclusionRetryCooldown
+		return BlackboardConclusionReceipt{}, false, false, ErrBlackboardConclusionRetryCooldown
 	}
 	dispatch, err := e.activeConclusionDispatchTx(tx, obligation.ID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, false, err
 	}
 	if dispatch == nil {
 		// No active dispatch (for example the failed repair was superseded).
@@ -1083,11 +1129,54 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 		// source binding of the completed Work Turn.
 		dispatch, err = e.latestConclusionDispatchTx(tx, obligation.ID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return BlackboardConclusionReceipt{}, false, err
+			return BlackboardConclusionReceipt{}, false, false, err
 		}
 	}
 	retryNumber := obligation.ExplicitRetryCount + 1
 	if dispatch == nil {
+		if binding != nil {
+			requestID := blackboardConclusionAttemptRequestID("retry", binding.ContinuationID, obligation.SourceTurnID, retryNumber, idempotencyKey)
+			_, applyKey := blackboardConclusionRequestLineage(obligation.SourceContinuationID, obligation.SourceTurnID)
+			nowDispatch := ConclusionDispatch{
+				ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindInitial,
+				ContinuationID: binding.ContinuationID, SourceSessionID: binding.SessionID,
+				DispatchRequestID: requestID, BaseRevision: intPointer(binding.BaseRevision),
+				DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
+			}
+			if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
+				(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
+				VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
+				nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, binding.BaseRevision, string(nowDispatch.DeliveryState),
+				now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+				return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("store replacement retry Conclusion Dispatch: %w", err)
+			}
+			obligation.State = BlackboardConclusionReceiptDispatchRequested
+			obligation.ExplicitRetryCount++
+			obligation.OperatorRetryKey = idempotencyKey
+			obligation.ApplyIdempotencyKey = applyKey
+			obligation.BaseRevision = intPointer(binding.BaseRevision)
+			obligation.AutomaticTurnCount++
+			obligation.ErrorCode = ""
+			obligation.RecoveryReason = ""
+			obligation.NextEligibleAt = nil
+			obligation.UpdatedAt = now
+			if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
+				return BlackboardConclusionReceipt{}, false, false, err
+			}
+			if _, err := tx.Exec(`INSERT INTO `+e.Dialect.RetryKeysTable+`
+				(`+e.Dialect.RetryKeysOwnerColumn+`,`+e.Dialect.RetryKeysReceiptColumn+`,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
+				obligation.OwnerID, obligation.ID, idempotencyKey, requestID, now.Format(time.RFC3339Nano)); err != nil {
+				return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("store replacement "+e.Dialect.Subject+" retry history: %w", err)
+			}
+			view := blackboardConclusionReceiptFromObligationDispatch(&nowDispatch, obligation)
+			if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{
+				"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": requestID,
+				"explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control",
+			}, now); err != nil {
+				return BlackboardConclusionReceipt{}, false, false, err
+			}
+			return view, true, true, nil
+		}
 		// Never-dispatched obligation: re-arm to pending so the initial claim
 		// runs on the live runtime. The retry history records the deterministic
 		// initial request lineage.
@@ -1099,42 +1188,53 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 		obligation.NextEligibleAt = nil
 		obligation.UpdatedAt = now
 		if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
+			return BlackboardConclusionReceipt{}, false, false, err
 		}
 		if _, err := tx.Exec(`INSERT INTO `+e.Dialect.RetryKeysTable+`
 			(`+e.Dialect.RetryKeysOwnerColumn+`,`+e.Dialect.RetryKeysReceiptColumn+`,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
 			obligation.OwnerID, obligation.ID, idempotencyKey, initialRequestID, now.Format(time.RFC3339Nano)); err != nil {
-			return BlackboardConclusionReceipt{}, false, fmt.Errorf("store pending "+e.Dialect.Subject+" retry history: %w", err)
+			return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("store pending "+e.Dialect.Subject+" retry history: %w", err)
 		}
 		if err := e.appendBlackboardConclusionEventTx(tx, obligationView(obligation), map[string]any{
 			"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": initialRequestID,
 			"explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control",
 		}, now); err != nil {
-			return BlackboardConclusionReceipt{}, false, err
+			return BlackboardConclusionReceipt{}, false, false, err
 		}
-		return obligationView(obligation), true, nil
+		return obligationView(obligation), true, true, nil
 	}
-	requestID := blackboardConclusionAttemptRequestID("retry", dispatch.ContinuationID, obligation.SourceTurnID, retryNumber, idempotencyKey)
+	dispatchContinuationID, dispatchSessionID := dispatch.ContinuationID, dispatch.SourceSessionID
+	dispatchBaseRevision := dispatch.BaseRevision
+	if binding != nil {
+		dispatchContinuationID = binding.ContinuationID
+		dispatchSessionID = binding.SessionID
+		dispatchBaseRevision = intPointer(binding.BaseRevision)
+	}
+	requestID := blackboardConclusionAttemptRequestID("retry", dispatchContinuationID, obligation.SourceTurnID, retryNumber, idempotencyKey)
 	nowDispatch := ConclusionDispatch{
 		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRetry,
-		ContinuationID: dispatch.ContinuationID, SourceSessionID: dispatch.SourceSessionID,
-		DispatchRequestID: requestID, BaseRevision: dispatch.BaseRevision,
+		ContinuationID: dispatchContinuationID, SourceSessionID: dispatchSessionID,
+		DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision,
 		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
 	}
 	if err := e.supersedeActiveDispatchTx(tx, dispatch, "superseded_by_retry", now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, false, err
 	}
 	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.DispatchesTable+`
 		(id,obligation_id,kind,continuation_id,source_session_id,dispatch_request_id,base_revision,delivery_state,created_at,updated_at)
 		VALUES (?,?,?,?,?,?,?,?,?,?)`, nowDispatch.ID, nowDispatch.ObligationID, string(nowDispatch.Kind), nowDispatch.ContinuationID,
 		nowDispatch.SourceSessionID, nowDispatch.DispatchRequestID, intPointerValue(nowDispatch.BaseRevision), string(nowDispatch.DeliveryState),
 		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store retry Conclusion Dispatch: %w", err)
+		return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("store retry Conclusion Dispatch: %w", err)
 	}
 	obligation.State = BlackboardConclusionReceiptDispatchRequested
 	obligation.ExplicitRetryCount++
 	obligation.OperatorRetryKey = idempotencyKey
 	obligation.ErrorCode = ""
+	if binding != nil {
+		obligation.BaseRevision = dispatchBaseRevision
+		obligation.RecoveryReason = ""
+	}
 	obligation.NextEligibleAt = nil
 	// The operator retry starts a fresh generation: the previous validated
 	// result and its bounded rejection detail are no longer current.
@@ -1145,12 +1245,12 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 	obligation.ValidationExpected = ""
 	obligation.UpdatedAt = now
 	if err := e.updateObligationProtocolTx(tx, obligation); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, false, err
 	}
 	if _, err := tx.Exec(`INSERT INTO `+e.Dialect.RetryKeysTable+`
 		(`+e.Dialect.RetryKeysOwnerColumn+`,`+e.Dialect.RetryKeysReceiptColumn+`,idempotency_key,dispatch_request_id,created_at) VALUES (?,?,?,?,?)`,
 		obligation.OwnerID, obligation.ID, idempotencyKey, requestID, now.Format(time.RFC3339Nano)); err != nil {
-		return BlackboardConclusionReceipt{}, false, fmt.Errorf("store "+e.Dialect.Subject+" retry idempotency history: %w", err)
+		return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("store "+e.Dialect.Subject+" retry idempotency history: %w", err)
 	}
 	view := obligationView(obligation)
 	view.ActiveDispatchID = nowDispatch.ID
@@ -1160,9 +1260,9 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 	view.SourceSessionID = nowDispatch.SourceSessionID
 	view.BaseRevision = nowDispatch.BaseRevision
 	if err := e.appendBlackboardConclusionEventTx(tx, view, map[string]any{"phase": "retry_requested", "receipt_id": obligation.ID, "request_id": requestID, "explicit_retry_count": obligation.ExplicitRetryCount, "turn_kind": "control"}, now); err != nil {
-		return BlackboardConclusionReceipt{}, false, err
+		return BlackboardConclusionReceipt{}, false, false, err
 	}
-	return view, true, nil
+	return view, true, false, nil
 }
 
 // BlackboardConclusionByDispatchRequestID resolves the obligation whose ACTIVE

--- a/internal/owner/conclusion/conclusion.go
+++ b/internal/owner/conclusion/conclusion.go
@@ -1017,7 +1017,7 @@ func (e *Engine) RetryBlackboardConclusion(obligationID, idempotencyKey string, 
 	if err != nil {
 		return BlackboardConclusionReceipt{}, false, e.blackboardConclusionLookupError(err)
 	}
-	receipt, won, _, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, nil, now)
+	receipt, won, _, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, nil, false, now)
 	if err != nil || !won {
 		return receipt, won, err
 	}
@@ -1030,7 +1030,14 @@ func (e *Engine) RetryBlackboardConclusion(obligationID, idempotencyKey string, 
 // RetryLatestBlackboardConclusion atomically applies an owner-scoped operator
 // retry key to the latest durable conclusion obligation.
 func (e *Engine) RetryLatestBlackboardConclusion(ownerID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	receipt, won, _, err := e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, nil, now)
+	receipt, won, _, err := e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, nil, false, now)
+	return receipt, won, err
+}
+
+// RetryLatestBlackboardConclusionFailClosedOnDispatchFailure atomically
+// retries only when no daemon-proven replacement Runtime binding is required.
+func (e *Engine) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(ownerID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	receipt, won, _, err := e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, nil, true, now)
 	return receipt, won, err
 }
 
@@ -1043,10 +1050,10 @@ func (e *Engine) RetryLatestBlackboardConclusionForRuntime(ownerID, idempotencyK
 	if binding.ContinuationID == "" || binding.SessionID == "" || binding.BaseRevision < 0 {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
-	return e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, &binding, now)
+	return e.retryLatestBlackboardConclusion(ownerID, idempotencyKey, &binding, true, now)
 }
 
-func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string, binding *RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
+func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string, binding *RetryRuntimeBinding, requireRuntimeBinding bool, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
 	ownerID, idempotencyKey = strings.TrimSpace(ownerID), strings.TrimSpace(idempotencyKey)
 	if ownerID == "" || idempotencyKey == "" {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
@@ -1079,7 +1086,7 @@ func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string,
 			return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 		}
 	}
-	receipt, won, initial, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, binding, now)
+	receipt, won, initial, err := e.retryBlackboardConclusionTx(tx, obligation, idempotencyKey, binding, requireRuntimeBinding, now)
 	if err != nil || !won {
 		return receipt, won, initial, err
 	}
@@ -1089,7 +1096,7 @@ func (e *Engine) retryLatestBlackboardConclusion(ownerID, idempotencyKey string,
 	return receipt, true, initial, nil
 }
 
-func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, binding *RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
+func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlackboardConclusion, idempotencyKey string, binding *RetryRuntimeBinding, requireRuntimeBinding bool, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
 	var priorObligationID string
 	err := tx.QueryRow(`SELECT `+e.Dialect.RetryKeysReceiptColumn+` FROM `+e.Dialect.RetryKeysTable+`
 		WHERE `+e.Dialect.RetryKeysOwnerColumn+`=? AND idempotency_key=?`, obligation.OwnerID, idempotencyKey).Scan(&priorObligationID)
@@ -1106,6 +1113,9 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("read "+e.Dialect.Subject+" retry idempotency history: %w", err)
+	}
+	if requireRuntimeBinding && obligation.RecoveryReason == ConclusionRecoveryDispatchFailed && binding == nil {
+		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	if binding != nil && obligation.RecoveryReason != ConclusionRecoveryDispatchFailed {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt

--- a/internal/owner/conclusion/conclusion.go
+++ b/internal/owner/conclusion/conclusion.go
@@ -1550,10 +1550,14 @@ func (e *Engine) CreateRecoveryConclusionDispatches(taskID, oldContinuationID, r
 				return nil, err
 			}
 		}
+		dispatchKind, kindErr := e.recoveryConclusionDispatchKindTx(tx, obligation, dispatch)
+		if kindErr != nil {
+			return nil, kindErr
+		}
 		number := e.conclusionDispatchSequence(tx, obligation.ID) + 1
 		requestID := blackboardConclusionAttemptRequestID("recovery", replacementContinuationID, obligation.SourceTurnID, number, "")
 		nowDispatch := ConclusionDispatch{
-			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
+			ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: dispatchKind,
 			ContinuationID: replacementContinuationID, SourceSessionID: replacementSessionID,
 			DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
 			DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
@@ -1639,10 +1643,14 @@ func (e *Engine) CreateRecoveryConclusionDispatch(obligationID, continuationID, 
 			return BlackboardConclusionReceipt{}, false, err
 		}
 	}
+	dispatchKind, err := e.recoveryConclusionDispatchKindTx(tx, obligation, dispatch)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, err
+	}
 	number := e.conclusionDispatchSequence(tx, obligation.ID) + 1
 	requestID := blackboardConclusionAttemptRequestID("recovery", continuationID, obligation.SourceTurnID, number, "")
 	nowDispatch := ConclusionDispatch{
-		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: ConclusionDispatchKindRecovery,
+		ID: e.Dialect.NewID(), ObligationID: obligation.ID, Kind: dispatchKind,
 		ContinuationID: continuationID, SourceSessionID: sessionID,
 		DispatchRequestID: requestID, BaseRevision: dispatchBaseRevision(dispatch),
 		DeliveryState: ConclusionDispatchRequested, CreatedAt: now, UpdatedAt: now,
@@ -1680,6 +1688,35 @@ func (e *Engine) CreateRecoveryConclusionDispatch(obligationID, continuationID, 
 		return BlackboardConclusionReceipt{}, false, fmt.Errorf("commit recovery Conclusion Dispatch: %w", err)
 	}
 	return view, true, nil
+}
+
+func (e *Engine) recoveryConclusionDispatchKindTx(tx *sql.Tx, obligation PendingBlackboardConclusion, active *ConclusionDispatch) (ConclusionDispatchKind, error) {
+	if active != nil && active.Kind != ConclusionDispatchKindRecovery {
+		return active.Kind, nil
+	}
+	var stored string
+	err := tx.QueryRow(`SELECT kind FROM `+e.Dialect.DispatchesTable+`
+		WHERE obligation_id=? AND kind<>? ORDER BY created_at DESC,id DESC LIMIT 1`,
+		obligation.ID, string(ConclusionDispatchKindRecovery)).Scan(&stored)
+	if err == nil {
+		return ConclusionDispatchKind(stored), nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("read recovery Conclusion Dispatch semantic kind: %w", err)
+	}
+	switch obligation.State {
+	case BlackboardConclusionReceiptPending, BlackboardConclusionReceiptDispatchRequested, BlackboardConclusionReceiptAwaitingResult:
+		if obligation.ExplicitRetryCount > 0 {
+			return ConclusionDispatchKindRetry, nil
+		}
+		return ConclusionDispatchKindInitial, nil
+	case BlackboardConclusionReceiptRepairDispatchRequested:
+		return ConclusionDispatchKindRepair, nil
+	case BlackboardConclusionReceiptVersionSyncRequested, BlackboardConclusionReceiptVersionRegenerationDispatchRequested:
+		return ConclusionDispatchKindVersionRegeneration, nil
+	default:
+		return ConclusionDispatchKindRecovery, nil
+	}
 }
 
 // --- internal helpers ---

--- a/internal/owner/conclusion/conclusion.go
+++ b/internal/owner/conclusion/conclusion.go
@@ -1041,7 +1041,7 @@ func (e *Engine) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(owne
 	return receipt, won, err
 }
 
-// RetryLatestBlackboardConclusionForRuntime atomically binds a dispatch_failed
+// RetryLatestBlackboardConclusionForRuntime atomically binds a Runtime-recovery
 // retry to a daemon-proven live replacement Runtime. Initial is true only when
 // the obligation had never created a prior Conclusion Dispatch.
 func (e *Engine) RetryLatestBlackboardConclusionForRuntime(ownerID, idempotencyKey string, binding RetryRuntimeBinding, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
@@ -1114,10 +1114,10 @@ func (e *Engine) retryBlackboardConclusionTx(tx *sql.Tx, obligation PendingBlack
 	if !errors.Is(err, sql.ErrNoRows) {
 		return BlackboardConclusionReceipt{}, false, false, fmt.Errorf("read "+e.Dialect.Subject+" retry idempotency history: %w", err)
 	}
-	if requireRuntimeBinding && obligation.RecoveryReason == ConclusionRecoveryDispatchFailed && binding == nil {
+	if requireRuntimeBinding && owner.ConclusionRecoveryRequiresRuntimeBinding(obligation.RecoveryReason) && binding == nil {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
-	if binding != nil && obligation.RecoveryReason != ConclusionRecoveryDispatchFailed {
+	if binding != nil && !owner.ConclusionRecoveryRequiresRuntimeBinding(obligation.RecoveryReason) {
 		return BlackboardConclusionReceipt{}, false, false, ErrInvalidBlackboardConclusionReceipt
 	}
 	switch owner.ConclusionRetryDecisionFor(obligation.State, obligation.ErrorCode, obligation.RecoveryReason, obligation.NextEligibleAt, now) {
@@ -1880,11 +1880,11 @@ func (e *Engine) failActiveDispatchTx(tx *sql.Tx, obligation PendingBlackboardCo
 
 func (e *Engine) updateObligationProtocolTx(tx *sql.Tx, obligation PendingBlackboardConclusion) error {
 	if _, err := tx.Exec(`UPDATE `+e.Dialect.ObligationsTable+`
-		SET state=?,canonical_result_json=?,canonical_result_sha256=?,applied_revision=?,base_revision=?,automatic_turn_count=?,repair_count=?,
+		SET state=?,canonical_result_json=?,canonical_result_sha256=?,apply_idempotency_key=?,applied_revision=?,base_revision=?,automatic_turn_count=?,repair_count=?,
 		version_regeneration_count=?,explicit_retry_count=?,operator_retry_key=?,error_code=?,recovery_reason=?,next_eligible_at=?,
 		validation_reason=?,validation_field_path=?,validation_expected=?,updated_at=? WHERE id=?`,
 		string(obligation.State), obligation.CanonicalResultJSON, obligation.CanonicalResultSHA256,
-		intPointerValue(obligation.AppliedRevision), intPointerValue(obligation.BaseRevision), obligation.AutomaticTurnCount, obligation.RepairCount,
+		obligation.ApplyIdempotencyKey, intPointerValue(obligation.AppliedRevision), intPointerValue(obligation.BaseRevision), obligation.AutomaticTurnCount, obligation.RepairCount,
 		obligation.VersionRegenerationCount, obligation.ExplicitRetryCount, obligation.OperatorRetryKey,
 		string(obligation.ErrorCode), string(obligation.RecoveryReason),
 		formatTimePtr(obligation.NextEligibleAt), obligation.ValidationReason, obligation.ValidationFieldPath,

--- a/internal/session/blackboard_conclusion.go
+++ b/internal/session/blackboard_conclusion.go
@@ -383,6 +383,32 @@ func (s *Service) RetryLatestBlackboardConclusion(sessionID, idempotencyKey stri
 	return receiptFromConclusion(rec), won, nil
 }
 
+// RetryLatestBlackboardConclusionFailClosedOnDispatchFailure retries only when
+// the transaction confirms that no replacement Runtime binding is required.
+func (s *Service) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(sessionID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	rec, won, err := s.conclusions().RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(sessionID, idempotencyKey, now)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
+	}
+	return receiptFromConclusion(rec), won, nil
+}
+
+// RetryLatestBlackboardConclusionForRuntime binds a Runtime-recovery retry to
+// one daemon-proven live replacement Runtime.
+func (s *Service) RetryLatestBlackboardConclusionForRuntime(sessionID, idempotencyKey, continuationID, providerSessionID string, baseRevision int, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
+	rec, won, initial, err := s.conclusions().RetryLatestBlackboardConclusionForRuntime(
+		sessionID, idempotencyKey, conclusion.RetryRuntimeBinding{
+			ContinuationID: continuationID,
+			SessionID:      providerSessionID,
+			BaseRevision:   baseRevision,
+		}, now,
+	)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, false, mapConclusionError(err)
+	}
+	return receiptFromConclusion(rec), won, initial, nil
+}
+
 func (s *Service) BlackboardConclusionByDispatchRequestID(dispatchRequestID string) (BlackboardConclusionReceipt, error) {
 	rec, err := s.conclusions().BlackboardConclusionByDispatchRequestID(dispatchRequestID)
 	if err != nil {

--- a/internal/session/blackboard_conclusion.go
+++ b/internal/session/blackboard_conclusion.go
@@ -50,13 +50,14 @@ type BlackboardConclusionReceipt struct {
 	RecoveryReason string `json:"recovery_reason,omitempty"`
 	// ActiveDispatchID and DispatchKind expose the active Conclusion Dispatch
 	// so recovery can create a new dispatch without rewriting history.
-	ActiveDispatchID    string                 `json:"-"`
-	DispatchKind        ConclusionDispatchKind `json:"-"`
-	ValidationReason    string                 `json:"validation_reason,omitempty"`
-	ValidationFieldPath string                 `json:"validation_field_path,omitempty"`
-	ValidationExpected  string                 `json:"validation_expected,omitempty"`
-	CreatedAt           time.Time              `json:"created_at"`
-	UpdatedAt           time.Time              `json:"updated_at"`
+	ActiveDispatchID    string                  `json:"-"`
+	DispatchKind        ConclusionDispatchKind  `json:"-"`
+	DirectiveKind       ConclusionDirectiveKind `json:"-"`
+	ValidationReason    string                  `json:"validation_reason,omitempty"`
+	ValidationFieldPath string                  `json:"validation_field_path,omitempty"`
+	ValidationExpected  string                  `json:"validation_expected,omitempty"`
+	CreatedAt           time.Time               `json:"created_at"`
+	UpdatedAt           time.Time               `json:"updated_at"`
 }
 
 // View projects internal coordinator progress into the compact Session API
@@ -228,6 +229,7 @@ func receiptFromConclusion(rec conclusion.BlackboardConclusionReceipt) Blackboar
 		RecoveryReason:           rec.RecoveryReason,
 		ActiveDispatchID:         rec.ActiveDispatchID,
 		DispatchKind:             rec.DispatchKind,
+		DirectiveKind:            rec.DirectiveKind,
 		ValidationReason:         rec.ValidationReason,
 		ValidationFieldPath:      rec.ValidationFieldPath,
 		ValidationExpected:       rec.ValidationExpected,

--- a/internal/session/blackboard_conclusion.go
+++ b/internal/session/blackboard_conclusion.go
@@ -383,16 +383,6 @@ func (s *Service) RetryLatestBlackboardConclusion(sessionID, idempotencyKey stri
 	return receiptFromConclusion(rec), won, nil
 }
 
-// RetryLatestBlackboardConclusionFailClosedOnDispatchFailure retries only when
-// the transaction confirms that no replacement Runtime binding is required.
-func (s *Service) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(sessionID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	rec, won, err := s.conclusions().RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(sessionID, idempotencyKey, now)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
-	}
-	return receiptFromConclusion(rec), won, nil
-}
-
 // RetryLatestBlackboardConclusionForRuntime binds a Runtime-recovery retry to
 // one daemon-proven live replacement Runtime.
 func (s *Service) RetryLatestBlackboardConclusionForRuntime(sessionID, idempotencyKey, continuationID, providerSessionID string, baseRevision int, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {

--- a/internal/session/blackboard_conclusion_test.go
+++ b/internal/session/blackboard_conclusion_test.go
@@ -31,6 +31,13 @@ func TestSessionBlackboardConclusionRestartRecoveryAndRetryAreOwnerScoped(t *tes
 	if err != nil {
 		t.Fatalf("create Session continuation: %v", err)
 	}
+	continuation, err = service.UpdateContinuationRuntimeMetadata(continuation.ID, "", "provider-session-1", "")
+	if err != nil {
+		t.Fatalf("bind Session Runtime metadata: %v", err)
+	}
+	if _, err := service.UpdateContinuationStatus(continuation.ID, RuntimeStatusRunning); err != nil {
+		t.Fatalf("mark Session Continuation running: %v", err)
+	}
 	otherContinuation, err := service.CreateContinuation(second.ID, "profile-1", "codex", RunnerSandbox)
 	if err != nil {
 		t.Fatalf("create other Session continuation: %v", err)
@@ -62,8 +69,11 @@ func TestSessionBlackboardConclusionRestartRecoveryAndRetryAreOwnerScoped(t *tes
 	}
 
 	retryAt := latest.NextEligibleAt.Add(time.Nanosecond)
-	retried, won, err := service.RetryLatestBlackboardConclusion(first.ID, "session-retry-1", retryAt)
-	if err != nil || !won || retried.InternalState != BlackboardConclusionReceiptPending {
+	retried, won, initial, err := service.RetryLatestBlackboardConclusionForRuntime(
+		first.ID, "session-retry-1", continuation.ID, continuation.NativeSessionID, 0, retryAt,
+	)
+	if err != nil || !won || !initial || retried.InternalState != BlackboardConclusionReceiptDispatchRequested ||
+		retried.DispatchKind != ConclusionDispatchKindInitial {
 		t.Fatalf("Session retry = %#v won=%v err=%v", retried, won, err)
 	}
 	replayed, won, err := service.RetryLatestBlackboardConclusion(first.ID, "session-retry-1", retryAt)

--- a/internal/session/blackboard_conclusion_test.go
+++ b/internal/session/blackboard_conclusion_test.go
@@ -75,6 +75,62 @@ func TestSessionBlackboardConclusionRestartRecoveryAndRetryAreOwnerScoped(t *tes
 	}
 }
 
+func TestSessionRuntimeRetryPersistsInitialDispatchKindForRestart(t *testing.T) {
+	root := t.TempDir()
+	db, err := store.Open(filepath.Join(root, "pentest.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	service := NewService(db, filepath.Join(root, "sessions"))
+	found, err := service.Create(CreateRequest{
+		Input: "Retry undispatched conclusion", BlackboardConclusionMode: BlackboardConclusionModeAssisted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, err := service.CreateContinuation(found.ID, "profile-1", "codex", RunnerSandbox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, err = service.UpdateContinuationRuntimeMetadata(original.ID, "", "session-original", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _, err := service.RecordBlackboardConclusionCheckpoint(
+		found.ID, original.ID, "work-request-undispatched", original.NativeSessionID, "work-turn-undispatched",
+		RuntimeTurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		SemanticDebtWatermarks{SourceWork: 1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	if _, changed, err := service.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
+		receipt.ID, ConclusionRecoveryRuntimeOwnershipNotProven, now, 0,
+	); err != nil || !changed {
+		t.Fatalf("mark recovery: changed=%v err=%v", changed, err)
+	}
+	replacement, err := service.CreateReplacementContinuation(original, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement, err = service.UpdateContinuationRuntimeMetadata(replacement.ID, "", "session-replacement", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.UpdateContinuationStatus(replacement.ID, RuntimeStatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	retried, won, initial, err := service.RetryLatestBlackboardConclusionForRuntime(
+		found.ID, "session-initial-runtime-retry", replacement.ID, replacement.NativeSessionID, 0, now,
+	)
+	if err != nil || !won || !initial || retried.DispatchKind != ConclusionDispatchKindInitial ||
+		retried.ContinuationID != replacement.ID || retried.SourceSessionID != replacement.NativeSessionID {
+		t.Fatalf("Session initial Runtime retry=%#v won=%v initial=%v err=%v", retried, won, initial, err)
+	}
+}
+
 func TestSessionBlackboardConclusionRecoveryReplayIsCompareAndSet(t *testing.T) {
 	root := t.TempDir()
 	db, err := store.Open(filepath.Join(root, "pentest.db"))

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -203,6 +203,16 @@ const (
 	ConclusionDispatchKindRecovery            = owner.ConclusionDispatchKindRecovery
 )
 
+// ConclusionDirectiveKind is the semantic control instruction carried by a
+// dispatch. Recovery changes delivery lineage, not directive semantics.
+type ConclusionDirectiveKind = owner.ConclusionDirectiveKind
+
+const (
+	ConclusionDirectiveKindInitial             = owner.ConclusionDirectiveKindInitial
+	ConclusionDirectiveKindRepair              = owner.ConclusionDirectiveKindRepair
+	ConclusionDirectiveKindVersionRegeneration = owner.ConclusionDirectiveKindVersionRegeneration
+)
+
 // ConclusionDispatchState is the delivery lifecycle of one immutable dispatch.
 type ConclusionDispatchState = owner.ConclusionDispatchState
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -944,7 +944,112 @@ func migrations() []migration {
 		newMigration(57, "task_type_snapshot", migration57SQL, migration57Up),
 		newMigration(58, "challenge_operation_recovery_settlement", migration58SQL, migration58Up),
 		newMigration(59, "project_approval_workflows", migration59SQL, migration59Up),
+		newMigration(60, "blackboard_conclusion_directive_kind", migration60SQL, migration60Up),
 	}
+}
+
+// migration60SQL separates immutable delivery lineage from the semantic
+// control instruction. Existing recovery rows retain an empty directive kind;
+// the owner engine derives their legacy meaning from prior dispatch history.
+const migration60SQL = `
+ALTER TABLE conclusion_dispatches ADD COLUMN directive_kind TEXT NOT NULL DEFAULT ''
+	CHECK (directive_kind IN ('','initial','repair','version_regeneration'));
+ALTER TABLE session_conclusion_dispatches ADD COLUMN directive_kind TEXT NOT NULL DEFAULT ''
+	CHECK (directive_kind IN ('','initial','repair','version_regeneration'));
+UPDATE conclusion_dispatches
+	SET directive_kind = CASE kind
+		WHEN 'repair' THEN 'repair'
+		WHEN 'retry' THEN 'repair'
+		WHEN 'version_regeneration' THEN 'version_regeneration'
+		WHEN 'initial' THEN 'initial'
+		ELSE '' END;
+UPDATE conclusion_dispatches
+	SET directive_kind = COALESCE((
+		SELECT CASE prior.kind
+			WHEN 'repair' THEN 'repair'
+			WHEN 'retry' THEN 'repair'
+			WHEN 'version_regeneration' THEN 'version_regeneration'
+			ELSE 'initial' END
+		FROM conclusion_dispatches AS prior
+		WHERE prior.obligation_id=conclusion_dispatches.obligation_id
+			AND prior.kind<>'recovery'
+			AND prior.rowid<conclusion_dispatches.rowid
+		ORDER BY prior.rowid DESC LIMIT 1
+	), 'initial')
+	WHERE kind='recovery' AND directive_kind='';
+UPDATE session_conclusion_dispatches
+	SET directive_kind = CASE kind
+		WHEN 'repair' THEN 'repair'
+		WHEN 'retry' THEN 'repair'
+		WHEN 'version_regeneration' THEN 'version_regeneration'
+		WHEN 'initial' THEN 'initial'
+		ELSE '' END;
+UPDATE session_conclusion_dispatches
+	SET directive_kind = COALESCE((
+		SELECT CASE prior.kind
+			WHEN 'repair' THEN 'repair'
+			WHEN 'retry' THEN 'repair'
+			WHEN 'version_regeneration' THEN 'version_regeneration'
+			ELSE 'initial' END
+		FROM session_conclusion_dispatches AS prior
+		WHERE prior.obligation_id=session_conclusion_dispatches.obligation_id
+			AND prior.kind<>'recovery'
+			AND prior.rowid<session_conclusion_dispatches.rowid
+		ORDER BY prior.rowid DESC LIMIT 1
+	), 'initial')
+	WHERE kind='recovery' AND directive_kind='';
+`
+
+func migration60Up(tx *sql.Tx) error {
+	definition := "TEXT NOT NULL DEFAULT '' CHECK (directive_kind IN ('','initial','repair','version_regeneration'))"
+	if err := ensureColumn(tx, "conclusion_dispatches", "directive_kind", definition); err != nil {
+		return err
+	}
+	if err := ensureColumn(tx, "session_conclusion_dispatches", "directive_kind", definition); err != nil {
+		return err
+	}
+	_, err := tx.Exec(`UPDATE conclusion_dispatches
+		SET directive_kind = CASE kind
+			WHEN 'repair' THEN 'repair'
+			WHEN 'retry' THEN 'repair'
+			WHEN 'version_regeneration' THEN 'version_regeneration'
+			WHEN 'initial' THEN 'initial'
+			ELSE directive_kind END`)
+	if err != nil {
+		return err
+	}
+	if err := backfillRecoveryConclusionDirectiveKinds(tx, "conclusion_dispatches"); err != nil {
+		return err
+	}
+	_, err = tx.Exec(`UPDATE session_conclusion_dispatches
+		SET directive_kind = CASE kind
+			WHEN 'repair' THEN 'repair'
+			WHEN 'retry' THEN 'repair'
+			WHEN 'version_regeneration' THEN 'version_regeneration'
+			WHEN 'initial' THEN 'initial'
+			ELSE directive_kind END`)
+	if err != nil {
+		return err
+	}
+	return backfillRecoveryConclusionDirectiveKinds(tx, "session_conclusion_dispatches")
+}
+
+func backfillRecoveryConclusionDirectiveKinds(tx *sql.Tx, table string) error {
+	_, err := tx.Exec(`UPDATE ` + table + `
+		SET directive_kind = COALESCE((
+			SELECT CASE prior.kind
+				WHEN 'repair' THEN 'repair'
+				WHEN 'retry' THEN 'repair'
+				WHEN 'version_regeneration' THEN 'version_regeneration'
+				ELSE 'initial' END
+			FROM ` + table + ` AS prior
+			WHERE prior.obligation_id=` + table + `.obligation_id
+				AND prior.kind<>'recovery'
+				AND prior.rowid<` + table + `.rowid
+			ORDER BY prior.rowid DESC LIMIT 1
+		), 'initial')
+		WHERE kind='recovery' AND directive_kind=''`)
+	return err
 }
 
 // migration59SQL stores operator-approved Project workflows. Scope Expansion

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -949,8 +949,9 @@ func migrations() []migration {
 }
 
 // migration60SQL separates immutable delivery lineage from the semantic
-// control instruction. Existing recovery rows retain an empty directive kind;
-// the owner engine derives their legacy meaning from prior dispatch history.
+// control instruction. Existing recovery rows derive their directive from the
+// nearest earlier non-recovery dispatch; rows without history default to the
+// initial directive.
 const migration60SQL = `
 ALTER TABLE conclusion_dispatches ADD COLUMN directive_kind TEXT NOT NULL DEFAULT ''
 	CHECK (directive_kind IN ('','initial','repair','version_regeneration'));

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1253,6 +1253,16 @@ func TestMigration60BackfillsActiveRecoveryDirectiveKindsFromDispatchHistory(t *
 			 'superseded','superseded_by_recovery','2026-08-24T10:00:01Z','2026-08-24T10:00:01Z'),
 			('task-recovery','task-obligation','recovery','','task-new','task-session-new','task-request-recovery',
 			 'dispatch_requested','','2026-08-24T10:00:02Z','2026-08-24T10:00:02Z');
+		INSERT INTO pending_blackboard_conclusions
+			(id,task_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,
+			 state,source_work_watermark,semantic_persistence_watermark,created_at,updated_at)
+			VALUES ('task-obligation-no-history','task-2','task-request-no-history',1,'task-old-no-history','task-session-no-history','task-turn-no-history',
+			 'dispatch_requested',1,0,?,?);
+		INSERT INTO conclusion_dispatches
+			(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,delivery_state,
+			 terminal_outcome,created_at,updated_at)
+			VALUES ('task-recovery-no-history','task-obligation-no-history','recovery','','task-new-no-history','task-session-new-no-history',
+			 'task-request-recovery-no-history','dispatch_requested','','2026-08-24T10:00:02Z','2026-08-24T10:00:02Z');
 
 		INSERT INTO session_pending_blackboard_conclusions
 			(id,session_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,
@@ -1266,8 +1276,18 @@ func TestMigration60BackfillsActiveRecoveryDirectiveKindsFromDispatchHistory(t *
 			 'superseded','superseded_by_recovery','2026-08-24T10:00:01Z','2026-08-24T10:00:01Z'),
 			('session-recovery','session-obligation','recovery','','session-new','native-session-new','session-request-recovery',
 			 'dispatch_requested','','2026-08-24T10:00:02Z','2026-08-24T10:00:02Z');
+		INSERT INTO session_pending_blackboard_conclusions
+			(id,session_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,
+			 state,source_work_watermark,semantic_persistence_watermark,created_at,updated_at)
+			VALUES ('session-obligation-no-history','session-2','session-request-no-history',1,'session-old-no-history','native-session-no-history','session-turn-no-history',
+			 'dispatch_requested',1,0,?,?);
+		INSERT INTO session_conclusion_dispatches
+			(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,delivery_state,
+			 terminal_outcome,created_at,updated_at)
+			VALUES ('session-recovery-no-history','session-obligation-no-history','recovery','','session-new-no-history','native-session-new-no-history',
+			 'session-request-recovery-no-history','dispatch_requested','','2026-08-24T10:00:02Z','2026-08-24T10:00:02Z');
 		DELETE FROM schema_migrations WHERE version=60;
-	`, now, now, now, now); err != nil {
+	`, now, now, now, now, now, now, now, now); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {
@@ -1285,7 +1305,9 @@ func TestMigration60BackfillsActiveRecoveryDirectiveKindsFromDispatchHistory(t *
 		want  string
 	}{
 		{table: "conclusion_dispatches", id: "task-recovery", want: "initial"},
+		{table: "conclusion_dispatches", id: "task-recovery-no-history", want: "initial"},
 		{table: "session_conclusion_dispatches", id: "session-recovery", want: "repair"},
+		{table: "session_conclusion_dispatches", id: "session-recovery-no-history", want: "initial"},
 	} {
 		var got string
 		if err := reopened.QueryRow(`SELECT directive_kind FROM `+test.table+` WHERE id=?`, test.id).Scan(&got); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1208,19 +1208,19 @@ func TestMigration53ConvertsLegacyReceiptsIntoObligationsAndDispatches(t *testin
 			canonical, resultHash, applyKey, work, semantic, automaticTurns, repairCount, versionCount, retryCount)
 	}
 
-	var kind, continuationID, dispatchRequestID, controlTurnID, deliveryState, sendStartedAt, terminalOutcome string
+	var kind, directiveKind, continuationID, dispatchRequestID, controlTurnID, deliveryState, sendStartedAt, terminalOutcome string
 	var baseRevision int
-	if err := reopened.QueryRow(`SELECT kind,continuation_id,dispatch_request_id,control_turn_id,base_revision,delivery_state,
+	if err := reopened.QueryRow(`SELECT kind,directive_kind,continuation_id,dispatch_request_id,control_turn_id,base_revision,delivery_state,
 		send_started_at,terminal_outcome FROM conclusion_dispatches WHERE obligation_id='legacy-validated'`).Scan(
-		&kind, &continuationID, &dispatchRequestID, &controlTurnID, &baseRevision, &deliveryState,
+		&kind, &directiveKind, &continuationID, &dispatchRequestID, &controlTurnID, &baseRevision, &deliveryState,
 		&sendStartedAt, &terminalOutcome); err != nil {
 		t.Fatal(err)
 	}
-	if kind != "retry" || continuationID != "continuation-legacy" || dispatchRequestID != "dispatch-legacy" ||
+	if kind != "retry" || directiveKind != "repair" || continuationID != "continuation-legacy" || dispatchRequestID != "dispatch-legacy" ||
 		controlTurnID != "control-legacy" || baseRevision != 9 || deliveryState != "validated" ||
 		sendStartedAt != "2026-07-27T12:00:30Z" || terminalOutcome != "" {
-		t.Fatalf("migrated dispatch lost binding: kind=%q continuation=%q request=%q control=%q base=%d state=%q sent=%q outcome=%q",
-			kind, continuationID, dispatchRequestID, controlTurnID, baseRevision, deliveryState, sendStartedAt, terminalOutcome)
+		t.Fatalf("migrated dispatch lost binding: kind=%q directive=%q continuation=%q request=%q control=%q base=%d state=%q sent=%q outcome=%q",
+			kind, directiveKind, continuationID, dispatchRequestID, controlTurnID, baseRevision, deliveryState, sendStartedAt, terminalOutcome)
 	}
 
 	// The Session retry-keys table now references the obligation table.
@@ -1230,6 +1230,70 @@ func TestMigration53ConvertsLegacyReceiptsIntoObligationsAndDispatches(t *testin
 	}
 	if !strings.Contains(obligationFK, "session_pending_blackboard_conclusions") {
 		t.Fatalf("session retry keys still reference the legacy receipt table: %s", obligationFK)
+	}
+}
+
+func TestMigration60BackfillsActiveRecoveryDirectiveKindsFromDispatchHistory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pentest.db")
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-08-24T10:00:00Z"
+	if _, err := db.Exec(`
+		INSERT INTO pending_blackboard_conclusions
+			(id,task_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,
+			 state,source_work_watermark,semantic_persistence_watermark,explicit_retry_count,created_at,updated_at)
+			VALUES ('task-obligation','task-1','task-request',1,'task-old','task-session-old','task-turn',
+			 'dispatch_requested',1,0,1,?,?);
+		INSERT INTO conclusion_dispatches
+			(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,delivery_state,
+			 terminal_outcome,created_at,updated_at)
+			VALUES ('task-initial','task-obligation','initial','initial','task-old','task-session-old','task-request-initial',
+			 'superseded','superseded_by_recovery','2026-08-24T10:00:01Z','2026-08-24T10:00:01Z'),
+			('task-recovery','task-obligation','recovery','','task-new','task-session-new','task-request-recovery',
+			 'dispatch_requested','','2026-08-24T10:00:02Z','2026-08-24T10:00:02Z');
+
+		INSERT INTO session_pending_blackboard_conclusions
+			(id,session_id,source_request_id,source_request_correlation_exact,source_continuation_id,source_session_id,source_turn_id,
+			 state,source_work_watermark,semantic_persistence_watermark,explicit_retry_count,created_at,updated_at)
+			VALUES ('session-obligation','session-1','session-request',1,'session-old','native-session-old','session-turn',
+			 'dispatch_requested',1,0,1,?,?);
+		INSERT INTO session_conclusion_dispatches
+			(id,obligation_id,kind,directive_kind,continuation_id,source_session_id,dispatch_request_id,delivery_state,
+			 terminal_outcome,created_at,updated_at)
+			VALUES ('session-repair','session-obligation','repair','repair','session-old','native-session-old','session-request-repair',
+			 'superseded','superseded_by_recovery','2026-08-24T10:00:01Z','2026-08-24T10:00:01Z'),
+			('session-recovery','session-obligation','recovery','','session-new','native-session-new','session-request-recovery',
+			 'dispatch_requested','','2026-08-24T10:00:02Z','2026-08-24T10:00:02Z');
+		DELETE FROM schema_migrations WHERE version=60;
+	`, now, now, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	for _, test := range []struct {
+		table string
+		id    string
+		want  string
+	}{
+		{table: "conclusion_dispatches", id: "task-recovery", want: "initial"},
+		{table: "session_conclusion_dispatches", id: "session-recovery", want: "repair"},
+	} {
+		var got string
+		if err := reopened.QueryRow(`SELECT directive_kind FROM `+test.table+` WHERE id=?`, test.id).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		if got != test.want {
+			t.Errorf("%s directive_kind = %q, want %q", test.id, got, test.want)
+		}
 	}
 }
 

--- a/internal/store/store_v2_test.go
+++ b/internal/store/store_v2_test.go
@@ -135,7 +135,7 @@ func TestOrdinaryOpenRefusesUnknownEpochWithoutTouchingSQLiteState(t *testing.T)
 			prepare: func(t *testing.T, path string) func() {
 				return holdStoreEpochUpdateInWAL(t, path, "future_v3")
 			},
-			wantMigrationCount: 59,
+			wantMigrationCount: 60,
 			wantSidecars:       true,
 		},
 	}

--- a/internal/task/blackboard_conclusion.go
+++ b/internal/task/blackboard_conclusion.go
@@ -283,6 +283,23 @@ func (s *Service) RetryLatestBlackboardConclusion(taskID, idempotencyKey string,
 	return receiptFromConclusion(rec), won, nil
 }
 
+// RetryLatestBlackboardConclusionForRuntime binds a dispatch_failed retry to
+// one daemon-proven live replacement Runtime. Initial reports that no prior
+// Conclusion Dispatch existed for the obligation.
+func (s *Service) RetryLatestBlackboardConclusionForRuntime(taskID, idempotencyKey, continuationID, sessionID string, baseRevision int, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {
+	rec, won, initial, err := s.conclusions().RetryLatestBlackboardConclusionForRuntime(
+		taskID, idempotencyKey, conclusion.RetryRuntimeBinding{
+			ContinuationID: continuationID,
+			SessionID:      sessionID,
+			BaseRevision:   baseRevision,
+		}, now,
+	)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, false, mapConclusionError(err)
+	}
+	return receiptFromConclusion(rec), won, initial, nil
+}
+
 func (s *Service) BlackboardConclusionByDispatchRequestID(dispatchRequestID string) (BlackboardConclusionReceipt, error) {
 	rec, err := s.conclusions().BlackboardConclusionByDispatchRequestID(dispatchRequestID)
 	if err != nil {

--- a/internal/task/blackboard_conclusion.go
+++ b/internal/task/blackboard_conclusion.go
@@ -283,6 +283,16 @@ func (s *Service) RetryLatestBlackboardConclusion(taskID, idempotencyKey string,
 	return receiptFromConclusion(rec), won, nil
 }
 
+// RetryLatestBlackboardConclusionFailClosedOnDispatchFailure retries only when
+// the transaction confirms that no replacement Runtime binding is required.
+func (s *Service) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(taskID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
+	rec, won, err := s.conclusions().RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(taskID, idempotencyKey, now)
+	if err != nil {
+		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
+	}
+	return receiptFromConclusion(rec), won, nil
+}
+
 // RetryLatestBlackboardConclusionForRuntime binds a dispatch_failed retry to
 // one daemon-proven live replacement Runtime. Initial reports that no prior
 // Conclusion Dispatch existed for the obligation.

--- a/internal/task/blackboard_conclusion.go
+++ b/internal/task/blackboard_conclusion.go
@@ -293,7 +293,7 @@ func (s *Service) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(tas
 	return receiptFromConclusion(rec), won, nil
 }
 
-// RetryLatestBlackboardConclusionForRuntime binds a dispatch_failed retry to
+// RetryLatestBlackboardConclusionForRuntime binds a Runtime-recovery retry to
 // one daemon-proven live replacement Runtime. Initial reports that no prior
 // Conclusion Dispatch existed for the obligation.
 func (s *Service) RetryLatestBlackboardConclusionForRuntime(taskID, idempotencyKey, continuationID, sessionID string, baseRevision int, now time.Time) (BlackboardConclusionReceipt, bool, bool, error) {

--- a/internal/task/blackboard_conclusion.go
+++ b/internal/task/blackboard_conclusion.go
@@ -283,16 +283,6 @@ func (s *Service) RetryLatestBlackboardConclusion(taskID, idempotencyKey string,
 	return receiptFromConclusion(rec), won, nil
 }
 
-// RetryLatestBlackboardConclusionFailClosedOnDispatchFailure retries only when
-// the transaction confirms that no replacement Runtime binding is required.
-func (s *Service) RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(taskID, idempotencyKey string, now time.Time) (BlackboardConclusionReceipt, bool, error) {
-	rec, won, err := s.conclusions().RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(taskID, idempotencyKey, now)
-	if err != nil {
-		return BlackboardConclusionReceipt{}, false, mapConclusionError(err)
-	}
-	return receiptFromConclusion(rec), won, nil
-}
-
 // RetryLatestBlackboardConclusionForRuntime binds a Runtime-recovery retry to
 // one daemon-proven live replacement Runtime. Initial reports that no prior
 // Conclusion Dispatch existed for the obligation.

--- a/internal/task/blackboard_conclusion.go
+++ b/internal/task/blackboard_conclusion.go
@@ -122,6 +122,7 @@ func receiptFromConclusion(rec conclusion.BlackboardConclusionReceipt) Blackboar
 		RecoveryReason:           rec.RecoveryReason,
 		ActiveDispatchID:         rec.ActiveDispatchID,
 		DispatchKind:             rec.DispatchKind,
+		DirectiveKind:            rec.DirectiveKind,
 		ValidationReason:         rec.ValidationReason,
 		ValidationFieldPath:      rec.ValidationFieldPath,
 		ValidationExpected:       rec.ValidationExpected,

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -270,6 +270,16 @@ const (
 	ConclusionDispatchKindRecovery            = owner.ConclusionDispatchKindRecovery
 )
 
+// ConclusionDirectiveKind is the semantic control instruction carried by a
+// dispatch. Recovery changes delivery lineage, not directive semantics.
+type ConclusionDirectiveKind = owner.ConclusionDirectiveKind
+
+const (
+	ConclusionDirectiveKindInitial             = owner.ConclusionDirectiveKindInitial
+	ConclusionDirectiveKindRepair              = owner.ConclusionDirectiveKindRepair
+	ConclusionDirectiveKindVersionRegeneration = owner.ConclusionDirectiveKindVersionRegeneration
+)
+
 // ConclusionDispatchState is the delivery lifecycle of one immutable dispatch.
 type ConclusionDispatchState = owner.ConclusionDispatchState
 
@@ -331,13 +341,14 @@ type BlackboardConclusionReceipt struct {
 	RecoveryReason string `json:"recovery_reason,omitempty"`
 	// ActiveDispatchID and DispatchKind expose the active Conclusion Dispatch
 	// so recovery can create a new dispatch without rewriting history.
-	ActiveDispatchID    string                 `json:"-"`
-	DispatchKind        ConclusionDispatchKind `json:"-"`
-	ValidationReason    string                 `json:"validation_reason,omitempty"`
-	ValidationFieldPath string                 `json:"validation_field_path,omitempty"`
-	ValidationExpected  string                 `json:"validation_expected,omitempty"`
-	CreatedAt           time.Time              `json:"created_at"`
-	UpdatedAt           time.Time              `json:"updated_at"`
+	ActiveDispatchID    string                  `json:"-"`
+	DispatchKind        ConclusionDispatchKind  `json:"-"`
+	DirectiveKind       ConclusionDirectiveKind `json:"-"`
+	ValidationReason    string                  `json:"validation_reason,omitempty"`
+	ValidationFieldPath string                  `json:"validation_field_path,omitempty"`
+	ValidationExpected  string                  `json:"validation_expected,omitempty"`
+	CreatedAt           time.Time               `json:"created_at"`
+	UpdatedAt           time.Time               `json:"updated_at"`
 }
 
 // View projects internal coordinator progress into the compact Task API

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1256,6 +1256,8 @@ func TestVersionSyncRecoveryPreservesCanonicalResultUntilOperatorRetryStartsNewG
 		Type: task.TypePentest, Goal: "inspect", Runner: task.RunnerSandbox,
 		RunControls: task.RunControls{BlackboardConclusionMode: task.BlackboardConclusionModeAssisted}})
 	continuation, _ := svc.CreateContinuation(created.ID, "profile", "fake", task.RunnerSandbox)
+	continuation, _ = svc.UpdateContinuationRuntimeMetadata(continuation.ID, "", "session-1", "")
+	_, _ = svc.UpdateContinuationStatus(continuation.ID, task.StatusRunning)
 	now := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
 	receipt, _, _ := svc.RecordBlackboardConclusionCheckpoint(created.ID, continuation.ID, "work-request-sync-recovery",
 		"session-1", "turn-sync-recovery", task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
@@ -1277,7 +1279,9 @@ func TestVersionSyncRecoveryPreservesCanonicalResultUntilOperatorRetryStartsNewG
 		replayed.CanonicalResultSHA256 != validated.CanonicalResultSHA256 {
 		t.Fatalf("version-sync recovery replay = %#v, changed=%v, err=%v", replayed, changed, err)
 	}
-	retried, won, err := svc.RetryBlackboardConclusion(syncing.ID, "sync-recovery-retry", now.Add(5*time.Minute))
+	retried, won, _, err := svc.RetryLatestBlackboardConclusionForRuntime(
+		created.ID, "sync-recovery-retry", continuation.ID, "session-1", 4, now.Add(5*time.Minute),
+	)
 	if err != nil || !won || retried.InternalState != task.BlackboardConclusionReceiptDispatchRequested ||
 		len(retried.CanonicalResultJSON) != 0 || retried.CanonicalResultSHA256 != "" {
 		t.Fatalf("version-sync recovery retry = %#v, won=%v, err=%v", retried, won, err)
@@ -1293,6 +1297,8 @@ func TestPendingBlackboardConclusionRecoveryProjectsActionRequiredWithoutExtendi
 		Type: task.TypePentest, Goal: "inspect", Runner: task.RunnerSandbox,
 		RunControls: task.RunControls{BlackboardConclusionMode: task.BlackboardConclusionModeAssisted}})
 	continuation, _ := svc.CreateContinuation(created.ID, "profile", "fake", task.RunnerSandbox)
+	continuation, _ = svc.UpdateContinuationRuntimeMetadata(continuation.ID, "", "session-1", "")
+	_, _ = svc.UpdateContinuationStatus(continuation.ID, task.StatusRunning)
 	pending, _, err := svc.RecordBlackboardConclusionCheckpoint(created.ID, continuation.ID, "work-request-pending",
 		"session-1", "turn-pending", task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
 		task.SemanticDebtWatermarks{SourceWork: 1})
@@ -1317,22 +1323,20 @@ func TestPendingBlackboardConclusionRecoveryProjectsActionRequiredWithoutExtendi
 	if err != nil || changed || replay.NextEligibleAt == nil || !replay.NextEligibleAt.Equal(now.Add(5*time.Minute)) || replay.AutomaticTurnCount != 0 {
 		t.Fatalf("pending recovery replay = %#v, changed=%v, err=%v", replay, changed, err)
 	}
-	rearmed, won, err := svc.RetryLatestBlackboardConclusion(created.ID, "pending-recovery-retry", now.Add(5*time.Minute))
-	if err != nil || !won || rearmed.InternalState != task.BlackboardConclusionReceiptPending ||
-		rearmed.DispatchRequestID != "" || rearmed.BaseRevision != nil || rearmed.ApplyIdempotencyKey != "" ||
+	rearmed, won, initial, err := svc.RetryLatestBlackboardConclusionForRuntime(
+		created.ID, "pending-recovery-retry", continuation.ID, "session-1", 13, now.Add(5*time.Minute),
+	)
+	if err != nil || !won || !initial || rearmed.InternalState != task.BlackboardConclusionReceiptDispatchRequested ||
+		rearmed.DispatchRequestID == "" || rearmed.BaseRevision == nil || *rearmed.BaseRevision != 13 || rearmed.ApplyIdempotencyKey == "" ||
 		rearmed.ExplicitRetryCount != 1 || rearmed.OperatorRetryKey != "pending-recovery-retry" ||
-		rearmed.ErrorCode != "" || rearmed.NextEligibleAt != nil {
+		rearmed.AutomaticTurnCount != 1 || rearmed.ErrorCode != "" || rearmed.NextEligibleAt != nil {
 		t.Fatalf("pending recovery retry = %#v, won=%v, err=%v", rearmed, won, err)
 	}
 	replayedRetry, won, err := svc.RetryLatestBlackboardConclusion(created.ID, "pending-recovery-retry", now.Add(time.Hour))
-	if err != nil || won || replayedRetry.ID != pending.ID || replayedRetry.InternalState != task.BlackboardConclusionReceiptPending {
+	if err != nil || won || replayedRetry.ID != pending.ID || replayedRetry.InternalState != task.BlackboardConclusionReceiptDispatchRequested {
 		t.Fatalf("pending recovery retry replay = %#v, won=%v, err=%v", replayedRetry, won, err)
 	}
-	dispatched, won, err := svc.ClaimBlackboardConclusionDispatch(pending.ID, 13)
-	if err != nil || !won || dispatched.BaseRevision == nil || *dispatched.BaseRevision != 13 ||
-		dispatched.ApplyIdempotencyKey == "" || dispatched.AutomaticTurnCount != 1 || dispatched.ExplicitRetryCount != 1 {
-		t.Fatalf("rearmed pending dispatch = %#v, won=%v, err=%v", dispatched, won, err)
-	}
+	dispatched := rearmed
 	_, _, _ = svc.MarkBlackboardConclusionSendStarted(dispatched.DispatchRequestID, now.Add(6*time.Minute))
 	_, _, _ = svc.MarkBlackboardConclusionAwaiting(dispatched.DispatchRequestID, "control-after-recovery")
 	exhausted, dispatchedRepair, err := svc.HandleBlackboardConclusionFailure(dispatched.DispatchRequestID,
@@ -1366,9 +1370,13 @@ func TestRetryLatestBlackboardConclusionFailsClosedWhenDispatchFailureAppearsBef
 		t.Fatalf("mark dispatch_failed: changed=%v err=%v", changed, err)
 	}
 
-	retried, won, err := svc.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(created.ID, "stale-adapter-retry", now)
+	retried, won, err := svc.RetryLatestBlackboardConclusion(created.ID, "stale-adapter-retry", now)
 	if !errors.Is(err, task.ErrInvalidBlackboardConclusionReceipt) || won {
 		t.Fatalf("retry without proven Runtime = %#v, won=%v, err=%v", retried, won, err)
+	}
+	retried, won, err = svc.RetryBlackboardConclusion(receipt.ID, "stale-receipt-retry", now)
+	if !errors.Is(err, task.ErrInvalidBlackboardConclusionReceipt) || won {
+		t.Fatalf("receipt retry without proven Runtime = %#v, won=%v, err=%v", retried, won, err)
 	}
 	latest, latestErr := svc.LatestBlackboardConclusion(created.ID)
 	if latestErr != nil || latest == nil || latest.InternalState != task.BlackboardConclusionReceiptActionRequired ||

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1350,7 +1350,8 @@ func TestPendingBlackboardConclusionRecoveryProjectsActionRequiredWithoutExtendi
 	dispatched, reboundWon, err := svc.CreateRecoveryConclusionDispatch(
 		pending.ID, replacement.ID, "session-2", now.Add(6*time.Minute),
 	)
-	if err != nil || !reboundWon || dispatched.DispatchKind != task.ConclusionDispatchKindInitial {
+	if err != nil || !reboundWon || dispatched.DispatchKind != task.ConclusionDispatchKindRecovery ||
+		dispatched.DirectiveKind != task.ConclusionDirectiveKindInitial {
 		t.Fatalf("rebound initial retry = %#v, created=%v, err=%v", dispatched, reboundWon, err)
 	}
 	_, _, _ = svc.MarkBlackboardConclusionSendStarted(dispatched.DispatchRequestID, now.Add(6*time.Minute))

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1343,6 +1343,43 @@ func TestPendingBlackboardConclusionRecoveryProjectsActionRequiredWithoutExtendi
 	}
 }
 
+func TestRetryLatestBlackboardConclusionFailsClosedWhenDispatchFailureAppearsBeforeTransaction(t *testing.T) {
+	db := newStore(t)
+	projects := project.NewService(db)
+	svc := task.NewService(db, projects)
+	proj, _ := projects.Create("P", "", project.Scope{}, project.Defaults{})
+	created, _ := svc.Create(task.CreateRequest{ProjectID: proj.ID,
+		Type: task.TypePentest, Goal: "inspect", Runner: task.RunnerSandbox,
+		RunControls: task.RunControls{BlackboardConclusionMode: task.BlackboardConclusionModeAssisted}})
+	continuation, _ := svc.CreateContinuation(created.ID, "profile", "fake", task.RunnerSandbox)
+	receipt, _, err := svc.RecordBlackboardConclusionCheckpoint(created.ID, continuation.ID,
+		"work-request-race", "session-dead", "turn-race",
+		task.TurnSelection{ModelProviderID: "provider-1", Model: "model-1"},
+		task.SemanticDebtWatermarks{SourceWork: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	if _, changed, err := svc.MarkBlackboardConclusionRecoveryActionRequiredByReceiptID(
+		receipt.ID, task.ConclusionRecoveryDispatchFailed, now, 0,
+	); err != nil || !changed {
+		t.Fatalf("mark dispatch_failed: changed=%v err=%v", changed, err)
+	}
+
+	retried, won, err := svc.RetryLatestBlackboardConclusionFailClosedOnDispatchFailure(created.ID, "stale-adapter-retry", now)
+	if !errors.Is(err, task.ErrInvalidBlackboardConclusionReceipt) || won {
+		t.Fatalf("retry without proven Runtime = %#v, won=%v, err=%v", retried, won, err)
+	}
+	latest, latestErr := svc.LatestBlackboardConclusion(created.ID)
+	if latestErr != nil || latest == nil || latest.InternalState != task.BlackboardConclusionReceiptActionRequired ||
+		latest.RecoveryReason != string(task.ConclusionRecoveryDispatchFailed) || latest.ExplicitRetryCount != 0 {
+		t.Fatalf("failed-closed conclusion = %#v, err=%v", latest, latestErr)
+	}
+	if dispatches, historyErr := svc.ConclusionDispatches(receipt.ID); historyErr != nil || len(dispatches) != 0 {
+		t.Fatalf("failed-closed dispatch history = %#v, err=%v", dispatches, historyErr)
+	}
+}
+
 func TestRecoveryCandidatesIncludeInitialDispatchWithoutMutatingIt(t *testing.T) {
 	db := newStore(t)
 	projects := project.NewService(db)

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1336,7 +1336,23 @@ func TestPendingBlackboardConclusionRecoveryProjectsActionRequiredWithoutExtendi
 	if err != nil || won || replayedRetry.ID != pending.ID || replayedRetry.InternalState != task.BlackboardConclusionReceiptDispatchRequested {
 		t.Fatalf("pending recovery retry replay = %#v, won=%v, err=%v", replayedRetry, won, err)
 	}
-	dispatched := rearmed
+	replacement, err := svc.CreateReplacementContinuation(continuation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement, err = svc.UpdateContinuationRuntimeMetadata(replacement.ID, "", "session-2", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateContinuationStatus(replacement.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	dispatched, reboundWon, err := svc.CreateRecoveryConclusionDispatch(
+		pending.ID, replacement.ID, "session-2", now.Add(6*time.Minute),
+	)
+	if err != nil || !reboundWon || dispatched.DispatchKind != task.ConclusionDispatchKindInitial {
+		t.Fatalf("rebound initial retry = %#v, created=%v, err=%v", dispatched, reboundWon, err)
+	}
 	_, _, _ = svc.MarkBlackboardConclusionSendStarted(dispatched.DispatchRequestID, now.Add(6*time.Minute))
 	_, _, _ = svc.MarkBlackboardConclusionAwaiting(dispatched.DispatchRequestID, "control-after-recovery")
 	exhausted, dispatchedRepair, err := svc.HandleBlackboardConclusionFailure(dispatched.DispatchRequestID,


### PR DESCRIPTION
## Summary

- Rebind conclusion processing to the active runtime session and blackboard.
- Recover conclusion state and receipts after runtime replacement.
- Add retry handling for conclusion HTTP requests.
- Update owner, session, task, and store flows with focused regression coverage.

## Testing

- Added and updated unit tests for conclusion recovery, receipt rebinding, assisted conclusions, sessions, tasks, and stores.
- Not run (not requested).