### PR TITLE
Fix PR #230 review findings

### DIFF
--- a/internal/blackboardv2/evidence.go
+++ b/internal/blackboardv2/evidence.go
@@ -1358,7 +1358,7 @@ func (s *Service) ensureEvidencePublished(ctx context.Context, projectID, contin
 		if tempReady {
 			return nil, nil
 		}
-		return publisher.writer(stagingRoot, tempName)
+		return publisher.writer()
 	})
 	if err != nil {
 		return err
@@ -1368,7 +1368,7 @@ func (s *Service) ensureEvidencePublished(ctx context.Context, projectID, contin
 		if tempReady {
 			return nil, nil
 		}
-		return publisher.writer(stagingRoot, tempName)
+		return publisher.writer()
 	})
 	if err != nil {
 		return err
@@ -1376,7 +1376,7 @@ func (s *Service) ensureEvidencePublished(ctx context.Context, projectID, contin
 	tempReady = tempReady || previousAdopted
 	var legacyDestination func() (*os.File, error)
 	if !tempReady {
-		legacyDestination = func() (*os.File, error) { return publisher.writer(stagingRoot, tempName) }
+		legacyDestination = publisher.writer
 	}
 	legacyAdopted, err := s.sweepLegacyEvidenceTemps(ctx, projectID, *row, destinationRoot, legacyDestination)
 	if err != nil {
@@ -1387,7 +1387,7 @@ func (s *Service) ensureEvidencePublished(ctx context.Context, projectID, contin
 		if source == nil {
 			return semanticError("evidence_source_changed", "Evidence source is required to rebuild an incomplete journaled temp", "source_path", nil)
 		}
-		temp, err := publisher.writer(stagingRoot, tempName)
+		temp, err := publisher.writer()
 		if err != nil {
 			return err
 		}
@@ -1502,7 +1502,6 @@ type evidencePublisher struct {
 	file     *os.File
 	token    string
 	identity string
-	writerFD *os.File
 }
 
 func (s *Service) acquireEvidencePublisher(ctx context.Context, root *os.Root, projectID, continuationID, key string, row *evidenceRequestRow) (*evidencePublisher, error) {
@@ -1580,18 +1579,14 @@ func (s *Service) acquireEvidencePublisher(ctx context.Context, root *os.Root, p
 	return &evidencePublisher{file: file, token: token, identity: identity}, nil
 }
 
-func (publisher *evidencePublisher) writer(root *os.Root, name string) (*os.File, error) {
-	if publisher.writerFD != nil {
-		return publisher.writerFD, nil
-	}
+func (publisher *evidencePublisher) writer() (*os.File, error) {
 	if err := publisher.file.Chmod(0o600); err != nil {
 		return nil, fmt.Errorf("make journaled Evidence temp writable: %w", err)
 	}
 	// Write through the publisher handle itself: it carries the exclusive
 	// publication lock (LockFileEx byte-range lock on Windows), and a second
 	// handle to the same file would collide with the locked range.
-	publisher.writerFD = publisher.file
-	return publisher.writerFD, nil
+	return publisher.file, nil
 }
 
 func (publisher *evidencePublisher) validate(ctx context.Context, db *store.DB, root *os.Root, projectID, continuationID, key string, row evidenceRequestRow) error {
@@ -1614,11 +1609,6 @@ func (publisher *evidencePublisher) validate(ctx context.Context, db *store.DB, 
 }
 
 func (publisher *evidencePublisher) close() {
-	// writerFD is the publisher handle itself when writes went through the
-	// locked handle, so avoid closing the same *os.File twice.
-	if publisher.writerFD != nil && publisher.writerFD != publisher.file {
-		_ = publisher.writerFD.Close()
-	}
 	if publisher.file != nil {
 		unlockAndCloseEvidencePublisher(publisher.file)
 		publisher.file = nil

--- a/internal/runtime/posix_doubles_test.go
+++ b/internal/runtime/posix_doubles_test.go
@@ -1,9 +1,21 @@
 package runtime_test
 
 import (
+	"fmt"
+	"os"
 	"runtime"
 	"testing"
 )
+
+const alwaysRunningContainerCLIEnv = "CYBERPENDA_TEST_CONTAINER_ALWAYS_RUNNING"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(alwaysRunningContainerCLIEnv) == "1" {
+		fmt.Println("true")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 // skipUnlessPOSIXProcessDoubles skips tests whose process doubles (fake docker
 // CLI, fake runtime CLIs, bridge programs) are #!/bin/sh scripts. Windows

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -873,13 +874,15 @@ func TestDockerContainerStopConfirmationTimesOutWhileContainerRuns(t *testing.T)
 	if err := os.WriteFile(cidFile, []byte("ctr-running\n"), 0o600); err != nil {
 		t.Fatalf("write cidfile: %v", err)
 	}
-	docker := filepath.Join(dir, "docker")
-	if err := os.WriteFile(docker, []byte("#!/bin/sh\necho true\n"), 0o700); err != nil {
-		t.Fatalf("write docker stub: %v", err)
+	docker, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve portable container CLI double: %v", err)
 	}
+	t.Setenv(alwaysRunningContainerCLIEnv, "1")
 
-	if err := runtime.ConfirmDockerContainerExited(docker, cidFile, 80*time.Millisecond); err == nil {
-		t.Fatal("expected timeout while container is still running")
+	err = runtime.ConfirmDockerContainerExited(docker, cidFile, 80*time.Millisecond)
+	if got, want := fmt.Sprint(err), "container ctr-running did not stop before timeout"; got != want {
+		t.Fatalf("stop confirmation error = %q, want %q", got, want)
 	}
 }
 

--- a/internal/skill/builtin.go
+++ b/internal/skill/builtin.go
@@ -133,7 +133,7 @@ func (s *Service) migrateLegacyBuiltinSkillID(newID string) (Skill, error) {
 		newPath := s.bundlePath(newID)
 		if _, err := os.Lstat(oldPath); err == nil {
 			if _, newErr := os.Lstat(newPath); os.IsNotExist(newErr) {
-				if err := renameBundleDir(oldPath, newPath); err != nil {
+				if err := s.bundleFiles.renameDir(oldPath, newPath); err != nil {
 					return Skill{}, fmt.Errorf("migrate builtin skill bundle path: %w", err)
 				}
 			}

--- a/internal/skill/rename_retry_test.go
+++ b/internal/skill/rename_retry_test.go
@@ -1,10 +1,16 @@
 package skill
 
 import (
+	"context"
 	"errors"
 	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"pentest/internal/store"
 )
 
 func TestRenameRetryingRetriesTransientPermissionDenied(t *testing.T) {
@@ -81,5 +87,94 @@ func TestRenameRetryingDoesNotRetryWhenDisabled(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("rename calls = %d, want 1 (retry disabled)", calls)
+	}
+}
+
+func TestPublishRestoresPreviousLiveSkillAfterTransientRollbackDenial(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))
+	if err != nil {
+		t.Fatalf("open Store: %v", err)
+	}
+	svc := NewService(db, filepath.Join(t.TempDir(), "skills"))
+	ctx := context.Background()
+	if _, err := svc.Publish(ctx, PublishRequest{
+		Metadata: Metadata{ID: "recon-helper", Name: "Recon Helper"},
+		Files:    map[string]string{"SKILL.md": "version one"},
+	}); err != nil {
+		t.Fatalf("publish initial Skill: %v", err)
+	}
+	livePath := svc.bundlePath("recon-helper")
+
+	originalRename := svc.bundleFiles.rename
+	restoreAttempts := 0
+	svc.bundleFiles.retryPermission = true
+	svc.bundleFiles.sleep = func(time.Duration) {}
+	svc.bundleFiles.rename = func(oldpath, newpath string) error {
+		if strings.Contains(filepath.Base(oldpath), ".backup-") && newpath == livePath {
+			restoreAttempts++
+			if restoreAttempts == 1 {
+				return &fs.PathError{Op: "rename", Path: oldpath, Err: fs.ErrPermission}
+			}
+		}
+		return originalRename(oldpath, newpath)
+	}
+
+	// Force metadata persistence to fail after the replacement bundle reaches
+	// the live path. Publication must restore the previous live Skill.
+	if err := db.Close(); err != nil {
+		t.Fatalf("close Store before failed update: %v", err)
+	}
+	if _, err := svc.Publish(ctx, PublishRequest{
+		Metadata: Metadata{ID: "recon-helper", Name: "Recon Helper Updated"},
+		Files:    map[string]string{"SKILL.md": "version two"},
+	}); err == nil {
+		t.Fatal("expected metadata persistence failure")
+	}
+
+	content, err := os.ReadFile(filepath.Join(livePath, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read restored live Skill: %v", err)
+	}
+	if string(content) != "version one" {
+		t.Fatalf("restored live Skill = %q, want version one", content)
+	}
+	if restoreAttempts != 2 {
+		t.Fatalf("restore attempts = %d, want 2 after one transient denial", restoreAttempts)
+	}
+}
+
+func TestPublishReturnsRollbackFailure(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))
+	if err != nil {
+		t.Fatalf("open Store: %v", err)
+	}
+	svc := NewService(db, filepath.Join(t.TempDir(), "skills"))
+	ctx := context.Background()
+	if _, err := svc.Publish(ctx, PublishRequest{
+		Metadata: Metadata{ID: "recon-helper", Name: "Recon Helper"},
+		Files:    map[string]string{"SKILL.md": "version one"},
+	}); err != nil {
+		t.Fatalf("publish initial Skill: %v", err)
+	}
+	livePath := svc.bundlePath("recon-helper")
+
+	originalRename := svc.bundleFiles.rename
+	svc.bundleFiles.retryPermission = false
+	svc.bundleFiles.rename = func(oldpath, newpath string) error {
+		if strings.Contains(filepath.Base(oldpath), ".backup-") && newpath == livePath {
+			return &fs.PathError{Op: "rename", Path: oldpath, Err: fs.ErrPermission}
+		}
+		return originalRename(oldpath, newpath)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close Store before failed update: %v", err)
+	}
+	_, err = svc.Publish(ctx, PublishRequest{
+		Metadata: Metadata{ID: "recon-helper", Name: "Recon Helper Updated"},
+		Files:    map[string]string{"SKILL.md": "version two"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "restore previous live Skill") {
+		t.Fatalf("publish error = %v, want reported rollback failure", err)
 	}
 }

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -41,10 +41,24 @@ func renameRetrying(rename func(oldpath, newpath string) error, oldpath, newpath
 	}
 }
 
-// renameBundleDir moves a skill bundle directory inside the library, retrying
-// transient Windows access-denied failures (antivirus/indexer handles).
-func renameBundleDir(oldpath, newpath string) error {
-	return renameRetrying(os.Rename, oldpath, newpath, runtime.GOOS == "windows", time.Sleep)
+type bundleFileOperations struct {
+	rename          func(oldpath, newpath string) error
+	removeAll       func(path string) error
+	retryPermission bool
+	sleep           func(time.Duration)
+}
+
+func defaultBundleFileOperations() bundleFileOperations {
+	return bundleFileOperations{
+		rename:          os.Rename,
+		removeAll:       os.RemoveAll,
+		retryPermission: runtime.GOOS == "windows",
+		sleep:           time.Sleep,
+	}
+}
+
+func (ops bundleFileOperations) renameDir(oldpath, newpath string) error {
+	return renameRetrying(ops.rename, oldpath, newpath, ops.retryPermission, ops.sleep)
 }
 
 type PublishRequest struct {
@@ -72,13 +86,14 @@ type Service struct {
 	db          *store.DB
 	libraryRoot string
 	importer    Importer
+	bundleFiles bundleFileOperations
 }
 
 func NewService(db *store.DB, libraryRoot string, importers ...Importer) *Service {
 	if strings.TrimSpace(libraryRoot) == "" {
 		libraryRoot = filepath.Join(".", "skills")
 	}
-	svc := &Service{db: db, libraryRoot: libraryRoot}
+	svc := &Service{db: db, libraryRoot: libraryRoot, bundleFiles: defaultBundleFileOperations()}
 	if len(importers) > 0 {
 		svc.importer = importers[0]
 	}
@@ -113,28 +128,31 @@ func (s *Service) Publish(ctx context.Context, req PublishRequest) (Skill, error
 	hadLive := false
 	if _, err := os.Lstat(live); err == nil {
 		hadLive = true
-		if err := renameBundleDir(live, backup); err != nil {
+		if err := s.bundleFiles.renameDir(live, backup); err != nil {
 			return Skill{}, fmt.Errorf("stage existing live skill: %w", err)
 		}
 	} else if !os.IsNotExist(err) {
 		return Skill{}, fmt.Errorf("inspect live skill: %w", err)
 	}
 
-	restore := func() {
-		_ = os.RemoveAll(live)
-		if hadLive {
-			_ = os.Rename(backup, live)
+	restore := func() error {
+		if err := s.bundleFiles.removeAll(live); err != nil {
+			return fmt.Errorf("remove failed live Skill: %w", err)
 		}
+		if hadLive {
+			if err := s.bundleFiles.renameDir(backup, live); err != nil {
+				return fmt.Errorf("restore previous live Skill: %w", err)
+			}
+		}
+		return nil
 	}
-	if err := renameBundleDir(staging, live); err != nil {
-		restore()
-		return Skill{}, fmt.Errorf("promote skill bundle: %w", err)
+	if err := s.bundleFiles.renameDir(staging, live); err != nil {
+		return Skill{}, errors.Join(fmt.Errorf("promote skill bundle: %w", err), restore())
 	}
 
 	stored, err := s.upsertMetadata(meta)
 	if err != nil {
-		restore()
-		return Skill{}, err
+		return Skill{}, errors.Join(err, restore())
 	}
 	if hadLive {
 		_ = os.RemoveAll(backup)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -945,7 +945,153 @@ func migrations() []migration {
 		newMigration(58, "challenge_operation_recovery_settlement", migration58SQL, migration58Up),
 		newMigration(59, "project_approval_workflows", migration59SQL, migration59Up),
 		newMigration(60, "blackboard_conclusion_directive_kind", migration60SQL, migration60Up),
+		newMigration(61, "slash_form_evidence_path_identities", migration61SQL, migration61Up),
 	}
+}
+
+// migration61SQL records the canonical slash-form identity cutover for
+// Evidence journal paths. The data rewrite is implemented in migration61Up so
+// it can detect and merge Windows path aliases without losing payload state.
+const migration61SQL = `-- Canonicalize legacy Windows Evidence path identities and merge aliases.`
+
+type migration61EvidencePayload struct {
+	projectID      string
+	managedPath    string
+	sha256         string
+	size           int64
+	state          string
+	gcContinuation string
+	gcIdempotency  string
+	createdAt      string
+	updatedAt      string
+}
+
+// normalizeLegacyWindowsEvidencePath converts only paths whose internal root
+// was written with Windows separators. A backslash inside a slash-form Linux
+// filename remains data rather than being reinterpreted as a separator.
+func normalizeLegacyWindowsEvidencePath(value string) string {
+	if strings.HasPrefix(value, `projects\`) {
+		return strings.ReplaceAll(value, `\`, "/")
+	}
+	return value
+}
+
+func migration61Up(tx *sql.Tx) error {
+	payloadRows, err := tx.Query(`
+		SELECT project_id,managed_internal_path,sha256,size_bytes,state,
+		       gc_continuation_id,gc_idempotency_key,created_at,updated_at
+		FROM blackboard_v2_evidence_payloads
+		ORDER BY project_id,managed_internal_path`)
+	if err != nil {
+		return fmt.Errorf("read legacy Evidence payload identities: %w", err)
+	}
+	var payloads []migration61EvidencePayload
+	byIdentity := map[string]int{}
+	for payloadRows.Next() {
+		var row migration61EvidencePayload
+		if err := payloadRows.Scan(
+			&row.projectID, &row.managedPath, &row.sha256, &row.size, &row.state,
+			&row.gcContinuation, &row.gcIdempotency, &row.createdAt, &row.updatedAt,
+		); err != nil {
+			_ = payloadRows.Close()
+			return fmt.Errorf("scan legacy Evidence payload identity: %w", err)
+		}
+		row.managedPath = normalizeLegacyWindowsEvidencePath(row.managedPath)
+		identity := row.projectID + "\x00" + row.managedPath
+		if index, ok := byIdentity[identity]; ok {
+			existing := &payloads[index]
+			if existing.sha256 != row.sha256 || existing.size != row.size {
+				_ = payloadRows.Close()
+				return fmt.Errorf("conflicting Evidence payload aliases for Project %q path %q", row.projectID, row.managedPath)
+			}
+			if row.createdAt < existing.createdAt {
+				existing.createdAt = row.createdAt
+			}
+			if row.updatedAt > existing.updatedAt {
+				existing.updatedAt = row.updatedAt
+			}
+			if existing.state == "active" || row.state == "active" {
+				existing.state = "active"
+				existing.gcContinuation = ""
+				existing.gcIdempotency = ""
+			} else if row.gcContinuation+"\x00"+row.gcIdempotency < existing.gcContinuation+"\x00"+existing.gcIdempotency {
+				existing.gcContinuation = row.gcContinuation
+				existing.gcIdempotency = row.gcIdempotency
+			}
+			continue
+		}
+		byIdentity[identity] = len(payloads)
+		payloads = append(payloads, row)
+	}
+	if err := payloadRows.Err(); err != nil {
+		_ = payloadRows.Close()
+		return fmt.Errorf("iterate legacy Evidence payload identities: %w", err)
+	}
+	if err := payloadRows.Close(); err != nil {
+		return fmt.Errorf("close legacy Evidence payload identities: %w", err)
+	}
+
+	type requestPathRow struct {
+		projectID, continuationID, key                     string
+		managedPath, tempPath, previousTemp, migrationTemp string
+	}
+	requestRows, err := tx.Query(`
+		SELECT project_id,continuation_id,idempotency_key,managed_internal_path,
+		       temp_internal_path,previous_temp_internal_path,migration27_temp_internal_path
+		FROM blackboard_v2_evidence_requests`)
+	if err != nil {
+		return fmt.Errorf("read legacy Evidence request paths: %w", err)
+	}
+	var requests []requestPathRow
+	for requestRows.Next() {
+		var row requestPathRow
+		if err := requestRows.Scan(
+			&row.projectID, &row.continuationID, &row.key, &row.managedPath,
+			&row.tempPath, &row.previousTemp, &row.migrationTemp,
+		); err != nil {
+			_ = requestRows.Close()
+			return fmt.Errorf("scan legacy Evidence request paths: %w", err)
+		}
+		row.managedPath = normalizeLegacyWindowsEvidencePath(row.managedPath)
+		row.tempPath = normalizeLegacyWindowsEvidencePath(row.tempPath)
+		row.previousTemp = normalizeLegacyWindowsEvidencePath(row.previousTemp)
+		row.migrationTemp = normalizeLegacyWindowsEvidencePath(row.migrationTemp)
+		requests = append(requests, row)
+	}
+	if err := requestRows.Err(); err != nil {
+		_ = requestRows.Close()
+		return fmt.Errorf("iterate legacy Evidence request paths: %w", err)
+	}
+	if err := requestRows.Close(); err != nil {
+		return fmt.Errorf("close legacy Evidence request paths: %w", err)
+	}
+
+	if _, err := tx.Exec(`DELETE FROM blackboard_v2_evidence_payloads`); err != nil {
+		return fmt.Errorf("clear aliased Evidence payload identities: %w", err)
+	}
+	for _, payload := range payloads {
+		if _, err := tx.Exec(`
+			INSERT INTO blackboard_v2_evidence_payloads
+				(project_id,managed_internal_path,sha256,size_bytes,state,gc_continuation_id,gc_idempotency_key,created_at,updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?)`,
+			payload.projectID, payload.managedPath, payload.sha256, payload.size, payload.state,
+			payload.gcContinuation, payload.gcIdempotency, payload.createdAt, payload.updatedAt,
+		); err != nil {
+			return fmt.Errorf("store canonical Evidence payload identity: %w", err)
+		}
+	}
+	for _, request := range requests {
+		if _, err := tx.Exec(`
+			UPDATE blackboard_v2_evidence_requests
+			SET managed_internal_path=?,temp_internal_path=?,previous_temp_internal_path=?,migration27_temp_internal_path=?
+			WHERE project_id=? AND continuation_id=? AND idempotency_key=?`,
+			request.managedPath, request.tempPath, request.previousTemp, request.migrationTemp,
+			request.projectID, request.continuationID, request.key,
+		); err != nil {
+			return fmt.Errorf("store canonical Evidence request paths: %w", err)
+		}
+	}
+	return execStatements(tx, migration61SQL)
 }
 
 // migration60SQL separates immutable delivery lineage from the semantic
@@ -2986,7 +3132,7 @@ func migration28Up(tx *sql.Tx) error {
 func fixedEvidenceStagingPath(managedPath, continuationID, key, requestHash string) (string, error) {
 	// Evidence journal paths are slash-form contracts, but rows written by
 	// pre-fix Windows builds may hold backslashes; normalize before parsing.
-	managedPath = filepath.ToSlash(managedPath)
+	managedPath = normalizeLegacyWindowsEvidencePath(filepath.ToSlash(managedPath))
 	const marker = "/retained/"
 	index := strings.Index(managedPath, marker)
 	if index <= 0 || len(requestHash) != 64 {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13,7 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"pentest/internal/project"
 	"pentest/internal/store"
+	"pentest/internal/task"
 )
 
 // TestOpenRunsMigrationsIdempotently guards against re-running migrations on an
@@ -1320,6 +1322,132 @@ func TestMigration60BackfillsActiveRecoveryDirectiveKindsFromDispatchHistory(t *
 		if got != test.want {
 			t.Errorf("%s directive_kind = %q, want %q", test.id, got, test.want)
 		}
+	}
+}
+
+func TestMigration61NormalizesLegacyWindowsEvidencePathIdentities(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pentest.db")
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projects := project.NewService(db)
+	createdProject, err := projects.Create("Evidence path migration", "", project.Scope{}, project.Defaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewService(db, projects)
+	createdTask, err := tasks.Create(task.CreateRequest{
+		ProjectID: createdProject.ID,
+		Type:      task.TypePentest,
+		Goal:      "preserve Evidence ownership",
+		Runner:    task.RunnerHost,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyContinuation, err := tasks.CreateContinuation(createdTask.ID, "profile", "fake", task.RunnerHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalContinuation, err := tasks.CreateContinuation(createdTask.ID, "profile", "fake", task.RunnerHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digest := strings.Repeat("a", 64)
+	requestHash := strings.Repeat("b", 64)
+	canonicalManaged := "projects/project-hash/retained/" + digest + "/proof.txt"
+	canonicalTemp := "projects/project-hash/.evidence-staging/request/" + requestHash
+	canonicalPrevious := "projects/project-hash/retained/" + digest + "/.proof.txt.stage-old"
+	canonicalMigration27 := "projects/project-hash/.evidence-staging/legacy/" + requestHash
+	legacyManaged := strings.ReplaceAll(canonicalManaged, "/", `\`)
+	legacyTemp := strings.ReplaceAll(canonicalTemp, "/", `\`)
+	legacyPrevious := strings.ReplaceAll(canonicalPrevious, "/", `\`)
+	legacyMigration27 := strings.ReplaceAll(canonicalMigration27, "/", `\`)
+	now := "2026-08-24T12:00:00Z"
+	if _, err := db.Exec(`
+		INSERT INTO blackboard_v2_evidence_payloads
+			(project_id,managed_internal_path,sha256,size_bytes,state,created_at,updated_at)
+		VALUES (?,?,?,?, 'active',?,?)`, createdProject.ID, legacyManaged, digest, 5, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO blackboard_v2_evidence_payloads
+			(project_id,managed_internal_path,sha256,size_bytes,state,gc_continuation_id,gc_idempotency_key,created_at,updated_at)
+		VALUES (?,?,?,?, 'gc',?,?,?,?)`, createdProject.ID, canonicalManaged, digest, 5, canonicalContinuation.ID, "canonical-request", now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO blackboard_v2_evidence_requests
+			(project_id,continuation_id,idempotency_key,request_hash,source_identity,source_sha256,source_size_bytes,
+			 managed_internal_path,temp_internal_path,previous_temp_internal_path,migration27_temp_internal_path,
+			 payload_owned,status,result_json,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?, 'completed','{}',?,?)`,
+		createdProject.ID, legacyContinuation.ID, "legacy-request", requestHash, "legacy-source", digest, 5,
+		legacyManaged, legacyTemp, legacyPrevious, legacyMigration27, 1, now, now,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO blackboard_v2_evidence_requests
+			(project_id,continuation_id,idempotency_key,request_hash,source_identity,source_sha256,source_size_bytes,
+			 managed_internal_path,temp_internal_path,previous_temp_internal_path,migration27_temp_internal_path,
+			 payload_owned,status,result_json,created_at,updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?, 'completed','{}',?,?)`,
+		createdProject.ID, canonicalContinuation.ID, "canonical-request", requestHash, "canonical-source", digest, 5,
+		canonicalManaged, canonicalTemp, canonicalPrevious, canonicalMigration27, 1, now, now,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DELETE FROM schema_migrations WHERE version=61`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	var payloadCount int
+	if err := reopened.QueryRow(`SELECT COUNT(*) FROM blackboard_v2_evidence_payloads WHERE project_id=?`, createdProject.ID).Scan(&payloadCount); err != nil {
+		t.Fatal(err)
+	}
+	if payloadCount != 1 {
+		t.Fatalf("normalized Evidence payload identities = %d, want 1", payloadCount)
+	}
+	var managedPath, state, gcContinuationID, gcKey string
+	if err := reopened.QueryRow(`SELECT managed_internal_path,state,gc_continuation_id,gc_idempotency_key FROM blackboard_v2_evidence_payloads WHERE project_id=?`, createdProject.ID).Scan(&managedPath, &state, &gcContinuationID, &gcKey); err != nil {
+		t.Fatal(err)
+	}
+	if managedPath != canonicalManaged || state != "active" || gcContinuationID != "" || gcKey != "" {
+		t.Fatalf("normalized Evidence payload = path %q state %q gc=(%q,%q)", managedPath, state, gcContinuationID, gcKey)
+	}
+
+	rows, err := reopened.Query(`SELECT managed_internal_path,temp_internal_path,previous_temp_internal_path,migration27_temp_internal_path FROM blackboard_v2_evidence_requests WHERE project_id=? ORDER BY idempotency_key`, createdProject.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	requestCount := 0
+	for rows.Next() {
+		requestCount++
+		var gotManaged, gotTemp, gotPrevious, gotMigration27 string
+		if err := rows.Scan(&gotManaged, &gotTemp, &gotPrevious, &gotMigration27); err != nil {
+			t.Fatal(err)
+		}
+		if gotManaged != canonicalManaged || gotTemp != canonicalTemp || gotPrevious != canonicalPrevious || gotMigration27 != canonicalMigration27 {
+			t.Errorf("normalized Evidence request paths = (%q,%q,%q,%q)", gotManaged, gotTemp, gotPrevious, gotMigration27)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("normalized Evidence requests = %d, want 2", requestCount)
 	}
 }
 

--- a/internal/store/store_v2_test.go
+++ b/internal/store/store_v2_test.go
@@ -135,7 +135,7 @@ func TestOrdinaryOpenRefusesUnknownEpochWithoutTouchingSQLiteState(t *testing.T)
 			prepare: func(t *testing.T, path string) func() {
 				return holdStoreEpochUpdateInWAL(t, path, "future_v3")
 			},
-			wantMigrationCount: 60,
+			wantMigrationCount: 61,
 			wantSidecars:       true,
 		},
 	}


### PR DESCRIPTION
## Summary

- make Skill publication rollback retry transient Windows rename failures and report rollback errors
- add migration 61 to merge legacy Windows Evidence path identities safely
- make the Docker stop timeout regression test portable across Windows and POSIX
- remove stale Evidence publisher writer state

## Verification

- go test -timeout 20m ./cmd/... ./internal/... ./scripts
- go vet ./cmd/... ./internal/... ./scripts
- git diff --check