### PR TITLE
Fix Windows container stop timeout regression

### DIFF
--- a/internal/runtime/container.go
+++ b/internal/runtime/container.go
@@ -57,6 +57,9 @@ func ConfirmDockerContainerExited(containerCLI, cidFile string, timeout time.Dur
 	for {
 		stopped, err := dockerContainerStopped(ctx, containerCLI, id)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("container %s did not stop before timeout", id)
+			}
 			return err
 		}
 		if stopped {

--- a/internal/runtime/posix_doubles_test.go
+++ b/internal/runtime/posix_doubles_test.go
@@ -5,12 +5,26 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 )
 
 const alwaysRunningContainerCLIEnv = "CYBERPENDA_TEST_CONTAINER_ALWAYS_RUNNING"
+const containerCLIInvocationPathEnv = "CYBERPENDA_TEST_CONTAINER_INVOCATION_PATH"
+const slowContainerCLIEnv = "CYBERPENDA_TEST_CONTAINER_SLOW"
 
 func TestMain(m *testing.M) {
+	if os.Getenv(slowContainerCLIEnv) == "1" {
+		time.Sleep(time.Second)
+		fmt.Println("true")
+		os.Exit(0)
+	}
 	if os.Getenv(alwaysRunningContainerCLIEnv) == "1" {
+		if marker := os.Getenv(containerCLIInvocationPathEnv); marker != "" {
+			if err := os.WriteFile(marker, []byte("called"), 0o600); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
+		}
 		fmt.Println("true")
 		os.Exit(0)
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -878,10 +878,33 @@ func TestDockerContainerStopConfirmationTimesOutWhileContainerRuns(t *testing.T)
 	if err != nil {
 		t.Fatalf("resolve portable container CLI double: %v", err)
 	}
+	invocationMarker := filepath.Join(dir, "container-cli-called")
 	t.Setenv(alwaysRunningContainerCLIEnv, "1")
+	t.Setenv(containerCLIInvocationPathEnv, invocationMarker)
 
-	err = runtime.ConfirmDockerContainerExited(docker, cidFile, 80*time.Millisecond)
+	err = runtime.ConfirmDockerContainerExited(docker, cidFile, time.Second)
 	if got, want := fmt.Sprint(err), "container ctr-running did not stop before timeout"; got != want {
+		t.Fatalf("stop confirmation error = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(invocationMarker); err != nil {
+		t.Fatalf("portable container CLI was not invoked: %v", err)
+	}
+}
+
+func TestDockerContainerStopConfirmationReportsStableTimeoutWhenInspectExceedsDeadline(t *testing.T) {
+	dir := t.TempDir()
+	cidFile := filepath.Join(dir, "container.cid")
+	if err := os.WriteFile(cidFile, []byte("ctr-slow\n"), 0o600); err != nil {
+		t.Fatalf("write cidfile: %v", err)
+	}
+	docker, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve portable container CLI double: %v", err)
+	}
+	t.Setenv(slowContainerCLIEnv, "1")
+
+	err = runtime.ConfirmDockerContainerExited(docker, cidFile, 30*time.Millisecond)
+	if got, want := fmt.Sprint(err), "container ctr-slow did not stop before timeout"; got != want {
 		t.Fatalf("stop confirmation error = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Root cause

ConfirmDockerContainerExited shared its timeout context with the Docker inspect process. On Windows, starting the portable Go test-binary CLI double could consume the short deadline. The function then returned raw context deadline exceeded before it produced the stable container-stop timeout.

## Fix

- map an owned inspect deadline to the container-specific timeout error
- add a deterministic slow-CLI regression test
- give the portable running-container test a realistic deadline and require proof that the CLI started

## Verification

- targeted timeout regression tests
- full Runtime package tests
- Windows Runtime test-binary compilation
- full repository Go tests
- scoped Go vet
- diff check