### PR TITLE
Implement runtime-native steering across providers and session workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pentest.db.pre-blackboard-v2.*.bak
 /pentestd
 /pentestd.exe
 daemon.log
+/model-capability-cache.json
 runs/
 __pycache__/
 *.pyc

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,12 +112,16 @@ _Avoid_: audit log entry, transcript line, raw output dump
 The user-runtime interaction that continues inside one **Task** after launch.
 _Avoid_: new task per reply, detached chat
 
+**Session Conversation**:
+The user-runtime interaction that continues inside one **Non-Project Session**.
+_Avoid_: Project Task Conversation, disposable chat, detached runtime log
+
 **Runtime Turn**:
-A single provider response cycle initiated by operator input within a **Task Conversation** or by a bounded **Harness Control Turn**. It retains the **Task** identity while using its own **Runtime Turn Selection**.
+A single provider response cycle initiated by operator input within a **Task Conversation** or **Session Conversation**, or by a bounded **Harness Control Turn**. It retains its **Runtime Owner** identity while using its own **Runtime Turn Selection**.
 _Avoid_: task, continuation, internal reasoning step
 
 **Work Runtime Turn**:
-A **Runtime Turn** initiated by the operator's Task Goal or Task Conversation input. The **Runtime Harness** assigns this kind from request lineage; provider output cannot claim it. In assisted Blackboard mode, bounded Tool and Turn observations from this kind may create a **Pending Blackboard Conclusion**.
+A **Runtime Turn** initiated by the operator's Task Goal, Task Conversation input, or Session Conversation input. The **Runtime Harness** assigns this kind from request lineage; provider output cannot claim it. In assisted Blackboard mode, bounded Tool and Turn observations from this kind may create a **Pending Blackboard Conclusion**.
 _Avoid_: harness control turn, provider-classified turn, task
 
 **Harness Control Turn**:
@@ -157,28 +161,28 @@ An immutable copy of **Scope** captured when a **Task** starts.
 _Avoid_: current scope, cached target list
 
 **Runtime**:
-The local agent CLI or assistant process scheduled to perform one **Task**.
+The local agent CLI or assistant process scheduled to perform work for one **Runtime Owner**.
 _Avoid_: pentest agent, model, provider, worker
 
-**Task-Scoped Persistent Runtime**:
-A **Runtime** process or native session that remains available across **Runtime Turns** within one **Task** and closes only at explicit Task completion, stop, failure, or a required **Config Projection** restart.
+**Runtime Owner-Scoped Persistent Runtime**:
+A **Runtime** process or native session that remains available across **Runtime Turns** within one **Runtime Owner**. The Runtime Owner is a **Task** or **Non-Project Session**. The Runtime closes only at explicit owner completion, stop, failure, archive, or a required **Config Projection** restart.
 _Avoid_: daemon-global session, infinite process, session-wide setting
 
 **Runtime Harness**:
-The daemon-managed control wrapper that launches, resumes, steers, and stops a **Runtime** for one **Task**.
+The daemon-managed, owner-neutral control wrapper that launches, resumes, steers, and stops a **Runtime** for one **Runtime Owner**.
 _Avoid_: pentest tool executor, agent brain, sandbox
 
 **Harness Steering**:
-A task-local control action that changes how the **Runtime Harness** continues a **Task** without creating a new task.
-_Avoid_: direct tool control, hidden prompt mutation, new task
+An owner-local control action that changes how the **Runtime Harness** continues a **Task** or **Non-Project Session** without creating a new Runtime Owner. When the Runtime exposes provider-native same-turn steering, it may append operator input to the current active steerable **Work Runtime Turn**; otherwise it changes a later or replacement **Runtime Continuation**.
+_Avoid_: direct tool control, hidden prompt mutation, new Runtime Owner
 
 **Accepted Steering**:
-A durable **Harness Steering** request whose ordered dispatch and settlement responsibility belongs to the **Runtime Harness**. It must reach `applied`, `failed`, or `action_required`, including after daemon restart.
+A durable **Harness Steering** request for one **Runtime Owner** whose ordered dispatch and settlement responsibility belongs to the **Runtime Harness**. It must reach `applied`, `failed`, or `action_required`, including after daemon restart.
 _Avoid_: saved message, in-memory callback, permanent pending state
 
 **Runtime Continuation**:
-The next unit of runtime progress after launch, user input, checkpoint, interrupt, or resume.
-_Avoid_: live thought editing, new task
+One writable unit of runtime progress after launch, user input, checkpoint, interrupt, or resume. Provider-native same-turn steering remains inside the current Runtime Continuation; interrupt-then-replace creates a replacement Runtime Continuation.
+_Avoid_: rewriting completed Runtime items, new task
 
 **Runtime Activity Indicator**:
 An operator-visible current-state view with Runtime liveness (`live`, `offline`, `orphaned`, or `unknown`) and, while live, turn activity (`busy` or `idle`), independently of the durable **Task** lifecycle.
@@ -1109,7 +1113,7 @@ _Avoid_: transcript, export, source of truth
 - **Runtime Custom Arguments** cannot declare a **Model Provider**, model, or **Reasoning Effort** through any runtime-native alias; Profile validation and **Preflight** reject such conflicts with a clear offending-argument error and diagnostic log instead of relying on CLI argument order.
 - CyberPenda does not migrate, remove, reinterpret, or otherwise fall back around conflicting **Runtime Custom Arguments**.
 - Structured Profile, launch, and **Runtime Turn Selection** fields are authoritative for **Model Provider**, model, and **Reasoning Effort**.
-- Non-conflicting **Runtime Custom Arguments** continue to apply to both **Sandbox Runner** and **Host Runner** launches, including **Task-Scoped Persistent Runtime** bridges.
+- Non-conflicting **Runtime Custom Arguments** continue to apply to both **Sandbox Runner** and **Host Runner** launches, including **Runtime Owner-Scoped Persistent Runtime** bridges.
 - Editing a **Model Provider** does not change existing **Task Runtime Configurations** or an active **Runtime Continuation**.
 - A **Model Provider** cannot be deleted while any **Runtime Profile** still references it, unless the operator explicitly confirms a deletion that clears the **Model Provider** reference and its pinned **Model Provider Protocol** from every referencing **Runtime Profile**.
 - Historical task views read captured **Task Runtime Configurations** and **Model Provider Snapshots**, not live **Runtime Profiles** or live **Model Providers**.
@@ -1173,10 +1177,10 @@ _Avoid_: transcript, export, source of truth
 - A **Scope Snapshot** records historical authorization and does not change when current **Scope** later changes.
 - A **Runtime** performs a **Task** but is not the whole **Pentest Agent**.
 - A **Runtime Harness** launches, resumes, steers, and stops a **Runtime** without executing pentest tools itself.
-- Built-in Codex, Claude Code, Pi, and Hermes **Runtimes** use a **Task-Scoped Persistent Runtime** on both **Sandbox Runner** and **Host Runner** when their native session bridge is available.
-- **Task-Scoped Persistent Runtime** does not remove **Host Runner Activation** or weaken the separate Sandbox and Host execution boundaries.
+- Built-in Codex, Claude Code, Pi, and Hermes **Runtimes** use a **Runtime Owner-Scoped Persistent Runtime** on both **Sandbox Runner** and **Host Runner** when their native session bridge is available.
+- **Runtime Owner-Scoped Persistent Runtime** does not remove **Host Runner Activation** or weaken the separate Sandbox and Host execution boundaries.
 - A plugin without a usable native session bridge may retain one-shot Runtime execution; normal process exit completes that one-shot **Task**.
-- A **Task-Scoped Persistent Runtime** remains active until the operator invokes **Task Finish** or **Stop**, a required **Config Projection** restart replaces it, it fails, or daemon shutdown closes it.
+- A **Runtime Owner-Scoped Persistent Runtime** remains active until the operator finishes, stops, archives, or otherwise closes its **Runtime Owner**, a required **Config Projection** restart replaces it, it fails, or daemon shutdown closes it.
 - A **Runtime** cannot autonomously complete its **Task** through a **Project Interface**; a valid **Blackboard Finish Intent** closes only the current Continuation's Blackboard write protocol when its **Work Runtime Turn** settles.
 - Source work after a **Blackboard Finish Intent** invalidates that intent and continues to advance **Semantic Debt Watermarks**.
 - `blackboard_finish` reports that a **Blackboard Finish Intent** was recorded, not that the Runtime Continuation is already closed.
@@ -1189,16 +1193,16 @@ _Avoid_: transcript, export, source of truth
 - **Task Finish** marks the **Task** completed after Runtime shutdown and required Continuation reconciliation; **Stop** marks it stopped and remains resumable.
 - **Task Finish** is available only when the **Runtime Activity Indicator** reports `live` with turn activity `idle`; an operator uses **Stop** to interrupt a `busy` Runtime.
 - A durable active **Task** whose Runtime is confirmed `offline` becomes failed; one whose Runtime is `orphaned` becomes interrupted; `unknown` liveness warns the operator without changing Task lifecycle.
-- Sending a new user message to a completed, failed, interrupted, or stopped **Task** resumes that Task and launches a replacement **Task-Scoped Persistent Runtime**, preferring provider-native session recovery and otherwise rebuilding a fresh **Runtime Continuation** from Task-owned continuity state.
+- Sending a new user message to a completed, failed, interrupted, or stopped **Task** resumes that Task and launches a replacement **Runtime Owner-Scoped Persistent Runtime**, preferring provider-native session recovery and otherwise rebuilding a fresh **Runtime Continuation** from Task-owned continuity state.
 - **Task Finish** releases Runtime resources and records a completed lifecycle state without sealing the **Task Conversation**; a later user message may resume the same **Task**.
 - An `orphaned` Runtime must be closed or proven absent before a replacement Runtime starts, preventing two live Runtimes from owning one **Task**.
-- **Harness Steering** changes the next runtime continuation, not the **Task** identity.
-- **Harness Steering** affects a **Runtime Continuation**, not an already-running internal reasoning step.
+- **Harness Steering** never changes the **Runtime Owner** identity. Provider-native same-turn steering appends operator input to the current active steerable **Work Runtime Turn** and keeps its Runtime Continuation; interrupt-then-replace creates a replacement **Work Runtime Turn** and changes the writable Runtime Continuation when the provider contract requires it.
+- **Harness Steering** never rewrites completed reasoning, messages, or tool items. A provider-native same-turn steer may enqueue additional operator input while the active Runtime Turn is still running.
 - A **Pending Blackboard Conclusion** may survive replacement of its source **Runtime Continuation**.
 - Each **Conclusion Dispatch** belongs to exactly one **Pending Blackboard Conclusion** and is bound immutably to exactly one Runtime Continuation and source Runtime session.
 - Replacing a Runtime Continuation never rewrites an earlier **Conclusion Dispatch**; recovery creates a new dispatch and retains the earlier dispatch outcome.
 - Only one **Conclusion Dispatch** for a **Pending Blackboard Conclusion** may be active at a time.
-- A new **Conclusion Dispatch** requires proven ownership of the current Task-scoped Runtime and a writable replacement Runtime Continuation.
+- A new **Conclusion Dispatch** requires proven ownership of the current Runtime Owner-scoped Runtime and a writable replacement Runtime Continuation.
 - A recovered **Conclusion Dispatch** reuses the source **Runtime Turn Selection**; if that selection cannot be projected safely, the **Pending Blackboard Conclusion** becomes `action_required`.
 - Automatic conclusion and repair budgets belong to the **Pending Blackboard Conclusion** and do not reset when a new **Conclusion Dispatch** is created.
 - Only the active **Conclusion Dispatch** may validate or apply a result. A late result from an earlier dispatch is retained as a terminal delivery outcome and cannot change Blackboard state.
@@ -1500,8 +1504,8 @@ _Avoid_: transcript, export, source of truth
 - **Project Defaults** are not copied **Runtime Profiles**; resolved: they select defaults while profiles remain global.
 - **Project Dashboard** is not a chat-first view; resolved: the project home prioritizes scope, task runs, blackboard state, findings, and evidence.
 - **Task Goal** is not the whole task configuration; resolved: natural-language goals are paired with visible **Run Controls**.
-- **Harness Steering** is not direct pentest tool control; resolved: it controls runtime continuation inside the same **Task** through the **Runtime Harness**.
-- **Runtime Continuation** is not live thought editing; resolved: steering applies at input, checkpoint, interrupt, or resume boundaries.
+- **Harness Steering** is not direct pentest tool control; resolved: it controls one **Runtime Owner** through the **Runtime Harness**, and provider-native same-turn steering may append operator input only to the current active steerable **Work Runtime Turn**.
+- **Runtime Continuation** is not live thought editing; resolved: provider-native same-turn steering may enqueue new operator input into an active steerable Runtime Turn without rewriting completed items, while interrupt-then-replace applies at a replacement boundary.
 - **Harness Steering** is not silent run-control mutation; resolved: runner, profile, or other run-control changes apply through explicit task events and only at continuation boundaries.
 - **Profile Selector** is not raw configuration editing; resolved: switching profiles is fast, while editing profiles remains structured.
 - **Generated Runtime Config** is not the editable source of truth; resolved: raw config preview and diff are derived from structured profile fields.

--- a/docs/specs/runtime-native-steer.md
+++ b/docs/specs/runtime-native-steer.md
@@ -1,150 +1,132 @@
-# Interactive Sandbox Provider Sessions and Native Steer
+# Runtime Owner Provider Sessions and Native Steering
 
 ## Problem Statement
 
-CyberPenda executes each Runtime Continuation as a one-shot foreground process.
-Task controls can stop, resume, or steer only by ending the current sandbox
-container and starting another continuation from a persisted native session
-identifier. This is not the interactive Agent UI experience operators expect
-from Paseo: an active Claude Code, Codex, or Pi session should remain inside
-one sandbox-owned Task session, receive a user follow-up through the provider's
-native control protocol, and preserve a truthful Task Conversation and
-transcript.
+A **Runtime Owner** can be a Project **Task** or a **Non-Project Session**.
+Both owners use one persistent provider session and one shared Runtime Owner
+Workspace. Operator follow-up must not create a different owner or make the UI
+report `idle` while a provider **Runtime Turn** is still active.
+
+Codex App Server supports `turn/steer` for same-turn input. A blanket
+interrupt-then-replace implementation loses that behavior and can start an
+expensive replacement Turn. The Conversation can also appear blank if the
+Runtime output projection stores only completed assistant messages and tools.
 
 ## Solution
 
-Add a Task-owned Sandbox/provider session bridge. The bridge keeps the provider
-process and its bidirectional, non-PTY protocol channel alive for the Task.
-Runtime Continuations become durable turn/control boundaries inside that
-session. A user message is recorded once as a Task Conversation event. Direct
-provider in-turn steer is preferred when capability negotiation exposes it.
-Otherwise the Runtime Harness performs provider-native interrupt/cancel/abort,
-waits for acknowledged settlement, and sends the new prompt on the same
-session. The daemon records typed lifecycle and provider acknowledgement events
-and projects them once into the existing transcript.
+Use provider-native same-turn steering when the current active Turn is a
+steerable **Work Runtime Turn** and the requested **Runtime Turn Selection** does
+not require replacement. For Codex, send App Server `turn/steer` with the
+current thread ID, `expectedTurnId`, and operator input. For Pi, use its native
+same-turn RPC. If a provider does not implement same-turn steering, use its
+native interrupt, wait for acknowledged settlement, and start one replacement
+Work Turn on the same native session.
 
-The first provider release is Claude Code, Codex, and Pi. Providers without a
-persistent session or interrupt capability fail with a typed unsupported
-capability error. PTY, shell emulation, raw terminal input, process-kill steer,
-and mechanical handoff are outside this feature.
+Every request first becomes durable **Accepted Steering**. The Runtime Harness
+then dispatches requests first-in, first-out for that Runtime Owner. Runtime
+activity follows the provider Turn, and the Conversation shows bounded
+reasoning summaries plus started and completed tool work.
 
-## User Stories
+## Required Behavior
 
-1. As an operator, I want to send a follow-up message while a Task Runtime is
-   active, so that I can redirect work without creating a new Task.
-2. As an operator, I want my Task to keep one Sandbox/provider session, so that
-   the provider retains its native context and workdir.
-3. As an operator, I want provider-native in-turn steer used when available,
-   so that the provider can apply its own interruption semantics.
-4. As an operator, I want providers without direct steer to interrupt natively
-   and then receive my prompt on the same session, so that fallback preserves
-   provider context.
-5. As an operator, I want failed or unsupported steer to be reported clearly,
-   so that the UI never claims a redirect was applied when it was not.
-6. As an operator, I want one Task Conversation user message, so that the
-   transcript does not duplicate my prompt as both conversation and steering.
-7. As an operator, I want the transcript to show steer requested, provider
-   acknowledgement, old-turn settlement, and replacement turn boundaries, so
-   that I can audit what happened.
-8. As an operator, I want duplicate steer requests to be idempotent, so that a
-   retry after a lost response cannot create two replacement turns.
-9. As an operator, I want concurrent steer, stop, and close operations to be
-   serialized, so that one Task cannot own conflicting active controls.
-10. As an operator, I want provider permission requests and responses to remain
-    on the same typed session channel, so that approval state is not lost.
-11. As an operator, I want a daemon restart to fail closed on orphaned live
-    bridges, so that a stale process cannot mutate a Task after ownership is
-    lost.
-12. As an operator, I want restart recovery to use durable provider metadata
-    and a fresh Continuation pin, so that recovery is deterministic.
-13. As an operator, I want Claude Code, Codex, and Pi supported in the first
-    release, so that the common local runtimes share one interaction model.
-14. As an operator, I want unsupported providers to expose capability errors,
-    so that the UI can disable controls honestly.
-15. As an operator, I want Scope Snapshot and Project Interface authority to
-    remain unchanged during steer, so that interactivity cannot expand access.
-16. As an operator, I want Host Runner activation and Sandbox Runner reporting
-    to remain explicit, so that steer cannot cause an invisible runner switch.
-17. As an operator, I want provider protocol diagnostics redacted and separated
-    from user conversation, so that secrets and raw wire data do not leak.
-18. As an operator, I want the existing mechanical handoff path preserved as a
-    separately named recovery action, so that native interaction does not blur
-    recovery modes.
+1. Steering keeps the Task or Session identity and its native provider session.
+2. Direct same-turn steering requires one active provider Turn whose Harness
+   lineage is `work`. It never targets a Harness Control Turn.
+3. Codex `turn/steer` uses the current active Turn as an explicit precondition.
+   A mismatched or completed Turn fails closed.
+4. A same-turn steer request is a Harness control action but does not reclassify
+   the active Work Turn. A new or replacement provider Turn has `work` lineage.
+5. A model or Requested Reasoning Effort change that cannot apply in the active
+   Turn, or an explicit force-replace request, uses interrupt-then-replace. Pi
+   also uses replacement for a Model Provider change when the target belongs to
+   its fixed projected Provider set. Other Model Provider changes follow the
+   existing Config Projection and fresh Continuation rules: Task keeps its
+   queue-then-stop-then-resume safety order, while Session stops and sends the
+   operator message on the fresh Continuation. A live Session steer rejects
+   that non-Pi cross-provider request so it cannot bypass the restart path.
+6. If `turn/steer` returns JSON-RPC method-not-found, the Codex adapter disables
+   same-turn steering for that live adapter and safely retries the accepted
+   request through interrupt-then-replace. Codex InitializeResponse exposes
+   server identity, not a server capability set, so version text is not a
+   capability authority.
+7. A request ID is idempotent from the public Runtime Owner API through provider
+   dispatch. Durable replay is checked before live provider binding, active-Turn
+   checks, and server-selected steering mode.
+8. Replay identity uses only client-controlled fields: request ID, operator
+   message, Model Provider, model, and Requested Reasoning Effort. A changed
+   provider Turn ID or fallback mode cannot create a false conflict.
+9. A 202 response is returned only after the operator Conversation projection
+   and Accepted Steering record commit in one transaction.
+10. Session steering attachments are staged before acceptance. Attachment
+    Events, the Conversation Event, and Accepted Steering commit in one database
+    transaction. Failed acceptance removes staged files.
+11. The durable send-start fence remains the recovery authority. A pre-fence
+    request may dispatch after restart. A post-fence request without a durable
+    result becomes `action_required` and is never sent again automatically.
+12. Per-owner serialization covers steering dispatch, stop, close, and recovery.
+    Steering requests for different owners do not block each other.
+13. Runtime Activity is `busy` while a control RPC is active or while the
+    provider session has an active Turn ID. Elapsed time and historical Events
+    are not liveness authority.
+14. Codex Runtime output retains bounded `item/started` tool records and
+    completed reasoning summaries. Deltas remain excluded. Conversation
+    projects reasoning as collapsed `thinking`, not as an assistant answer.
+15. Started command and MCP tool records project a tool call. Completion adds
+    the matching result without duplicating the tool call.
+16. Scope, Project Interface authority, Runner choice, credentials, Workdir,
+    and Runtime Non-Interactive Defaults do not change during steering.
 
 ## Implementation Decisions
 
-- A Task owns one Sandbox/provider session for its selected Runtime Profile and
-  provider. Runtime Continuations own provider turn/control boundaries inside
-  that session.
-- The provider-session contract separates `persistent_session`, `send_turn`,
-  `interrupt_turn`, `interrupt_then_replace`, `in_turn_steer`,
-  `permission_response`, and `resume_session` capabilities.
-- The daemon-to-bridge v1 transport is a non-PTY, line-framed JSON-RPC stream
-  over daemon-owned container stdin/stdout. Bridge stdout contains only framed
-  protocol; diagnostics use redacted stderr/runtime events.
-- A bridge process owns the provider child process. The daemon owns bridge
-  lifecycle, Task binding, request ids, provider turn ids, and event persistence.
-- Direct `in_turn_steer` is preferred and is used by Pi RPC. The fallback is provider-native
-  interrupt/cancel/abort, acknowledged settlement, then same-session
-  replacement prompt. Process cancellation, PTY input, and raw stdin injection
-  are not steer implementations.
-- The first provider adapters are Claude Code, Codex, and Pi. Production
-  capability advertisement is gated by a verified transport: Codex App Server
-  and Pi RPC are stable non-PTY protocols; Claude native interrupt requires an
-  explicit Claude Agent SDK `Query` bridge and remains typed unsupported until
-  that bridge is installed. ACP is deferred until provider handshake
-  capability negotiation is implemented.
-- The canonical user message is a Task Conversation event. Control/provider
-  lifecycle events are correlated typed Task Events and are projected once into
-  the transcript without duplicating the user message.
-- A steer request is idempotent by request id. Provider turn ids and session ids
-  bind acknowledgements and replacement Continuations.
-- The old Continuation is not marked replaced/applied until provider
-  acknowledgement and settlement are durable. A failed acknowledgement cannot
-  produce `steering_applied`.
-- Per-Task control serialization covers steer, stop, close, and recovery.
-- Daemon restart does not blindly reattach an old stdio bridge in v1. Startup
-  cleans stale ownership fail-closed and resumes through durable provider
-  metadata plus a fresh Continuation pin.
-- Scope, Preflight, Project Interface grants, credential projection, Runtime
-  Workdir, Host Runner activation, and Runtime Non-Interactive Defaults remain
+- The shared ProviderSession contract exposes `send_turn`, `interrupt_turn`,
+  `interrupt_then_replace`, `in_turn_steer`, `permission_response`, persistent
+  session identity, and atomic Turn state.
+- Codex App Server is a non-PTY JSON-RPC transport. Its same-turn method is
+  `turn/steer`; its fallback is `turn/interrupt` followed by `turn/start`.
+- The provider manifest advertises the supported wire contract. Live
+  method-not-found is the backward-compatible negotiation and downgrade path.
+- Accepted Steering is the source of truth for dispatch and settlement.
+  Conversation and Timeline entries are owner-local projections.
+- Task and Session adapters share the Accepted Steering state machine. Their
+  persistence and continuation transitions remain owner-specific.
+- Runtime Turn kind comes from Harness request lineage. Provider output cannot
+  choose or change it.
+- Same-turn steering preserves the source Work Turn lineage. Replacement sends
+  always create Work Turn lineage, including method-not-found fallback.
+- Provider Turn liveness is read as one atomic snapshot when possible.
+- Pi applies model, Model Provider, and Requested Reasoning Effort through
+  pre-prompt RPCs. Therefore a selection-changing Pi steer always starts a
+  replacement Work Turn; `pi/steer` is used only when the raw selection is
   unchanged.
 
 ## Testing Decisions
 
-- Use TDD at the daemon Task control API as the highest seam, with a fake
-  provider session and fake bridge for deterministic red-green cycles.
-- Test the public behavior: same Task/session identity, typed event ordering,
-  acknowledgement gating, idempotency, unsupported capability errors,
-  concurrent control conflicts, and truthful failure states.
-- Add provider contract tests for Codex App Server JSON-RPC, Claude Code SDK
-  input/interrupt, and Pi RPC prompt/steer/abort. Tests must not require live model
-  credentials for the core contract.
-- Add sandbox lifecycle tests proving bidirectional non-PTY protocol input,
-  `-i` without `-t`, cancellation cleanup, and no duplicate containers during
-  native steer.
-- Add transcript projection tests for one canonical user message and the
-  correlated steer/provider lifecycle entries.
-- Add restart/crash-window tests for request-before-send, sent-before-ack, and
-  ack-before-commit, with at-most-once replacement creation.
-- Port Paseo's tool-call replacement behavior as an integration acceptance
-  scenario: run a long tool, send a follow-up, observe no false idle/error gap,
-  and verify same session identity.
+Use TDD. The main seam is the daemon Task and Session HTTP APIs with real owner
+services, SQLite, and deterministic fake ProviderSessions.
+
+Required tests cover:
+
+- Codex `turn/steer` wire parameters and expected active Turn checks.
+- Same-turn Work lineage preservation and replacement Work lineage creation.
+- Method-not-found downgrade and one safe interrupt-then-replace fallback.
+- Request replay before live provider checks, including daemon restart and the
+  fallback window.
+- Client-controlled conflict identity.
+- Atomic Session attachment, Conversation, and Accepted Steering persistence,
+  including staged-file rollback.
+- Provider Turn busy/idle transitions after launch, direct steer, replacement,
+  completion, interruption, and close.
+- Bounded reasoning and started-tool Runtime output parsing and Transcript
+  projection.
+- A web TranscriptRow test that renders `thinking` as collapsed text.
+- Full backend tests, web tests, web build, and `git diff --check`.
 
 ## Out of Scope
 
-- PTY, shell emulation, terminal resize, raw terminal bytes, or arbitrary Docker
-  attach/exec exposed to the web client.
-- ACP implementation in the first provider release.
-- Cross-provider session migration.
-- Automatic fallback from Sandbox Runner to Host Runner.
-- Dynamic injection into an already-running model reasoning step without a
-  provider-defined boundary.
-- Replacing provider-native persistence stores.
-- Distributed worker orchestration or remote bridge ownership.
-
-## Further Notes
-
-The existing native resume and Interrupt & Steer paths remain useful as an
-explicit recovery path while the Task-owned bridge is introduced. They must not
-be labeled as live native steer after the new capability is available.
+- Making maximum Requested Reasoning Effort faster.
+- Rewriting completed reasoning, messages, or tool items.
+- Backfilling historical Sessions that did not store reasoning summaries.
+- Raw PTY input, shell emulation, terminal bytes, or process-kill steering.
+- Cross-provider native session migration.
+- Automatic Sandbox-to-Host Runner fallback.
+- Changing Scope or Project Interface authority during steering.

--- a/internal/daemon/accepted_steering_durable_test.go
+++ b/internal/daemon/accepted_steering_durable_test.go
@@ -52,7 +52,14 @@ func (s *blockingSteerSession) SteerInTurn(ctx context.Context, request runtime.
 	case <-ctx.Done():
 		return runtime.ProviderSessionResult{}, ctx.Err()
 	}
-	return s.FakeProviderSession.SendTurn(ctx, request, emit)
+	state := s.FakeProviderSession.TurnState()
+	if request.ProviderTurnID != "" && request.ProviderTurnID != state.ActiveTurnID {
+		return runtime.ProviderSessionResult{}, &runtime.ProviderSessionOperationError{
+			Mode:  runtime.ProviderSessionModeInTurnSteer,
+			Cause: &runtime.ProviderTurnChangedError{ExpectedTurnID: request.ProviderTurnID, ActiveTurnID: state.ActiveTurnID},
+		}
+	}
+	return s.FakeProviderSession.SteerInTurn(ctx, request, emit)
 }
 
 // newBlockingSteerFixture creates an interactive Task with a bound provider
@@ -237,6 +244,9 @@ func TestAcceptedSteeringRecordsDurableSendStartFence(t *testing.T) {
 	if fenced.SendStartedAt == nil || fenced.SendStartedAt.IsZero() {
 		t.Fatalf("fenced record has no send_started_at: %#v", fenced)
 	}
+	if fenced.ExpectedProviderTurnID != "turn-1" {
+		t.Fatalf("fenced expected provider Turn = %q, want turn-1", fenced.ExpectedProviderTurnID)
+	}
 
 	close(blocked.releaseSteer)
 	waitForSteerOutcomeEvent(t, server, created.ID, "fence-1", "applied")
@@ -246,6 +256,45 @@ func TestAcceptedSteeringRecordsDurableSendStartFence(t *testing.T) {
 	}
 	if len(applied.Result) == 0 {
 		t.Fatalf("applied record carries no delivery evidence: %#v", applied)
+	}
+	requests := blocked.LastRequests()
+	if len(requests) != 1 || requests[0].ProviderTurnID != "turn-1" {
+		t.Fatalf("provider steer requests = %#v, want one request for turn-1", requests)
+	}
+}
+
+func TestAcceptedSameTurnSteeringDoesNotRetargetAChangedProviderTurn(t *testing.T) {
+	server, projectID, created, blocked := newBlockingSteerFixture(t)
+
+	response := postSteerTimed(t, server, projectID, created.ID, `{"request_id":"turn-race","message":"Stay on the accepted Turn."}`, time.Second)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("steer status=%d body=%s", response.Code, response.Body.String())
+	}
+	select {
+	case <-blocked.steerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("accepted steering did not reach provider dispatch")
+	}
+	if err := blocked.EmitObservation(runtime.ProviderSessionObservation{
+		Kind: runtime.ProviderSessionObservationTurnCompleted, SessionID: blocked.SessionID(),
+		ProviderTurnID: "turn-1", RequestID: "work-1", Status: "completed",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blocked.SendTurn(context.Background(), runtime.ProviderSessionRequest{RequestID: "later-work", Message: "new work"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if state := blocked.TurnState(); state.ActiveTurnID == "turn-1" || state.ActiveTurnID == "" {
+		t.Fatalf("replacement provider Turn state = %#v", state)
+	}
+	close(blocked.releaseSteer)
+	waitForSteerOutcomeEvent(t, server, created.ID, "turn-race", "action_required")
+	record, err := server.steering.ByRequestID(owner.KindTask, created.ID, "turn-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.ErrorCode != owner.SteeringReasonTargetTurnChanged {
+		t.Fatalf("settlement = %#v, want target_turn_changed", record)
 	}
 }
 
@@ -316,6 +365,41 @@ func TestAcceptedSteeringPostFenceRestartBecomesActionRequiredWithoutReplay(t *t
 	}
 	if sawApplied {
 		t.Fatalf("post-fence request was replayed as applied: %#v", events)
+	}
+	detail := httptest.NewRecorder()
+	server2.ServeHTTP(detail, httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID+"/tasks/"+created.ID, nil))
+	if detail.Code != http.StatusOK {
+		t.Fatalf("recovered Task detail status=%d body=%s", detail.Code, detail.Body.String())
+	}
+	var recoveredTask task.Task
+	if err := json.Unmarshal(detail.Body.Bytes(), &recoveredTask); err != nil {
+		t.Fatal(err)
+	}
+	if recoveredTask.RuntimeControls.NativeSteerState != "action_required" ||
+		recoveredTask.RuntimeControls.NativeSteerErrorCode != string(owner.SteeringReasonDeliveryAmbiguous) {
+		t.Fatalf("recovered Task Runtime Controls = %#v", recoveredTask.RuntimeControls)
+	}
+	beforeReplayEvents := len(events)
+	replay := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID+"/tasks/"+created.ID+"/steer", bytes.NewBufferString(`{
+		"request_id":"post-fence-restart",
+		"message":"Crashed after the fence."
+	}`))
+	replay.Header.Set("Content-Type", "application/json")
+	replay.Header.Set("Idempotency-Key", "post-fence-restart")
+	replayResponse := httptest.NewRecorder()
+	server2.ServeHTTP(replayResponse, replay)
+	if replayResponse.Code != http.StatusAccepted {
+		t.Fatalf("recovered Task replay status=%d body=%s", replayResponse.Code, replayResponse.Body.String())
+	}
+	var replayOutcome struct {
+		Outcome string `json:"outcome"`
+	}
+	if err := json.Unmarshal(replayResponse.Body.Bytes(), &replayOutcome); err != nil || replayOutcome.Outcome != "action_required" {
+		t.Fatalf("recovered Task replay outcome=%#v err=%v body=%s", replayOutcome, err, replayResponse.Body.String())
+	}
+	afterReplayEvents, err := server2.tasks.Events(created.ID)
+	if err != nil || len(afterReplayEvents) != beforeReplayEvents {
+		t.Fatalf("recovered Task replay events=%d err=%v, want %d", len(afterReplayEvents), err, beforeReplayEvents)
 	}
 }
 
@@ -393,7 +477,7 @@ func TestAcceptedSteeringPreFenceRestartResumesDispatchAfterResume(t *testing.T)
 
 func TestAcceptedSteeringReplayReturnsDurableOutcomeAndRejectsConflict(t *testing.T) {
 	server, projectID, created, blocked := newBlockingSteerFixture(t)
-	body := `{"request_id":"replay-1","message":"Replay the durable outcome."}`
+	body := `{"request_id":"replay-1","message":"Replay the durable outcome.","model":"gpt-test"}`
 	first := postSteerTimed(t, server, projectID, created.ID, body, time.Second)
 	if first.Code != http.StatusAccepted {
 		t.Fatalf("first steer status=%d body=%s", first.Code, first.Body.String())
@@ -425,6 +509,16 @@ func TestAcceptedSteeringReplayReturnsDurableOutcomeAndRejectsConflict(t *testin
 	}
 	if conversations != 1 {
 		t.Fatalf("replay created %d conversation items, want 1", conversations)
+	}
+
+	// Omitting an explicitly supplied client Turn Selection changes the
+	// idempotency identity even when the resolved provider selection is equal.
+	omittedSelection := postSteerTimed(t, server, projectID, created.ID, `{
+		"request_id":"replay-1",
+		"message":"Replay the durable outcome."
+	}`, time.Second)
+	if omittedSelection.Code != http.StatusConflict {
+		t.Fatalf("omitted selection replay status=%d body=%s, want 409", omittedSelection.Code, omittedSelection.Body.String())
 	}
 
 	// Conflicting content under the same request identity is a conflict.
@@ -628,6 +722,116 @@ func newSessionSteerFixture(t *testing.T) (*Server, string, *runtime.FakeProvide
 	return nil, "", nil
 }
 
+func TestAcceptedSteeringWithoutAttachmentsAdvancesSessionActivityAtomically(t *testing.T) {
+	server, err := NewServer(Config{DBPath: filepath.Join(t.TempDir(), "pentest.db"), DisableBuiltinSkills: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+	profile := createTestRuntimeProfile(t, server)
+	created, err := server.sessions.Create(session.CreateRequest{Input: "Session activity"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation, err := server.sessions.CreateContinuation(created.ID, profile.ID, string(runtimeprofile.ProviderCodex), session.RunnerHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-activity-provider", ActiveTurnID: "turn-session-activity",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InTurnSteer: true},
+	})
+	if err := server.BindSessionProviderSession(created.ID, active); err != nil {
+		t.Fatal(err)
+	}
+	releaseHarness := make(chan struct{})
+	t.Cleanup(func() { close(releaseHarness) })
+	go func() {
+		_ = server.sessionHarness.Launch(context.Background(), runtime.SessionLaunchRequest{
+			SessionID: created.ID, Goal: "Session activity", Adapter: holdAdapter{release: releaseHarness}, ContinuationID: continuation.ID,
+		})
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		events, eventsErr := server.sessions.Events(created.ID)
+		if eventsErr != nil {
+			t.Fatal(eventsErr)
+		}
+		started := false
+		for _, event := range events {
+			if event.Payload["phase"] == "hold_started" {
+				started = true
+				break
+			}
+		}
+		if started && server.sessionHarness.IsActive(created.ID) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("controlled Session Harness did not start: %#v", events)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	sessionID := created.ID
+	controlStarted := make(chan struct{})
+	releaseControl := make(chan struct{})
+	if !server.enqueueProviderTaskControl(sessionID, func(ctx context.Context) {
+		close(controlStarted)
+		select {
+		case <-releaseControl:
+		case <-ctx.Done():
+		}
+	}) {
+		t.Fatal("reserve Session provider control")
+	}
+	select {
+	case <-controlStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Session provider control did not start")
+	}
+	defer close(releaseControl)
+
+	stale := time.Date(2020, time.January, 2, 3, 4, 5, 0, time.UTC)
+	stamp := stale.Format(time.RFC3339Nano)
+	if _, err := server.db.Exec(`UPDATE sessions SET updated_at=?,last_activity_at=? WHERE id=?`, stamp, stamp, sessionID); err != nil {
+		t.Fatal(err)
+	}
+	before, err := server.sessions.Get(sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.LastActivityAt.Equal(stale) {
+		t.Fatalf("Session activity fixture = %s, want stale %s", before.LastActivityAt, stale)
+	}
+
+	steer := httptest.NewRequest(http.MethodPost, "/api/sessions/"+sessionID+"/steer", bytes.NewBufferString(`{
+		"request_id":"session-activity-1",
+		"message":"Advance Session activity before provider settlement."
+	}`))
+	steer.Header.Set("Content-Type", "application/json")
+	steer.Header.Set("Idempotency-Key", "session-activity-1")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, steer)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("Session steer status=%d body=%s", response.Code, response.Body.String())
+	}
+	record, err := server.steering.ByRequestID(owner.KindSession, sessionID, "session-activity-1")
+	if err != nil || record.State != owner.SteeringPending {
+		t.Fatalf("accepted Session steer = %#v err=%v, want pending behind provider control", record, err)
+	}
+	if requests := active.LastRequests(); len(requests) != 0 {
+		t.Fatalf("queued Session steer reached provider before activity assertion: %#v", requests)
+	}
+
+	found, err := server.sessions.Get(sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found.LastActivityAt.After(stale) {
+		t.Fatalf("Session last activity = %s, want after accepted steering at %s", found.LastActivityAt, stale)
+	}
+}
+
 func TestAcceptedSteeringSessionOwnerDispatchesDurably(t *testing.T) {
 	server, sessionID, fake := newSessionSteerFixture(t)
 
@@ -744,7 +948,7 @@ func TestAcceptedSteeringSessionPreFenceRestartResumesDispatchAfterMessage(t *te
 	server, sessionID, _ := newSessionSteerFixtureAt(t, root)
 	// A pre-fence queued request that never dispatched before the restart.
 	if _, err := server.steering.Accept(context.Background(), owner.KindSession, sessionID, steering.AcceptRequest{
-		RequestID: "session-pre-fence", Message: "Survive the Session restart.", Mode: owner.SteeringModeInTurnSteer,
+		RequestID: "session-pre-fence", Message: "Survive the Session restart.", Mode: owner.SteeringModeSendTurn,
 	}, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -927,6 +1131,39 @@ func TestAcceptedSteeringSessionPostFenceRestartBecomesActionRequiredWithoutRepl
 	}
 	if !sawActionRequired || sawApplied {
 		t.Fatalf("Session post-fence projection = action_required:%v applied:%v events=%#v", sawActionRequired, sawApplied, events)
+	}
+	detail := httptest.NewRecorder()
+	server2.ServeHTTP(detail, httptest.NewRequest(http.MethodGet, "/api/sessions/"+sessionID, nil))
+	if detail.Code != http.StatusOK {
+		t.Fatalf("recovered Session detail status=%d body=%s", detail.Code, detail.Body.String())
+	}
+	var recoveredSession session.Session
+	if err := json.Unmarshal(detail.Body.Bytes(), &recoveredSession); err != nil {
+		t.Fatal(err)
+	}
+	if recoveredSession.RuntimeControls.NativeSteerState != "action_required" ||
+		recoveredSession.RuntimeControls.NativeSteerErrorCode != string(owner.SteeringReasonDeliveryAmbiguous) {
+		t.Fatalf("recovered Session Runtime Controls = %#v", recoveredSession.RuntimeControls)
+	}
+	beforeReplayEvents := len(events)
+	replay := httptest.NewRequest(http.MethodPost, "/api/sessions/"+sessionID+"/steer", bytes.NewBufferString(`{
+		"request_id":"session-post-fence",
+		"message":"Crashed after the Session fence."
+	}`))
+	replay.Header.Set("Content-Type", "application/json")
+	replay.Header.Set("Idempotency-Key", "session-post-fence")
+	replayResponse := httptest.NewRecorder()
+	server2.ServeHTTP(replayResponse, replay)
+	if replayResponse.Code != http.StatusAccepted {
+		t.Fatalf("recovered Session replay status=%d body=%s", replayResponse.Code, replayResponse.Body.String())
+	}
+	var replayed session.Session
+	if err := json.Unmarshal(replayResponse.Body.Bytes(), &replayed); err != nil || replayed.RuntimeControls.NativeSteerState != "action_required" {
+		t.Fatalf("recovered Session replay state=%#v err=%v body=%s", replayed.RuntimeControls, err, replayResponse.Body.String())
+	}
+	afterReplayEvents, err := server2.sessions.Events(sessionID)
+	if err != nil || len(afterReplayEvents) != beforeReplayEvents {
+		t.Fatalf("recovered Session replay events=%d err=%v, want %d", len(afterReplayEvents), err, beforeReplayEvents)
 	}
 }
 

--- a/internal/daemon/assisted_conclusion_test.go
+++ b/internal/daemon/assisted_conclusion_test.go
@@ -74,7 +74,7 @@ func TestAssistedWorkTurnWithTerminalToolResultBecomesPending(t *testing.T) {
 	if found.BlackboardConclusion.Mode != task.BlackboardConclusionModeAssisted || found.BlackboardConclusion.SourceTurnID != "work-turn-1" {
 		t.Fatalf("Blackboard conclusion view = %#v", found.BlackboardConclusion)
 	}
-	if found.Status != task.StatusRunning || found.RuntimeActivity.Liveness != "live" || found.RuntimeActivity.TurnActivity != "idle" {
+	if found.Status != task.StatusRunning || found.RuntimeActivity.Liveness != "live" || found.RuntimeActivity.TurnActivity != "busy" {
 		t.Fatalf("Task lifecycle/activity changed by pending conclusion: status=%q activity=%#v", found.Status, found.RuntimeActivity)
 	}
 
@@ -243,7 +243,7 @@ func TestAssistedWorkTurnDispatchesControlTurnAndAppliesClosedResult(t *testing.
 		t.Fatalf("control directive invites forbidden file access: %q", controlRequest.Message)
 	}
 	found := waitForBlackboardConclusionState(t, server, projectID, created.ID, task.BlackboardConclusionStateConcluding)
-	if found.Status != task.StatusRunning || found.RuntimeActivity.Liveness != "live" || found.RuntimeActivity.TurnActivity != "idle" {
+	if found.Status != task.StatusRunning || found.RuntimeActivity.Liveness != "live" || found.RuntimeActivity.TurnActivity != "busy" {
 		t.Fatalf("Conclude Turn changed Task lifecycle/activity: status=%q activity=%#v", found.Status, found.RuntimeActivity)
 	}
 	receipt, err := server.tasks.LatestBlackboardConclusion(created.ID)

--- a/internal/daemon/continuation_after_blackboard_finish_test.go
+++ b/internal/daemon/continuation_after_blackboard_finish_test.go
@@ -170,6 +170,28 @@ func (s *unbindableFinishSession) BindContinuation(continuationID string) error 
 	return errors.New("binding rejected")
 }
 
+func (s *unbindableFinishSession) TurnState() runtime.ProviderSessionTurnState {
+	reporter, ok := s.ProviderSession.(runtime.ProviderSessionTurnStateReporter)
+	if !ok {
+		return runtime.ProviderSessionTurnState{SessionID: s.SessionID()}
+	}
+	return reporter.TurnState()
+}
+
+func (s *unbindableFinishSession) TurnBusy() bool {
+	return s.TurnState().TurnBusy()
+}
+
+func (s *unbindableFinishSession) EmitObservation(observation runtime.ProviderSessionObservation) error {
+	emitter, ok := s.ProviderSession.(interface {
+		EmitObservation(runtime.ProviderSessionObservation) error
+	})
+	if !ok {
+		return errors.New("provider session cannot emit observations")
+	}
+	return emitter.EmitObservation(observation)
+}
+
 func TestPostFinishSteerRaceWithBlackboardFinishSettlesToWritableContinuation(t *testing.T) {
 	session, adapter := newFinishSessionPair("post-finish-race")
 	factory := &finishSessionFactory{session: session, adapter: adapter}

--- a/internal/daemon/finish_task_resume_test.go
+++ b/internal/daemon/finish_task_resume_test.go
@@ -161,6 +161,13 @@ func (s *forceBusySession) ControlBusy() bool {
 	return s.finishBoundSession.ControlBusy()
 }
 
+func (s *forceBusySession) TurnBusy() bool {
+	if s.busy {
+		return true
+	}
+	return s.finishBoundSession.TurnBusy()
+}
+
 func newFinishTaskFixture(t *testing.T, factory ProviderSessionFactory) (*Server, task.Task, modelprovider.Provider) {
 	t.Helper()
 	return newFinishTaskFixtureAt(t, t.TempDir(), factory)
@@ -223,6 +230,27 @@ func launchFinishTask(t *testing.T, server *Server, created task.Task) {
 		t.Fatal(err)
 	}
 	waitForHarnessActive(t, server, created.ID, true)
+	bound, ok := server.providerSessions.get(created.ID)
+	if !ok {
+		t.Fatal("provider session was not bound after launch")
+	}
+	emitter, ok := bound.(interface {
+		EmitObservation(runtime.ProviderSessionObservation) error
+	})
+	if !ok {
+		t.Fatalf("finish fixture provider session %T cannot complete its initial Turn", bound)
+	}
+	state := providerSessionTurnState(bound)
+	if strings.TrimSpace(state.ActiveTurnID) == "" {
+		t.Fatal("finish fixture launch did not create an active provider Turn")
+	}
+	if err := emitter.EmitObservation(runtime.ProviderSessionObservation{
+		Kind:           runtime.ProviderSessionObservationTurnCompleted,
+		ProviderTurnID: state.ActiveTurnID,
+		Status:         "completed",
+	}); err != nil {
+		t.Fatalf("complete initial provider Turn: %v", err)
+	}
 	waitForLiveIdle(t, server, created)
 }
 

--- a/internal/daemon/native_steer_failure.go
+++ b/internal/daemon/native_steer_failure.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"pentest/internal/owner"
+	"pentest/internal/runtime"
+)
+
+// nativeSteerFailure is the single redacted failure taxonomy used by durable
+// Steering state, Timeline projection, and operator recovery controls.
+type nativeSteerFailure struct {
+	state   owner.SteeringState
+	reason  owner.SteeringFailureReason
+	code    string
+	message string
+}
+
+func classifyNativeSteerFailure(operationErr error) nativeSteerFailure {
+	switch {
+	case errors.Is(operationErr, context.DeadlineExceeded):
+		return nativeSteerFailure{owner.SteeringActionRequired, owner.SteeringReasonDeliveryAmbiguous, string(owner.SteeringReasonDeliveryAmbiguous), "native steer timed out"}
+	case errors.Is(operationErr, context.Canceled):
+		return nativeSteerFailure{owner.SteeringActionRequired, owner.SteeringReasonDeliveryAmbiguous, string(owner.SteeringReasonDeliveryAmbiguous), "native steer canceled"}
+	case errors.Is(operationErr, runtime.ErrProviderTurnUnavailable):
+		return nativeSteerFailure{owner.SteeringActionRequired, owner.SteeringReasonTargetTurnCompleted, string(owner.SteeringReasonTargetTurnCompleted), "target provider Runtime Turn completed"}
+	case errors.Is(operationErr, runtime.ErrProviderTurnChanged):
+		return nativeSteerFailure{owner.SteeringActionRequired, owner.SteeringReasonTargetTurnChanged, string(owner.SteeringReasonTargetTurnChanged), "target provider Runtime Turn changed"}
+	case errors.Is(operationErr, runtime.ErrProviderTurnNotSteerable):
+		return nativeSteerFailure{owner.SteeringActionRequired, owner.SteeringReasonActiveTurnNotSteerable, string(owner.SteeringReasonActiveTurnNotSteerable), "active provider Runtime Turn is not steerable"}
+	case errors.Is(operationErr, runtime.ErrProviderSessionClosed):
+		return nativeSteerFailure{owner.SteeringFailed, owner.SteeringReasonSessionClosed, string(owner.SteeringReasonSessionClosed), "provider session is closed"}
+	case errors.Is(operationErr, runtime.ErrProviderSessionControlConflict):
+		return nativeSteerFailure{owner.SteeringFailed, owner.SteeringReasonControlConflict, string(owner.SteeringReasonControlConflict), "provider session control conflict"}
+	case errors.Is(operationErr, runtime.ErrProviderMethodUnavailable):
+		return nativeSteerFailure{owner.SteeringFailed, owner.SteeringReasonProviderControlUnavailable, string(owner.SteeringReasonProviderControlUnavailable), "provider native steering is unavailable"}
+	}
+	raw := ""
+	if cause := errors.Unwrap(operationErr); cause != nil {
+		raw = cause.Error()
+	} else if operationErr != nil {
+		raw = operationErr.Error()
+	}
+	lower := strings.ToLower(raw)
+	if strings.Contains(lower, "effort") || strings.Contains(lower, "reasoning") {
+		return nativeSteerFailure{owner.SteeringFailed, owner.SteeringReasonUnsupportedReasoningEffort, string(owner.SteeringReasonUnsupportedReasoningEffort), "requested reasoning effort is not supported"}
+	}
+	return nativeSteerFailure{owner.SteeringFailed, owner.SteeringReasonProviderRejected, string(owner.SteeringReasonProviderRejected), "provider rejected the turn"}
+}

--- a/internal/daemon/production_provider_session_factory.go
+++ b/internal/daemon/production_provider_session_factory.go
@@ -122,6 +122,20 @@ func (s *productionBoundSession) ControlBusy() bool {
 	return false
 }
 
+func (s *productionBoundSession) TurnState() runtime.ProviderSessionTurnState {
+	if reporter, ok := s.ProviderSession.(runtime.ProviderSessionTurnStateReporter); ok {
+		return reporter.TurnState()
+	}
+	return runtime.ProviderSessionTurnState{SessionID: s.SessionID(), ControlBusy: s.ControlBusy()}
+}
+
+func (s *productionBoundSession) TurnBusy() bool {
+	if reporter, ok := s.ProviderSession.(runtime.ProviderSessionTurnBusyReporter); ok {
+		return reporter.TurnBusy()
+	}
+	return s.ControlBusy()
+}
+
 func (s *productionBoundSession) SessionClosed() bool {
 	if reporter, ok := s.ProviderSession.(interface{ SessionClosed() bool }); ok {
 		return reporter.SessionClosed()

--- a/internal/daemon/provider_session_assembler.go
+++ b/internal/daemon/provider_session_assembler.go
@@ -79,6 +79,20 @@ func manifestSessionCapabilities(registry *runtimeplugin.Registry, provider runt
 	return plugin.Capabilities, nil
 }
 
+// sendProviderSetupRPC keeps transport failures and provider JSON-RPC failures
+// separate. Bridge transports return protocol error envelopes as responses so
+// Runtime adapters can classify them, but setup handshakes must fail closed.
+func sendProviderSetupRPC(ctx context.Context, bridge productionBridgeTransport, request runtime.SandboxBridgeRequest) (runtime.SandboxBridgeResponse, error) {
+	response, err := bridge.Send(ctx, request)
+	if err != nil {
+		return runtime.SandboxBridgeResponse{}, err
+	}
+	if len(response.Error) > 0 && string(response.Error) != "null" {
+		return runtime.SandboxBridgeResponse{}, fmt.Errorf("provider setup %s returned JSON-RPC error", request.Method)
+	}
+	return response, nil
+}
+
 // openHostWithAssembler is the shared Host Runner flow: prologue, host command
 // assembly, bridge bind, family handshake, and the shared finish. Only the
 // assembler differs per family.

--- a/internal/daemon/provider_session_assembler_claude.go
+++ b/internal/daemon/provider_session_assembler_claude.go
@@ -67,7 +67,7 @@ func (a claudeAssembler) SandboxCommand(assembly providerSessionAssembly) ([]str
 }
 
 func (a claudeAssembler) Setup(ctx context.Context, bridge productionBridgeTransport, assembly providerSessionAssembly) (providerSessionSetup, error) {
-	setupResponse, err := bridge.Send(ctx, runtime.SandboxBridgeRequest{ID: "setup:initialize", Method: "claude/initialize", Params: json.RawMessage(`{}`)})
+	setupResponse, err := sendProviderSetupRPC(ctx, bridge, runtime.SandboxBridgeRequest{ID: "setup:initialize", Method: "claude/initialize", Params: json.RawMessage(`{}`)})
 	if err != nil {
 		return providerSessionSetup{}, err
 	}

--- a/internal/daemon/provider_session_assembler_codex.go
+++ b/internal/daemon/provider_session_assembler_codex.go
@@ -38,7 +38,8 @@ func (a codexAssembler) SandboxCommand(assembly providerSessionAssembly) ([]stri
 }
 
 func (a codexAssembler) Setup(ctx context.Context, bridge productionBridgeTransport, assembly providerSessionAssembly) (providerSessionSetup, error) {
-	if _, err := bridge.Send(ctx, runtime.SandboxBridgeRequest{ID: "setup:initialize", Method: "initialize", Params: json.RawMessage(`{"clientInfo":{"name":"cyberpenda","version":"dev"}}`)}); err != nil {
+	_, err := sendProviderSetupRPC(ctx, bridge, runtime.SandboxBridgeRequest{ID: "setup:initialize", Method: "initialize", Params: json.RawMessage(`{"clientInfo":{"name":"cyberpenda","version":"dev"}}`)})
+	if err != nil {
 		return providerSessionSetup{}, err
 	}
 	cwd := assembly.facts().Workdir
@@ -46,7 +47,7 @@ func (a codexAssembler) Setup(ctx context.Context, bridge productionBridgeTransp
 	if durableThreadID := strings.TrimSpace(assembly.request.Continuation.NativeSessionID); durableThreadID != "" {
 		setupMethod, setupID, setupParams = "thread/resume", "setup:thread-resume", codexThreadSetupParams(cwd, durableThreadID)
 	}
-	setupResponse, err := bridge.Send(ctx, runtime.SandboxBridgeRequest{ID: setupID, Method: setupMethod, Params: setupParams})
+	setupResponse, err := sendProviderSetupRPC(ctx, bridge, runtime.SandboxBridgeRequest{ID: setupID, Method: setupMethod, Params: setupParams})
 	if err != nil {
 		return providerSessionSetup{}, err
 	}
@@ -77,6 +78,10 @@ func (a codexAssembler) Setup(ctx context.Context, bridge productionBridgeTransp
 	// assisted conclusion, which the manifest must not claim for production
 	// providers before it is proven.
 	capabilities.AssistedConclusion = true
+	// InitializeResponse exposes server identity, not a server capability set.
+	// Keep the manifest capability until the wire call negotiates support. A
+	// JSON-RPC method-not-found response downgrades this adapter and safely
+	// falls back to interrupt_then_replace.
 	return providerSessionSetup{
 		Session: runtime.NewCodexProviderSession(runtime.CodexProviderSessionConfig{
 			Transport: bridge, SessionID: threadID, Capabilities: capabilities,

--- a/internal/daemon/provider_session_assembler_hermes.go
+++ b/internal/daemon/provider_session_assembler_hermes.go
@@ -38,7 +38,7 @@ func (a hermesAssembler) SandboxCommand(assembly providerSessionAssembly) ([]str
 
 func (a hermesAssembler) Setup(ctx context.Context, bridge productionBridgeTransport, assembly providerSessionAssembly) (providerSessionSetup, error) {
 	// Hermes ACP InitializeRequest requires integer protocolVersion.
-	if _, err := bridge.Send(ctx, runtime.SandboxBridgeRequest{
+	if _, err := sendProviderSetupRPC(ctx, bridge, runtime.SandboxBridgeRequest{
 		ID: "setup:initialize", Method: "initialize",
 		Params: json.RawMessage(`{"protocolVersion":1,"clientInfo":{"name":"cyberpenda","version":"1"}}`),
 	}); err != nil {
@@ -58,7 +58,7 @@ func (a hermesAssembler) Setup(ctx context.Context, bridge productionBridgeTrans
 			return providerSessionSetup{}, err
 		}
 	}
-	setupResponse, err := bridge.Send(ctx, runtime.SandboxBridgeRequest{ID: "setup:session", Method: method, Params: params})
+	setupResponse, err := sendProviderSetupRPC(ctx, bridge, runtime.SandboxBridgeRequest{ID: "setup:session", Method: method, Params: params})
 	if err != nil {
 		return providerSessionSetup{}, err
 	}

--- a/internal/daemon/provider_session_assembler_pi.go
+++ b/internal/daemon/provider_session_assembler_pi.go
@@ -76,7 +76,7 @@ func (a piAssembler) SandboxCommand(assembly providerSessionAssembly) ([]string,
 }
 
 func (a piAssembler) Setup(ctx context.Context, bridge productionBridgeTransport, assembly providerSessionAssembly) (providerSessionSetup, error) {
-	setupResponse, err := bridge.Send(ctx, runtime.SandboxBridgeRequest{ID: "setup:state", Method: "pi/get_state", Params: json.RawMessage(`{}`)})
+	setupResponse, err := sendProviderSetupRPC(ctx, bridge, runtime.SandboxBridgeRequest{ID: "setup:state", Method: "pi/get_state", Params: json.RawMessage(`{}`)})
 	if err != nil {
 		return providerSessionSetup{}, err
 	}

--- a/internal/daemon/provider_session_assembler_test.go
+++ b/internal/daemon/provider_session_assembler_test.go
@@ -40,6 +40,67 @@ func serveFactoryProtocol(t *testing.T, input *io.PipeReader, output *io.PipeWri
 	}()
 }
 
+type setupRPCErrorBridge struct {
+	method     string
+	mu         sync.Mutex
+	calls      []string
+	closed     chan struct{}
+	terminated chan struct{}
+}
+
+func (b *setupRPCErrorBridge) Send(_ context.Context, request runtime.SandboxBridgeRequest) (runtime.SandboxBridgeResponse, error) {
+	b.mu.Lock()
+	b.calls = append(b.calls, request.Method)
+	b.mu.Unlock()
+	if request.Method == b.method {
+		return runtime.SandboxBridgeResponse{ID: request.ID, Error: json.RawMessage(`{"code":-32000,"message":"private provider setup detail"}`)}, nil
+	}
+	return runtime.SandboxBridgeResponse{ID: request.ID, Result: json.RawMessage(`{}`)}, nil
+}
+
+func (b *setupRPCErrorBridge) Close(context.Context) error { return nil }
+func (b *setupRPCErrorBridge) Closed() <-chan struct{}     { return b.closed }
+func (b *setupRPCErrorBridge) Terminated() <-chan struct{} { return b.terminated }
+
+func (b *setupRPCErrorBridge) callCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.calls)
+}
+
+func TestProviderSessionAssemblersRejectJSONRPCSetupErrors(t *testing.T) {
+	registry := runtimeplugin.MustBuiltinRegistry()
+	tests := []struct {
+		name      string
+		provider  runtimeprofile.Provider
+		method    string
+		assembler providerSessionAssembler
+	}{
+		{name: "codex initialize", provider: runtimeprofile.ProviderCodex, method: "initialize", assembler: codexAssembler{plugins: registry, bridge: "bridge"}},
+		{name: "claude initialize", provider: runtimeprofile.ProviderClaudeCode, method: "claude/initialize", assembler: claudeAssembler{plugins: registry}},
+		{name: "pi state", provider: runtimeprofile.ProviderPi, method: "pi/get_state", assembler: piAssembler{plugins: registry}},
+		{name: "hermes initialize", provider: runtimeprofile.ProviderHermes, method: "initialize", assembler: hermesAssembler{plugins: registry}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bridge := &setupRPCErrorBridge{method: test.method, closed: make(chan struct{}), terminated: make(chan struct{})}
+			_, err := test.assembler.Setup(context.Background(), bridge, providerSessionAssembly{request: ProviderSessionLaunchRequest{
+				Provider: test.provider, Continuation: owner.Continuation{ID: "continuation-1", OwnerID: "owner-1"},
+				Facts: ProviderSessionLaunchFacts{Workdir: "/work"},
+			}})
+			if err == nil || !strings.Contains(err.Error(), "JSON-RPC") {
+				t.Fatalf("setup error = %v, want bounded JSON-RPC failure", err)
+			}
+			if bridge.callCount() != 1 {
+				t.Fatalf("setup calls = %d, want fail closed on first RPC error", bridge.callCount())
+			}
+			if strings.Contains(err.Error(), "private provider setup detail") {
+				t.Fatalf("setup error leaked provider detail: %v", err)
+			}
+		})
+	}
+}
+
 func TestProviderSessionAssemblerSandboxConformance(t *testing.T) {
 	claudeFullHandshake := `{"session_id":"conf-claude","status":"ready","capabilities":{"persistent_session":true,"send_turn":true,"interrupt_turn":true,"normalized_tool_events":true,"normalized_turn_events":true,"attempt_result":true,"assisted_conclusion":true}}`
 	cases := []struct {
@@ -52,13 +113,16 @@ func TestProviderSessionAssemblerSandboxConformance(t *testing.T) {
 		{
 			provider: runtimeprofile.ProviderCodex,
 			respond: func(method string, _ json.RawMessage) string {
-				if method == "thread/start" {
+				switch method {
+				case "initialize":
+					return `{"userAgent":"codex_cli_rs/0.149.0"}`
+				case "thread/start":
 					return `{"thread":{"id":"conf-codex"}}`
 				}
 				return ""
 			},
 			wantBridge:    []string{"sandbox:test", "/usr/local/bin/pentest-provider-bridge", "--provider", "codex", "--", "codex", "app-server"},
-			wantSessionID: "conf-codex",
+			wantSessionID: "conf-codex", wantInTurnSteer: true,
 		},
 		{
 			provider: runtimeprofile.ProviderClaudeCode,
@@ -281,5 +345,64 @@ func TestProviderSessionAssemblerFakeDrivesSharedFinish(t *testing.T) {
 	fake.mu.Unlock()
 	if teardowns != 1 {
 		t.Fatalf("family teardown runs = %d, want 1 after close", teardowns)
+	}
+}
+
+type codexSetupTestBridge struct {
+	initialize json.RawMessage
+	closed     chan struct{}
+	terminated chan struct{}
+}
+
+func (b *codexSetupTestBridge) Send(_ context.Context, request runtime.SandboxBridgeRequest) (runtime.SandboxBridgeResponse, error) {
+	switch request.Method {
+	case "initialize":
+		return runtime.SandboxBridgeResponse{ID: request.ID, Result: b.initialize}, nil
+	case "thread/start":
+		return runtime.SandboxBridgeResponse{ID: request.ID, Result: json.RawMessage(`{"thread":{"id":"thread-version"}}`)}, nil
+	default:
+		return runtime.SandboxBridgeResponse{ID: request.ID, Result: json.RawMessage(`{}`)}, nil
+	}
+}
+
+func (b *codexSetupTestBridge) Close(context.Context) error { return nil }
+func (b *codexSetupTestBridge) Closed() <-chan struct{}     { return b.closed }
+func (b *codexSetupTestBridge) Terminated() <-chan struct{} { return b.terminated }
+
+func TestCodexAssemblerAdvertisesManifestSteerUntilWireNegotiation(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		initialize string
+		wantSteer  bool
+	}{
+		{name: "current version", initialize: `{"userAgent":"codex_cli_rs/0.149.0"}`, wantSteer: true},
+		{name: "older version", initialize: `{"userAgent":"codex_cli_rs/0.148.9"}`, wantSteer: true},
+		{name: "unknown version", initialize: `{"userAgent":"codex app-server"}`, wantSteer: true},
+		{name: "future response shape", initialize: `{}`, wantSteer: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			registry := runtimeplugin.MustBuiltinRegistry()
+			bridge := &codexSetupTestBridge{
+				initialize: json.RawMessage(test.initialize),
+				closed:     make(chan struct{}), terminated: make(chan struct{}),
+			}
+			setup, err := (codexAssembler{plugins: registry, bridge: "bridge"}).Setup(context.Background(), bridge, providerSessionAssembly{
+				request: ProviderSessionLaunchRequest{
+					Provider:     runtimeprofile.ProviderCodex,
+					Continuation: owner.Continuation{ID: "continuation-1", OwnerID: "task-1"},
+					Facts:        ProviderSessionLaunchFacts{Workdir: "/work"},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			capabilities := setup.Session.Capabilities()
+			if capabilities.InTurnSteer != test.wantSteer {
+				t.Fatalf("InTurnSteer = %v, want %v", capabilities.InTurnSteer, test.wantSteer)
+			}
+			if !capabilities.InterruptThenReplace {
+				t.Fatal("wire negotiation removed interrupt_then_replace fallback")
+			}
+		})
 	}
 }

--- a/internal/daemon/provider_session_assisted_delegation_test.go
+++ b/internal/daemon/provider_session_assisted_delegation_test.go
@@ -1,12 +1,27 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeplugin"
 )
+
+func TestProductionBoundSessionForwardsTurnBusy(t *testing.T) {
+	inner := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID:    "busy-session",
+		Capabilities: runtimeplugin.Capabilities{SendTurn: true},
+	})
+	base := &productionBoundSession{ProviderSession: inner}
+	if _, err := inner.SendTurn(context.Background(), runtime.ProviderSessionRequest{RequestID: "send-busy", Message: "inspect"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !base.TurnBusy() {
+		t.Fatal("production wrapper hid the active provider Runtime Turn")
+	}
+}
 
 type incompleteAssistedDelegationSession struct {
 	runtime.ProviderSession

--- a/internal/daemon/provider_session_control.go
+++ b/internal/daemon/provider_session_control.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"pentest/internal/runtime"
-	"pentest/internal/runtimeplugin"
+	"pentest/internal/runtimeprofile"
 	"pentest/internal/session"
 	"pentest/internal/task"
 )
@@ -366,9 +366,10 @@ func (server *Server) closeProviderSessionForStop(ctx context.Context, taskID st
 }
 
 type nativeSteerRequest struct {
-	RequestID string `json:"request_id"`
-	Message   string `json:"message"`
-	Directive string `json:"directive"` // backwards-compatible alias
+	RequestID    string `json:"request_id"`
+	Message      string `json:"message"`
+	Directive    string `json:"directive"` // backwards-compatible alias
+	ForceReplace bool   `json:"force_replace,omitempty"`
 	taskContinuationSelectionInput
 }
 
@@ -380,39 +381,101 @@ func newNativeSteerRequestID() string {
 	return "steer-" + hex.EncodeToString(raw[:])
 }
 
-func nativeSteerMode(capabilities runtimeplugin.Capabilities) (runtime.ProviderSessionMode, error) {
-	if !capabilities.PersistentSession || !capabilities.SendTurn {
-		return "", &runtime.UnsupportedProviderSessionCapabilityError{Capability: runtime.ProviderSessionCapabilityPersistentSession}
+func providerSessionTurnState(session runtime.ProviderSession) runtime.ProviderSessionTurnState {
+	if reporter, ok := session.(runtime.ProviderSessionTurnStateReporter); ok {
+		return reporter.TurnState()
 	}
-	if capabilities.InTurnSteer {
-		return runtime.ProviderSessionModeInTurnSteer, nil
+	state := runtime.ProviderSessionTurnState{SessionID: session.SessionID()}
+	if reporter, ok := session.(interface{ ControlBusy() bool }); ok {
+		state.ControlBusy = reporter.ControlBusy()
 	}
-	if capabilities.InterruptThenReplace {
-		return runtime.ProviderSessionModeInterruptThenReplace, nil
-	}
-	return "", &runtime.UnsupportedProviderSessionCapabilityError{Capability: runtime.ProviderSessionCapabilityInterruptThenReplace}
+	return state
 }
 
-func nativeSteerState(events []task.Event, requestID string) (mode runtime.ProviderSessionMode, outcome string, sessionID string) {
-	for _, event := range events {
-		if event.Payload["request_id"] != requestID {
-			continue
+func sameProviderTurnSelection(left, right runtime.ProviderSessionRequest) bool {
+	return strings.TrimSpace(left.ModelProviderID) == strings.TrimSpace(right.ModelProviderID) &&
+		strings.TrimSpace(left.Model) == strings.TrimSpace(right.Model) &&
+		strings.TrimSpace(left.RequestedReasoningEffort) == strings.TrimSpace(right.RequestedReasoningEffort)
+}
+
+func providerSelectionRequiresReplacement(provider runtimeprofile.Provider, current, requested runtime.ProviderSessionRequest) bool {
+	if sameProviderTurnSelection(current, requested) {
+		return false
+	}
+	// Codex and Pi apply Runtime Turn Selection only when a new Turn starts.
+	// Pi uses set_model and set_thinking_level immediately before pi/prompt;
+	// pi/steer cannot apply those fields to the active Turn.
+	return provider == runtimeprofile.ProviderCodex || provider == runtimeprofile.ProviderPi
+}
+
+type nativeSteerPreparation struct {
+	Mode                   runtime.ProviderSessionMode
+	ExpectedProviderTurnID string
+}
+
+// prepareNativeSteer chooses the provider operation and its durable target
+// fence from one TurnState snapshot. Task and Session handlers must not read
+// TurnState again while accepting the same Steering request.
+func prepareAcceptedNativeSteer(ctx context.Context, session runtime.ProviderSession, selectionChanged, forceReplace bool, settlement providerControlSettlement) (nativeSteerPreparation, error) {
+	if settlement != nil {
+		settled, err := settlement(ctx, false)
+		if err != nil {
+			return nativeSteerPreparation{}, err
 		}
-		if value, ok := event.Payload["mode"].(string); ok {
-			mode = runtime.ProviderSessionMode(value)
-		}
-		if value, ok := event.Payload["outcome"].(string); ok {
-			outcome = value
-		}
-		if value, ok := event.Payload["session_id"].(string); ok {
-			sessionID = value
+		if !settled {
+			capabilities := session.Capabilities()
+			if !capabilities.PersistentSession || !capabilities.SendTurn {
+				return nativeSteerPreparation{}, &runtime.UnsupportedProviderSessionCapabilityError{Capability: runtime.ProviderSessionCapabilityPersistentSession}
+			}
+			// The accepted request cannot target the current Turn because the
+			// owner settlement gate will complete that Turn before dispatch.
+			// Start one Work Turn after the gate instead of steering or
+			// interrupting the Harness Control Turn.
+			return nativeSteerPreparation{Mode: runtime.ProviderSessionModeSendTurn}, nil
 		}
 	}
-	return mode, outcome, sessionID
+	return prepareNativeSteer(session, selectionChanged, forceReplace)
+}
+
+func prepareNativeSteer(session runtime.ProviderSession, selectionChanged, forceReplace bool) (nativeSteerPreparation, error) {
+	capabilities := session.Capabilities()
+	if !capabilities.PersistentSession || !capabilities.SendTurn {
+		return nativeSteerPreparation{}, &runtime.UnsupportedProviderSessionCapabilityError{Capability: runtime.ProviderSessionCapabilityPersistentSession}
+	}
+	state := providerSessionTurnState(session)
+	activeTurnID := strings.TrimSpace(state.ActiveTurnID)
+	if activeTurnID == "" {
+		return nativeSteerPreparation{Mode: runtime.ProviderSessionModeSendTurn}, nil
+	}
+	if forceReplace || selectionChanged || state.ActiveTurnKind != runtime.RuntimeTurnKindWork {
+		if !capabilities.InterruptThenReplace {
+			if state.ActiveTurnKind != runtime.RuntimeTurnKindWork {
+				return nativeSteerPreparation{}, &runtime.ProviderSessionOperationError{
+					Mode: runtime.ProviderSessionModeInTurnSteer, Cause: runtime.ErrProviderTurnNotSteerable,
+				}
+			}
+			return nativeSteerPreparation{}, &runtime.UnsupportedProviderSessionCapabilityError{Capability: runtime.ProviderSessionCapabilityInterruptThenReplace}
+		}
+		return nativeSteerPreparation{Mode: runtime.ProviderSessionModeInterruptThenReplace, ExpectedProviderTurnID: activeTurnID}, nil
+	}
+	if capabilities.InTurnSteer {
+		return nativeSteerPreparation{Mode: runtime.ProviderSessionModeInTurnSteer, ExpectedProviderTurnID: activeTurnID}, nil
+	}
+	if capabilities.InterruptThenReplace {
+		return nativeSteerPreparation{Mode: runtime.ProviderSessionModeInterruptThenReplace, ExpectedProviderTurnID: activeTurnID}, nil
+	}
+	return nativeSteerPreparation{}, &runtime.UnsupportedProviderSessionCapabilityError{Capability: runtime.ProviderSessionCapabilityInTurnSteer}
+}
+
+func nativeSteerModeForSession(session runtime.ProviderSession, selectionChanged bool) (runtime.ProviderSessionMode, error) {
+	prepared, err := prepareNativeSteer(session, selectionChanged, false)
+	return prepared.Mode, err
 }
 
 func nativeSteerOperation(session runtime.ProviderSession, mode runtime.ProviderSessionMode) func(context.Context, runtime.ProviderSessionRequest, runtime.ProviderSessionEmit) (runtime.ProviderSessionResult, error) {
 	switch mode {
+	case runtime.ProviderSessionModeSendTurn:
+		return session.SendTurn
 	case runtime.ProviderSessionModeInTurnSteer:
 		return session.SteerInTurn
 	case runtime.ProviderSessionModeInterruptThenReplace:

--- a/internal/daemon/provider_session_control_test.go
+++ b/internal/daemon/provider_session_control_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 
 	"pentest/internal/blackboardv2"
 	"pentest/internal/modelprovider"
+	"pentest/internal/owner"
 	"pentest/internal/project"
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeplugin"
@@ -23,6 +25,13 @@ import (
 
 type failingContinuationBindSession struct {
 	runtime.ProviderSession
+}
+
+func (s failingContinuationBindSession) TurnState() runtime.ProviderSessionTurnState {
+	if reporter, ok := s.ProviderSession.(runtime.ProviderSessionTurnStateReporter); ok {
+		return reporter.TurnState()
+	}
+	return runtime.ProviderSessionTurnState{SessionID: s.SessionID()}
 }
 
 type stopRaceProviderSession struct {
@@ -441,6 +450,7 @@ func TestNativeSteerProviderFailureIsAcceptedThenProjectedAsFailed(t *testing.T)
 	}
 	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
 		SessionID:    "session-fail",
+		ActiveTurnID: "turn-fail",
 		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InTurnSteer: true},
 		Failures:     map[runtime.ProviderSessionMode]error{runtime.ProviderSessionModeInTurnSteer: errors.New("rejected")},
 	})
@@ -463,6 +473,70 @@ func TestNativeSteerProviderFailureIsAcceptedThenProjectedAsFailed(t *testing.T)
 		}
 		return false
 	})
+}
+
+func TestNativeSteerNonSteerableTurnRequiresExplicitOperatorRecovery(t *testing.T) {
+	server, err := NewServer(Config{DBPath: filepath.Join(t.TempDir(), "pentest.db"), DisableBuiltinSkills: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	projectRecord, err := server.projects.Create("Project", "", project.Scope{}, project.Defaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := createTestRuntimeProfile(t, server)
+	created, err := server.tasks.Create(task.CreateRequest{ProjectID: projectRecord.ID, Type: task.TypePentest, Goal: "inspect target", RuntimeProfileID: profile.ID, Runner: task.RunnerSandbox})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.tasks.UpdateStatus(created.ID, task.StatusRunning); err != nil {
+		t.Fatal(err)
+	}
+	provider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-review", ActiveTurnID: "turn-review",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InterruptThenReplace: true, InTurnSteer: true},
+		Failures:     map[runtime.ProviderSessionMode]error{runtime.ProviderSessionModeInTurnSteer: runtime.ErrProviderTurnNotSteerable},
+	})
+	if err := server.BindProviderSession(created.ID, provider); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectRecord.ID+"/tasks/"+created.ID+"/steer", bytes.NewBufferString(`{"request_id":"review-steer","message":"focus"}`))
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body=%s", response.Code, response.Body.String())
+	}
+	waitForTaskEvent(t, server, created.ID, func(events []task.Event) bool {
+		for _, event := range events {
+			if event.Kind == task.EventKindSteering && event.Payload["request_id"] == "review-steer" &&
+				event.Payload["outcome"] == "action_required" && event.Payload["error_code"] == "active_turn_not_steerable" {
+				if event.Payload["error"] != "active provider Runtime Turn is not steerable" {
+					t.Fatalf("public error = %#v", event.Payload["error"])
+				}
+				return true
+			}
+		}
+		return false
+	})
+	if requests := provider.LastRequests(); len(requests) != 1 {
+		t.Fatalf("provider requests = %#v, want no automatic interrupt fallback", requests)
+	}
+	detailRequest := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectRecord.ID+"/tasks/"+created.ID, nil)
+	detailResponse := httptest.NewRecorder()
+	server.ServeHTTP(detailResponse, detailRequest)
+	if detailResponse.Code != http.StatusOK {
+		t.Fatalf("detail status = %d, body=%s", detailResponse.Code, detailResponse.Body.String())
+	}
+	var detailed task.Task
+	if err := json.Unmarshal(detailResponse.Body.Bytes(), &detailed); err != nil {
+		t.Fatal(err)
+	}
+	if detailed.RuntimeControls.NativeSteerState != "action_required" ||
+		detailed.RuntimeControls.NativeSteerErrorCode != "active_turn_not_steerable" ||
+		detailed.RuntimeControls.NativeSteerError != "active provider Runtime Turn is not steerable" {
+		t.Fatalf("Runtime Controls = %#v", detailed.RuntimeControls)
+	}
 }
 
 func TestNativeSteerReplacementContinuationFailureFailsClosedWithoutApplied(t *testing.T) {
@@ -572,7 +646,7 @@ func TestTaskDetailExposesNativeSteerModeAndIdleState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !detailed.RuntimeControls.NativeSteerAvailable || detailed.RuntimeControls.NativeSteerMode != string(runtime.ProviderSessionModeInTurnSteer) || detailed.RuntimeControls.NativeSteerState != "idle" {
+	if !detailed.RuntimeControls.NativeSteerAvailable || detailed.RuntimeControls.NativeSteerMode != string(runtime.ProviderSessionModeSendTurn) || detailed.RuntimeControls.NativeSteerState != "idle" {
 		t.Fatalf("native steer controls = %#v", detailed.RuntimeControls)
 	}
 }
@@ -1058,5 +1132,148 @@ func TestNativeSteerReplacementCarriesBlackboardGrant(t *testing.T) {
 	}
 	if oldAfter.Status != task.StatusCompleted {
 		t.Fatalf("old Continuation status = %q, want completed", oldAfter.Status)
+	}
+}
+
+type countingTurnStateSession struct {
+	runtime.ProviderSession
+	calls int
+	state runtime.ProviderSessionTurnState
+}
+
+func (session *countingTurnStateSession) TurnState() runtime.ProviderSessionTurnState {
+	session.calls++
+	return session.state
+}
+
+func TestPrepareNativeSteerUsesOneTurnSnapshotForModeAndFence(t *testing.T) {
+	base := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-atomic",
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, InTurnSteer: true, InterruptThenReplace: true,
+		},
+	})
+	session := &countingTurnStateSession{
+		ProviderSession: base,
+		state: runtime.ProviderSessionTurnState{
+			SessionID: "session-atomic", ActiveTurnID: "turn-atomic", ActiveTurnKind: runtime.RuntimeTurnKindWork,
+		},
+	}
+
+	prepared, err := prepareNativeSteer(session, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.calls != 1 {
+		t.Fatalf("TurnState calls = %d, want 1", session.calls)
+	}
+	if prepared.Mode != runtime.ProviderSessionModeInTurnSteer || prepared.ExpectedProviderTurnID != "turn-atomic" {
+		t.Fatalf("prepared steer = %#v", prepared)
+	}
+}
+
+func TestPrepareNativeSteerReplacesNonWorkActiveTurn(t *testing.T) {
+	base := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-control",
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, InTurnSteer: true, InterruptThenReplace: true,
+		},
+	})
+	session := &countingTurnStateSession{
+		ProviderSession: base,
+		state: runtime.ProviderSessionTurnState{
+			SessionID: "session-control", ActiveTurnID: "turn-control", ActiveTurnKind: runtime.RuntimeTurnKindControl,
+		},
+	}
+	prepared, err := prepareNativeSteer(session, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Mode != runtime.ProviderSessionModeInterruptThenReplace || prepared.ExpectedProviderTurnID != "turn-control" {
+		t.Fatalf("prepared control-Turn steer = %#v", prepared)
+	}
+}
+
+func TestPrepareAcceptedNativeSteerStartsAfterPendingOwnerSettlement(t *testing.T) {
+	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-concluding", ActiveTurnID: "turn-conclusion", ActiveTurnKind: runtime.RuntimeTurnKindControl,
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, InTurnSteer: true,
+		},
+	})
+	settlement := func(context.Context, bool) (bool, error) { return false, nil }
+
+	prepared, err := prepareAcceptedNativeSteer(context.Background(), session, false, false, settlement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Mode != runtime.ProviderSessionModeSendTurn || prepared.ExpectedProviderTurnID != "" {
+		t.Fatalf("prepared deferred steer = %#v", prepared)
+	}
+}
+
+func TestPrepareNativeSteerCanExplicitlyReplaceActiveTurn(t *testing.T) {
+	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-replace", ActiveTurnID: "turn-old",
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, InTurnSteer: true, InterruptThenReplace: true,
+		},
+	})
+	prepared, err := prepareNativeSteer(session, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Mode != runtime.ProviderSessionModeInterruptThenReplace || prepared.ExpectedProviderTurnID != "turn-old" {
+		t.Fatalf("prepared steer = %#v", prepared)
+	}
+}
+
+func TestClassifyNativeSteerFailureDistinguishesCompletedTarget(t *testing.T) {
+	completed := classifyNativeSteerFailure(runtime.ErrProviderTurnUnavailable)
+	if completed.state != owner.SteeringActionRequired || completed.reason != owner.SteeringReasonTargetTurnCompleted || completed.code != "target_turn_completed" {
+		t.Fatalf("completed classification = %#v", completed)
+	}
+	changed := classifyNativeSteerFailure(runtime.ErrProviderTurnChanged)
+	if changed.state != owner.SteeringActionRequired || changed.reason != owner.SteeringReasonTargetTurnChanged || changed.code != "target_turn_changed" {
+		t.Fatalf("changed classification = %#v", changed)
+	}
+}
+
+func TestSteeringConflictUsesExactClientControlledSelectionIdentity(t *testing.T) {
+	recordedSelection := canonicalSteeringClientSelectionIdentity("provider-1", "model-1", "high")
+	record := &owner.SteeringRecord{
+		OperatorMessage: "focus", Message: "focus", Mode: owner.SteeringModeInTurnSteer, State: owner.SteeringPending,
+		ExpectedProviderTurnID: "turn-1", ModelProviderID: "provider-1", Model: "model-1",
+		RequestedReasoningEffort: "high", ClientSelectionIdentity: recordedSelection,
+	}
+	identity := steeringReplayIdentity{
+		requestID: "req-1", operatorMessage: "focus", clientSelectionIdentity: recordedSelection,
+	}
+	if conflict := steeringConflictMessage(record, identity); conflict != "" {
+		t.Fatalf("server-selected delivery fields caused conflict = %q", conflict)
+	}
+
+	identity.clientSelectionIdentity = canonicalSteeringClientSelectionIdentity("", "", "")
+	if conflict := steeringConflictMessage(record, identity); conflict != "steer request id already belongs to a different turn selection" {
+		t.Fatalf("omitted retry selection conflict = %q", conflict)
+	}
+
+	identity.clientSelectionIdentity = canonicalSteeringClientSelectionIdentity("provider-2", "model-1", "high")
+	if conflict := steeringConflictMessage(record, identity); conflict != "steer request id already belongs to a different turn selection" {
+		t.Fatalf("changed client selection conflict = %q", conflict)
+	}
+}
+
+func TestSteeringConflictKeepsLegacySelectionFallback(t *testing.T) {
+	record := &owner.SteeringRecord{
+		OperatorMessage: "focus", Message: "focus", ModelProviderID: "provider-1",
+	}
+	identity := steeringReplayIdentity{requestID: "req-1", operatorMessage: "focus"}
+	if conflict := steeringConflictMessage(record, identity); conflict != "" {
+		t.Fatalf("legacy omitted selection conflict = %q", conflict)
+	}
+	identity.modelProviderID = "provider-2"
+	if conflict := steeringConflictMessage(record, identity); conflict != "steer request id already belongs to a different turn selection" {
+		t.Fatalf("legacy changed selection conflict = %q", conflict)
 	}
 }

--- a/internal/daemon/runtime_activity.go
+++ b/internal/daemon/runtime_activity.go
@@ -365,6 +365,9 @@ func durableTaskActive(status task.Status) bool {
 }
 
 func sessionBusy(session runtime.ProviderSession) bool {
+	if reporter, ok := session.(runtime.ProviderSessionTurnBusyReporter); ok {
+		return reporter.TurnBusy()
+	}
 	if reporter, ok := session.(interface{ ControlBusy() bool }); ok {
 		return reporter.ControlBusy()
 	}

--- a/internal/daemon/runtime_activity_test.go
+++ b/internal/daemon/runtime_activity_test.go
@@ -170,7 +170,8 @@ func TestRuntimeActivityLiveIdleAndBusyForSandboxProviders(t *testing.T) {
 			server, created, mp := newRuntimeActivityFixture(t, provider, task.RunnerSandbox, factory)
 			launchActivityTask(t, server, created)
 
-			// After launch turn settles, health is live/idle independent of Task status.
+			// The launch RPC can settle before the provider Runtime Turn. Activity
+			// must remain live/busy until the matching provider terminal observation.
 			// Wait for status to leave pending — harness mark-running can lag under
 			// package-parallel load (CI: status=pending for Pi).
 			deadline := time.Now().Add(5 * time.Second)
@@ -179,7 +180,7 @@ func TestRuntimeActivityLiveIdleAndBusyForSandboxProviders(t *testing.T) {
 				body = getTaskActivity(t, server, created.ProjectID, created.ID)
 				if body.Status == "running" &&
 					body.RuntimeActivity.Liveness == "live" &&
-					body.RuntimeActivity.TurnActivity == "idle" {
+					body.RuntimeActivity.TurnActivity == "busy" {
 					break
 				}
 				time.Sleep(10 * time.Millisecond)
@@ -187,8 +188,25 @@ func TestRuntimeActivityLiveIdleAndBusyForSandboxProviders(t *testing.T) {
 			if body.Status != "running" {
 				t.Fatalf("status = %q, want running (independent of activity)", body.Status)
 			}
-			if body.RuntimeActivity.Liveness != "live" || body.RuntimeActivity.TurnActivity != "idle" {
+			if body.RuntimeActivity.Liveness != "live" || body.RuntimeActivity.TurnActivity != "busy" {
 				t.Fatalf("activity after launch = %#v", body.RuntimeActivity)
+			}
+			if err := session.EmitObservation(runtime.ProviderSessionObservation{
+				Kind:   runtime.ProviderSessionObservationTurnCompleted,
+				Status: "completed",
+			}); err != nil {
+				t.Fatalf("complete launch Runtime Turn: %v", err)
+			}
+			deadline = time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				body = getTaskActivity(t, server, created.ProjectID, created.ID)
+				if body.RuntimeActivity.TurnActivity == "idle" {
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if body.RuntimeActivity.Liveness != "live" || body.RuntimeActivity.TurnActivity != "idle" {
+				t.Fatalf("activity after launch terminal = %#v", body.RuntimeActivity)
 			}
 
 			model := "gpt-test"
@@ -204,21 +222,24 @@ func TestRuntimeActivityLiveIdleAndBusyForSandboxProviders(t *testing.T) {
 				t.Fatalf("steer status = %d body %s", resp.Code, resp.Body.String())
 			}
 
-			// Manual-ack native steer keeps ControlBusy true until acknowledged.
+			// An idle provider session uses send_turn. The RPC can settle immediately,
+			// but Activity must remain busy while its provider Turn is active.
 			deadline = time.Now().Add(2 * time.Second)
 			for time.Now().Before(deadline) {
 				body = getTaskActivity(t, server, created.ProjectID, created.ID)
-				if body.RuntimeActivity.Liveness == "live" && body.RuntimeActivity.TurnActivity == "busy" {
+				if body.RuntimeActivity.Liveness == "live" && body.RuntimeActivity.TurnActivity == "busy" && !session.ControlBusy() {
 					break
 				}
 				time.Sleep(10 * time.Millisecond)
 			}
-			if body.RuntimeActivity.Liveness != "live" || body.RuntimeActivity.TurnActivity != "busy" {
-				t.Fatalf("activity during steer = %#v", body.RuntimeActivity)
+			if body.RuntimeActivity.Liveness != "live" || body.RuntimeActivity.TurnActivity != "busy" || session.ControlBusy() {
+				t.Fatalf("activity after send_turn settle = %#v control_busy=%v", body.RuntimeActivity, session.ControlBusy())
 			}
-
-			if err := session.Acknowledge("act-steer-1"); err != nil {
-				t.Fatalf("acknowledge steer: %v", err)
+			if err := session.EmitObservation(runtime.ProviderSessionObservation{
+				Kind:   runtime.ProviderSessionObservationTurnCompleted,
+				Status: "completed",
+			}); err != nil {
+				t.Fatalf("complete replacement Runtime Turn: %v", err)
 			}
 			deadline = time.Now().Add(2 * time.Second)
 			for time.Now().Before(deadline) {
@@ -229,7 +250,7 @@ func TestRuntimeActivityLiveIdleAndBusyForSandboxProviders(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 			}
 			if body.RuntimeActivity.Liveness != "live" || body.RuntimeActivity.TurnActivity != "idle" {
-				t.Fatalf("activity after steer settle = %#v", body.RuntimeActivity)
+				t.Fatalf("activity after replacement terminal = %#v", body.RuntimeActivity)
 			}
 
 			close(closed)

--- a/internal/daemon/runtime_turn_selection_test.go
+++ b/internal/daemon/runtime_turn_selection_test.go
@@ -31,7 +31,7 @@ func TestCodexNativeSteerSameProviderModelAndEffortUsesExistingSession(t *testin
 	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
 		SessionID: "codex-thread-1",
 		Capabilities: runtimeplugin.Capabilities{
-			PersistentSession: true, SendTurn: true, InterruptThenReplace: true,
+			PersistentSession: true, SendTurn: true, InterruptThenReplace: true, InTurnSteer: true,
 		},
 	})
 	closed := make(chan struct{})
@@ -147,6 +147,9 @@ func TestCodexNativeSteerSameProviderModelAndEffortUsesExistingSession(t *testin
 	for _, event := range eventsAfter {
 		if event.Kind == task.EventKindConversation && event.Payload["request_id"] == "turn-select-1" {
 			conversationCount++
+			if event.Payload["mode"] != string(runtime.ProviderSessionModeInterruptThenReplace) {
+				t.Fatalf("selection-changing steer mode = %#v, want interrupt_then_replace", event.Payload["mode"])
+			}
 			if event.Payload["model_provider_id"] != provider.ID {
 				t.Fatalf("conversation missing model_provider_id: %#v", event.Payload)
 			}
@@ -412,6 +415,7 @@ func TestCodexNativeSteerUnsupportedEffortFailsTurnWithoutDowngrade(t *testing.T
 			PersistentSession: true, SendTurn: true, InterruptThenReplace: true,
 		},
 		Failures: map[runtime.ProviderSessionMode]error{
+			runtime.ProviderSessionModeSendTurn:             errUnsupportedEffortForTest,
 			runtime.ProviderSessionModeInterruptThenReplace: errUnsupportedEffortForTest,
 		},
 	})
@@ -1141,6 +1145,7 @@ func TestClaudeNativeSteerUnsupportedEffortFailsTurnWithoutDowngrade(t *testing.
 			PersistentSession: true, SendTurn: true, InterruptThenReplace: true,
 		},
 		Failures: map[runtime.ProviderSessionMode]error{
+			runtime.ProviderSessionModeSendTurn:             errUnsupportedEffortForTest,
 			runtime.ProviderSessionModeInterruptThenReplace: errUnsupportedEffortForTest,
 		},
 	})
@@ -1265,7 +1270,7 @@ func sessionIDOf(session runtime.ProviderSession) string {
 // natively (no Config Projection restart) and carries the full turn selection.
 func TestPiNativeSteerAcceptsCrossProviderWithoutRestart(t *testing.T) {
 	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
-		SessionID: "pi-session-1",
+		SessionID: "pi-session-1", ActiveTurnID: "pi-work-turn-1", ActiveTurnKind: runtime.RuntimeTurnKindWork,
 		Capabilities: runtimeplugin.Capabilities{
 			PersistentSession: true, SendTurn: true, InterruptThenReplace: true, InTurnSteer: true,
 		},
@@ -1370,6 +1375,9 @@ func TestPiNativeSteerAcceptsCrossProviderWithoutRestart(t *testing.T) {
 	if last.RequestedReasoningEffort != "xhigh" {
 		t.Fatalf("effort = %q, want xhigh", last.RequestedReasoningEffort)
 	}
+	if last.ProviderTurnID != "pi-work-turn-1" {
+		t.Fatalf("replacement request fence = %q, want pi-work-turn-1", last.ProviderTurnID)
+	}
 
 	versionsAfter, err := server.tasks.RuntimeConfigVersions(created.ID)
 	if err != nil {
@@ -1395,6 +1403,9 @@ func TestPiNativeSteerAcceptsCrossProviderWithoutRestart(t *testing.T) {
 			}
 			if event.Payload["delivery"] != "native_steer" {
 				t.Fatalf("delivery = %#v", event.Payload["delivery"])
+			}
+			if event.Payload["mode"] != string(runtime.ProviderSessionModeInterruptThenReplace) {
+				t.Fatalf("Pi selection-changing mode = %#v, want interrupt_then_replace", event.Payload["mode"])
 			}
 		}
 	}

--- a/internal/daemon/session_runtime_handlers.go
+++ b/internal/daemon/session_runtime_handlers.go
@@ -41,6 +41,7 @@ type sessionRuntimeInput struct {
 	Model            string         `json:"model"`
 	ModelOverride    string         `json:"model_override"`
 	ReasoningEffort  string         `json:"reasoning_effort"`
+	ForceReplace     bool           `json:"force_replace,omitempty"`
 	Runner           string         `json:"runner"`
 	HostActivated    bool           `json:"host_activated"`
 	RuntimeConfig    map[string]any `json:"runtime_config"`
@@ -79,13 +80,9 @@ type sessionRuntimePlan struct {
 	Facts            ProviderSessionLaunchFacts
 }
 
-func sessionGoalWithAttachmentEvents(goal, workdir string, run session.Runner, events []session.Event) string {
-	paths := make([]string, 0, len(events))
-	for _, event := range events {
-		reference, ok := event.AttachmentReference()
-		if !ok {
-			continue
-		}
+func sessionGoalWithAttachmentReferences(goal, workdir string, run session.Runner, references []session.AttachmentReference) string {
+	paths := make([]string, 0, len(references))
+	for _, reference := range references {
 		hostPath := filepath.Join(workdir, reference.RelativePath)
 		info, err := os.Stat(hostPath)
 		if err != nil || !info.Mode().IsRegular() {
@@ -94,6 +91,17 @@ func sessionGoalWithAttachmentEvents(goal, workdir string, run session.Runner, e
 		paths = append(paths, ownerAttachmentGoalPath(task.Runner(run), workdir, reference.RelativePath))
 	}
 	return appendAttachmentPathsToGoal(goal, paths)
+}
+
+func sessionGoalWithAttachmentEvents(goal, workdir string, run session.Runner, events []session.Event) string {
+	references := make([]session.AttachmentReference, 0, len(events))
+	for _, event := range events {
+		reference, ok := event.AttachmentReference()
+		if ok {
+			references = append(references, reference)
+		}
+	}
+	return sessionGoalWithAttachmentReferences(goal, workdir, run, references)
 }
 
 func (server *Server) sessionLaunchGoal(found session.Session, goal string, run session.Runner) (string, error) {
@@ -797,13 +805,23 @@ func (server *Server) decorateSession(found session.Session) (session.Session, e
 		}
 		controls.NativeResumeAvailable = active == nil && controls.NativeSessionCaptured && provider != string(runtimeprofile.ProviderFake)
 	}
+	steeringControl, steeringControlErr := server.latestSteeringControl(owner.KindSession, found.ID)
+	if steeringControlErr == nil {
+		controls.NativeSteerRequestID = steeringControl.requestID
+		controls.NativeSteerState = steeringControl.state
+		controls.NativeSteerErrorCode = steeringControl.errorCode
+		controls.NativeSteerError = steeringControl.error
+	}
 	if isBound {
 		capabilities := bound.Capabilities()
 		controls.QueueSteerAvailable = capabilities.SendTurn
-		if mode, modeErr := nativeSteerMode(capabilities); modeErr == nil {
+		if mode, modeErr := nativeSteerModeForSession(bound, false); modeErr == nil {
 			controls.NativeSteerAvailable = true
 			controls.NativeSteerMode = string(mode)
 			controls.InterruptSteerAvailable = capabilities.InterruptThenReplace || capabilities.InTurnSteer
+		}
+		if steeringControl.nonTerminal {
+			controls.NativeSteerAvailable = false
 		}
 	}
 	if active != nil && !isBound && !harnessActive {
@@ -1123,10 +1141,10 @@ func sessionInputChangesTurnSelection(input sessionRuntimeInput) bool {
 	return strings.TrimSpace(input.ModelProviderID) != "" || input.selectedModel() != "" || strings.TrimSpace(input.ReasoningEffort) != ""
 }
 
-func (server *Server) recordSessionTurnSelection(sessionID string, continuation session.Continuation, selection runtime.ProviderSessionRequest) error {
+func (server *Server) sessionTurnSelectionConfig(sessionID string, continuation session.Continuation, selection runtime.ProviderSessionRequest) (map[string]any, error) {
 	versions, err := server.sessions.RuntimeConfigVersions(sessionID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	config := map[string]any{
 		"runtime_profile_id": continuation.RuntimeProfileID,
@@ -1146,6 +1164,31 @@ func (server *Server) recordSessionTurnSelection(sessionID string, continuation 
 	}
 	if selection.RequestedReasoningEffort != "" {
 		config["reasoning_effort"] = selection.RequestedReasoningEffort
+	}
+	return config, nil
+}
+
+func (server *Server) sessionPiProjectedProviderAllowed(sessionID, providerID string) bool {
+	providerID = strings.TrimSpace(providerID)
+	if providerID == "" {
+		return false
+	}
+	versions, err := server.sessions.RuntimeConfigVersions(sessionID)
+	if err != nil || len(versions) == 0 {
+		return false
+	}
+	for _, projectedID := range stringSliceFromConfig(versions[len(versions)-1].Config["projected_model_provider_ids"]) {
+		if projectedID == providerID {
+			return true
+		}
+	}
+	return false
+}
+
+func (server *Server) recordSessionTurnSelection(sessionID string, continuation session.Continuation, selection runtime.ProviderSessionRequest) error {
+	config, err := server.sessionTurnSelectionConfig(sessionID, continuation, selection)
+	if err != nil {
+		return err
 	}
 	_, err = server.sessions.RecordRuntimeConfig(sessionID, continuation.RuntimeProfileID, config)
 	return err
@@ -1225,7 +1268,6 @@ func (server *Server) enqueueSessionProviderTurn(sessionID string, provider runt
 			selection.TurnKind = runtime.RuntimeTurnKindControl
 		}
 		spec := server.sessionSteerEmitSpec(ctx, sessionID, provider)
-		spec.mode = mode
 		protocol := newSteerEmitProtocol(continuationID, spec)
 		result, err := operation(ctx, selection, protocol.emit)
 		if err != nil || protocol.transitionErr() != nil {
@@ -1287,7 +1329,6 @@ func (server *Server) sessionSteerEmitSpec(ctx context.Context, sessionID string
 // The returned execution is the durable terminal outcome.
 func (server *Server) executeSessionNativeSteerOperation(ctx context.Context, sessionID string, provider runtime.ProviderSession, mode runtime.ProviderSessionMode, operation nativeSteerOperationFunc, providerRequest runtime.ProviderSessionRequest, continuationID string) steeringExecution {
 	spec := server.sessionSteerEmitSpec(ctx, sessionID, provider)
-	spec.mode = mode
 	return runNativeSteerTurn(ctx, steerExecutionSpec{
 		operation:             operation,
 		request:               providerRequest,
@@ -1400,6 +1441,28 @@ func (server *Server) handleSessionSteer(response http.ResponseWriter, request *
 		writeSessionError(response, err)
 		return
 	}
+	requestID := sessionRequestID(request, "steer")
+	adapter := sessionSteeringAdapter(server, id, server.sessionConclusionSettlementForID(id))
+	clientSelectionIdentity := canonicalSteeringClientSelectionIdentity(input.ModelProviderID, input.selectedModel(), input.ReasoningEffort)
+	replayIdentity := steeringReplayIdentity{
+		requestID: requestID, operatorMessage: message,
+		clientSelectionIdentity: clientSelectionIdentity,
+		modelProviderID:         input.ModelProviderID, model: input.selectedModel(),
+		requestedReasoningEffort: input.ReasoningEffort,
+	}
+	if record, replayed, replayErr := server.findAcceptedSteeringReplayByIdentity(adapter, replayIdentity); replayErr != nil || replayed {
+		if replayErr != nil {
+			var conflict *steeringRequestConflictError
+			if errors.As(replayErr, &conflict) {
+				writeError(response, http.StatusConflict, conflict.Error())
+			} else {
+				writeSessionError(response, replayErr)
+			}
+			return
+		}
+		server.writeDecoratedSessionWithSteeringOutcome(response, http.StatusAccepted, id, steeringOutcomeFromRecord(record))
+		return
+	}
 	provider, bound := server.sessionProviderSessions.get(id)
 	active, activeErr := server.sessions.ActiveContinuation(id)
 	if activeErr != nil {
@@ -1414,68 +1477,94 @@ func (server *Server) handleSessionSteer(response http.ResponseWriter, request *
 		writeError(response, http.StatusConflict, conflict)
 		return
 	}
-	mode, err := nativeSteerMode(provider.Capabilities())
-	if err != nil {
-		writeError(response, http.StatusConflict, err.Error())
-		return
-	}
-	if nativeSteerOperation(provider, mode) == nil {
-		writeError(response, http.StatusConflict, "provider session does not support native steer")
-		return
-	}
 	selection, err := server.sessionCurrentSelection(*active)
 	if err != nil {
 		writeSessionError(response, err)
 		return
 	}
 	if requestedProvider := strings.TrimSpace(input.ModelProviderID); requestedProvider != "" && requestedProvider != selection.ModelProviderID {
-		writeError(response, http.StatusConflict, "Session Runtime model provider changes require a fresh continuation")
-		return
+		if runtimeprofile.Provider(active.RuntimeProvider) != runtimeprofile.ProviderPi || !server.sessionPiProjectedProviderAllowed(id, requestedProvider) {
+			writeError(response, http.StatusConflict, "Session Runtime model provider changes require a fresh continuation")
+			return
+		}
 	}
+	currentSelection := selection
 	selection, err = sessionSelectionFromInput(selection, input)
 	if err != nil {
 		writeError(response, http.StatusBadRequest, err.Error())
 		return
 	}
-	if sessionInputChangesTurnSelection(input) {
-		if err := server.recordSessionTurnSelection(id, *active, selection); err != nil {
-			writeSessionError(response, err)
-			return
-		}
+	prepared, err := prepareAcceptedNativeSteer(
+		request.Context(), provider,
+		providerSelectionRequiresReplacement(runtimeprofile.Provider(active.RuntimeProvider), currentSelection, selection),
+		input.ForceReplace, adapter.settlement,
+	)
+	if err != nil {
+		writeError(response, http.StatusConflict, err.Error())
+		return
 	}
-	requestID := sessionRequestID(request, "steer")
+	if nativeSteerOperation(provider, prepared.Mode) == nil {
+		writeError(response, http.StatusConflict, "provider session does not support native steer")
+		return
+	}
+	mode := prepared.Mode
+	expectedProviderTurnID := prepared.ExpectedProviderTurnID
+	releaseSteeringRequest := server.steering.AcquireRequest(owner.KindSession, id, requestID)
+	defer releaseSteeringRequest()
 
-	// Repeated requests with the same request identity return the durable
-	// current outcome and never create a second queue item. Conflicting content
-	// under the same identity returns a conflict.
-	if record, err := server.steering.ByRequestID(owner.KindSession, id, requestID); err == nil {
-		if conflict := steeringConflictMessage(record, message, selection, owner.SteeringMode(mode)); conflict != "" {
-			writeError(response, http.StatusConflict, conflict)
+	acceptInput := steering.AcceptRequest{
+		RequestID:                requestID,
+		ClientSelectionIdentity:  clientSelectionIdentity,
+		OperatorMessage:          message,
+		Message:                  message,
+		Mode:                     owner.SteeringMode(mode),
+		ModelProviderID:          selection.ModelProviderID,
+		Model:                    selection.Model,
+		RequestedReasoningEffort: selection.RequestedReasoningEffort,
+		SessionID:                provider.SessionID(),
+		ExpectedProviderTurnID:   expectedProviderTurnID,
+	}
+	if record, replayed, replayErr := server.findAcceptedSteeringReplay(adapter, acceptInput); replayErr != nil || replayed {
+		if replayErr != nil {
+			var conflict *steeringRequestConflictError
+			if errors.As(replayErr, &conflict) {
+				writeError(response, http.StatusConflict, conflict.Error())
+			} else {
+				writeSessionError(response, replayErr)
+			}
 			return
 		}
 		server.writeDecoratedSessionWithSteeringOutcome(response, http.StatusAccepted, id, steeringOutcomeFromRecord(record))
 		return
-	} else if !errors.Is(err, steering.ErrNotFound) {
-		writeSessionError(response, err)
-		return
 	}
 
-	// Durable acceptance: the operator message and the dispatch record commit
-	// before the request returns 202. The accepted steering is dispatched by
-	// the owner-neutral FIFO queue after the assisted conclusion settles.
-	adapter := sessionSteeringAdapter(server, id, server.sessionConclusionSettlementForID(id))
-	accept := func(runtimeMessage, conversationID string) error {
-		_, acceptErr := server.acceptSteeringDurably(request.Context(), adapter, steering.AcceptRequest{
-			RequestID:                requestID,
-			Message:                  runtimeMessage,
-			Mode:                     owner.SteeringMode(mode),
-			ModelProviderID:          selection.ModelProviderID,
-			Model:                    selection.Model,
-			RequestedReasoningEffort: selection.RequestedReasoningEffort,
-			SessionID:                provider.SessionID(),
-		}, func(tx *sql.Tx) (string, error) {
-			if conversationID != "" {
-				return conversationID, nil
+	var turnSelectionConfig map[string]any
+	if sessionInputChangesTurnSelection(input) {
+		turnSelectionConfig, err = server.sessionTurnSelectionConfig(id, *active, selection)
+		if err != nil {
+			writeSessionError(response, err)
+			return
+		}
+	}
+
+	// Durable acceptance: the operator message, attachments, Turn Selection,
+	// and dispatch record commit in one transaction before the request returns
+	// 202. The accepted steering is dispatched by the owner-neutral FIFO queue after the
+	// assisted conclusion settles.
+	accept := func(runtimeMessage string, preparedInput *session.PreparedConversationInput) (*owner.SteeringRecord, error) {
+		acceptInput.Message = runtimeMessage
+		record, _, acceptErr := server.acceptSteeringOrReplay(request.Context(), adapter, acceptInput, func(tx *sql.Tx) (string, error) {
+			if preparedInput != nil {
+				_, conversation, appendErr := preparedInput.AppendTx(tx)
+				if appendErr != nil {
+					return "", appendErr
+				}
+				if turnSelectionConfig != nil {
+					if _, configErr := server.sessions.RecordRuntimeConfigTx(tx, id, active.RuntimeProfileID, turnSelectionConfig); configErr != nil {
+						return "", configErr
+					}
+				}
+				return conversation.ID, nil
 			}
 			payload := session.EventPayload{
 				"role": "user", "text": message, "request_id": requestID,
@@ -1484,6 +1573,9 @@ func (server *Server) handleSessionSteer(response http.ResponseWriter, request *
 				"model_provider_id": selection.ModelProviderID, "model": selection.Model,
 				"requested_reasoning_effort": selection.RequestedReasoningEffort,
 			}
+			if expectedProviderTurnID != "" {
+				payload["provider_turn_id"] = expectedProviderTurnID
+			}
 			if active != nil {
 				payload["continuation_id"] = active.ID
 			}
@@ -1491,49 +1583,51 @@ func (server *Server) handleSessionSteer(response http.ResponseWriter, request *
 			if eventErr != nil {
 				return "", eventErr
 			}
+			if turnSelectionConfig != nil {
+				if _, configErr := server.sessions.RecordRuntimeConfigTx(tx, id, active.RuntimeProfileID, turnSelectionConfig); configErr != nil {
+					return "", configErr
+				}
+			}
 			return event.ID, nil
 		})
-		return acceptErr
+		return record, acceptErr
 	}
 
 	runtimeMessage := message
 	if len(uploads) > 0 {
-		// Attachments are staged by the existing input path; the conversation
-		// event it produces becomes the projection reference for the record.
-		uploadedEvents, conversation, uploadErr := server.appendSessionConversationInput(id, active.ID, message, uploads)
-		if uploadErr != nil {
-			writeSessionError(response, uploadErr)
+		input := sessionConversationInput(message, uploads)
+		preparedInput, prepareErr := server.sessions.PrepareConversationInput(id, active.ID, input.Role, input.Text, input.Attachments)
+		if prepareErr != nil {
+			writeSessionError(response, prepareErr)
 			return
 		}
-		runtimeMessage = sessionGoalWithAttachmentEvents(message, found.Workdir, active.Runner, uploadedEvents)
-		if err := accept(runtimeMessage, conversation.ID); err != nil {
+		defer preparedInput.Rollback()
+		runtimeMessage = sessionGoalWithAttachmentReferences(message, found.Workdir, active.Runner, preparedInput.AttachmentReferences())
+		record, err := accept(runtimeMessage, preparedInput)
+		if err != nil {
+			var conflict *steeringRequestConflictError
+			if errors.As(err, &conflict) {
+				writeError(response, http.StatusConflict, conflict.Error())
+				return
+			}
 			writeSessionError(response, err)
 			return
 		}
-		server.writeDecoratedSession(response, http.StatusAccepted, id)
+		preparedInput.Commit()
+		server.writeDecoratedSessionWithSteeringOutcome(response, http.StatusAccepted, id, steeringOutcomeFromRecord(record))
 		return
 	}
-	if err := accept(runtimeMessage, ""); err != nil {
-		if errors.Is(err, steering.ErrDuplicateRequest) {
-			// A concurrent duplicate committed first; the same identity rules
-			// apply: matching content replays the durable outcome, conflicting
-			// content is a conflict.
-			replayed, replayErr := server.steering.ByRequestID(owner.KindSession, id, requestID)
-			if replayErr != nil {
-				writeSessionError(response, replayErr)
-				return
-			}
-			if conflict := steeringConflictMessage(replayed, message, selection, owner.SteeringMode(mode)); conflict != "" {
-				writeError(response, http.StatusConflict, conflict)
-				return
-			}
-			server.writeDecoratedSessionWithSteeringOutcome(response, http.StatusAccepted, id, steeringOutcomeFromRecord(replayed))
+	record, err := accept(runtimeMessage, nil)
+	if err != nil {
+		var conflict *steeringRequestConflictError
+		if errors.As(err, &conflict) {
+			writeError(response, http.StatusConflict, conflict.Error())
 			return
 		}
 		writeSessionError(response, err)
 		return
 	}
-	server.writeDecoratedSession(response, http.StatusAccepted, id)
+	server.writeDecoratedSessionWithSteeringOutcome(response, http.StatusAccepted, id, steeringOutcomeFromRecord(record))
 }
 func sessionConversationInput(message string, uploads []uploadedAttachment) session.ConversationInput {
 	attachments := make([]session.Attachment, 0, len(uploads))

--- a/internal/daemon/session_runtime_handlers_test.go
+++ b/internal/daemon/session_runtime_handlers_test.go
@@ -84,6 +84,30 @@ func TestSessionRuntimePlanUsesNativeResumeArgvWithoutAProviderBridge(t *testing
 	}
 }
 
+func TestSessionPiProjectedProviderAllowedUsesLatestRuntimeConfig(t *testing.T) {
+	server, err := NewServer(Config{DBPath: filepath.Join(t.TempDir(), "pentest.db"), DisableBuiltinSkills: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	created, err := server.sessions.Create(session.CreateRequest{Input: "inspect"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.sessions.CreateContinuation(created.ID, "profile-pi", string(runtimeprofile.ProviderPi), session.RunnerSandbox, map[string]any{
+		"model_provider_id":            "provider-a",
+		"projected_model_provider_ids": []string{"provider-a", "provider-b"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !server.sessionPiProjectedProviderAllowed(created.ID, "provider-b") {
+		t.Fatal("projected Session Pi provider was rejected")
+	}
+	if server.sessionPiProjectedProviderAllowed(created.ID, "provider-c") {
+		t.Fatal("unprojected Session Pi provider was accepted")
+	}
+}
+
 func TestSessionPiSandboxUsesTheSharedBootstrapWrapper(t *testing.T) {
 	server, err := NewServer(Config{
 		Version: "test", DBPath: filepath.Join(t.TempDir(), "pentest.db"), RuntimeRoot: t.TempDir(), DisableBuiltinSkills: true,

--- a/internal/daemon/steer_accepts_before_control_test.go
+++ b/internal/daemon/steer_accepts_before_control_test.go
@@ -24,7 +24,6 @@ type blockedControlSession struct {
 	*runtime.FakeProviderSession
 	controlStarted chan struct{}
 	releaseControl chan struct{}
-	steerStarted   chan struct{}
 }
 
 func (s *blockedControlSession) Capabilities() runtimeplugin.Capabilities {
@@ -49,15 +48,6 @@ func (s *blockedControlSession) SendTurn(ctx context.Context, request runtime.Pr
 	return s.FakeProviderSession.SendTurn(ctx, request, emit)
 }
 
-func (s *blockedControlSession) SteerInTurn(ctx context.Context, request runtime.ProviderSessionRequest, emit runtime.ProviderSessionEmit) (runtime.ProviderSessionResult, error) {
-	select {
-	case <-s.steerStarted:
-	default:
-		close(s.steerStarted)
-	}
-	return s.FakeProviderSession.SendTurn(ctx, request, emit)
-}
-
 func newBlockedControlFixture(t *testing.T) (*Server, string, task.Task, *blockedControlSession) {
 	t.Helper()
 	return newBlockedControlFixtureAt(t, t.TempDir())
@@ -73,7 +63,6 @@ func newBlockedControlFixtureAt(t *testing.T, root string) (*Server, string, tas
 				FakeProviderSession: fake,
 				controlStarted:      make(chan struct{}),
 				releaseControl:      make(chan struct{}),
-				steerStarted:        make(chan struct{}),
 			}
 			return blocked
 		},
@@ -120,10 +109,9 @@ func TestSteerReturnsAcceptedWhileProviderControlTurnBlocked(t *testing.T) {
 	if conversation.Payload["outcome"] != "pending" || conversation.Payload["delivery"] != "native_steer" {
 		t.Fatalf("accepted steer event = %#v, want pending native_steer", conversation.Payload)
 	}
-	select {
-	case <-blocked.steerStarted:
-		t.Fatal("steer applied before the control Turn completed")
-	case <-time.After(50 * time.Millisecond):
+	time.Sleep(50 * time.Millisecond)
+	if got := len(blocked.FakeProviderSession.LastRequests()); got != 1 {
+		t.Fatalf("steer applied before the control Turn completed: requests=%d", got)
 	}
 
 	// Release the control Turn: the conclusion settles, then the accepted
@@ -140,11 +128,6 @@ func TestSteerReturnsAcceptedWhileProviderControlTurnBlocked(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitForAssistedProviderRequests(t, blocked.FakeProviderSession, 3)
-	select {
-	case <-blocked.steerStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("accepted steering was not applied after the control Turn completed")
-	}
 	applied := blocked.FakeProviderSession.LastRequests()[2]
 	if applied.RequestID != "steer-while-blocked" || applied.Message != "Continue the inspection." {
 		t.Fatalf("applied steering request = %#v", applied)
@@ -246,10 +229,8 @@ func TestPendingSteerSurvivesConcurrentStopWithoutLosingMessage(t *testing.T) {
 	if conversation.Payload["outcome"] != "pending" {
 		t.Fatalf("stopped steer outcome = %v, want pending", conversation.Payload["outcome"])
 	}
-	select {
-	case <-blocked.steerStarted:
-		t.Fatal("pending steering applied after Stop")
-	default:
+	if got := len(blocked.FakeProviderSession.LastRequests()); got != 2 {
+		t.Fatalf("pending steering applied after Stop: requests=%d", got)
 	}
 }
 

--- a/internal/daemon/steer_executor.go
+++ b/internal/daemon/steer_executor.go
@@ -2,7 +2,7 @@ package daemon
 
 import (
 	"context"
-	"errors"
+	"strings"
 	"sync"
 
 	"pentest/internal/owner"
@@ -42,7 +42,6 @@ var sessionSteerEventVocabulary = steerEventVocabulary{
 // interrupt_then_replace steering settlement advances the Continuation under
 // the same mutex so the next provider event lands on the replacement.
 type steerEmitProtocolSpec struct {
-	mode runtime.ProviderSessionMode
 	// advanceOnSettled is false when the Continuation was created fresh by this
 	// dispatch and must not be advanced again.
 	advanceOnSettled bool
@@ -79,7 +78,7 @@ func newSteerEmitProtocol(initialContinuationID string, spec steerEmitProtocolSp
 		current := currentContinuationID
 		spec.persistEvent(current, kind, payload)
 		if transitionErr == nil && spec.advanceOnSettled &&
-			spec.mode == runtime.ProviderSessionModeInterruptThenReplace &&
+			payloadMode(payload) == runtime.ProviderSessionModeInterruptThenReplace &&
 			kind == task.EventKindSteering && payloadOutcome(payload) == "settled" && current != "" {
 			next, advanceErr := spec.advance(current)
 			if advanceErr != nil {
@@ -107,8 +106,9 @@ func newSteerEmitProtocol(initialContinuationID string, spec steerEmitProtocolSp
 }
 
 // steerExecutionSpec binds one Runtime Owner to the shared native steer
-// executor. The executor owns the owner-neutral delivery protocol: the request
-// is always lineage-assigned as a Harness Control Turn (ADR 0018), events
+// executor. The executor owns the owner-neutral delivery protocol: direct
+// same-turn input is a Harness control request that preserves the active Work
+// Turn lineage, while a new or replacement Turn receives Work lineage. Events
 // persist through the owner sink, a lost Continuation transition fails closed,
 // and a post-fence cancellation settles action_required instead of replaying.
 type steerExecutionSpec struct {
@@ -142,10 +142,14 @@ func runNativeSteerTurn(ctx context.Context, spec steerExecutionSpec) steeringEx
 	// from request lineage; provider payloads cannot choose or override it
 	// (ADR 0018).
 	request := spec.request
-	request.TurnKind = runtime.RuntimeTurnKindControl
+	request.TurnKind = runtime.RuntimeTurnKindWork
+	if spec.mode == runtime.ProviderSessionModeInTurnSteer {
+		// The steer request is Harness control, but the existing active provider
+		// Turn keeps its original Work lineage.
+		request.TurnKind = runtime.RuntimeTurnKindControl
+	}
 
 	protocol := newSteerEmitProtocol(spec.initialContinuationID, steerEmitProtocolSpec{
-		mode:              spec.mode,
 		advanceOnSettled:  spec.advanceOnSettled,
 		persistEvent:      spec.persistEvent,
 		persistOwnerEvent: spec.persistOwnerEvent,
@@ -165,38 +169,39 @@ func runNativeSteerTurn(ctx context.Context, spec steerExecutionSpec) steeringEx
 		}
 	}
 	if operationErr != nil {
-		errorCode, errorMessage := nativeSteerFailurePresentation(operationErr)
-		if errors.Is(operationErr, context.Canceled) || errors.Is(operationErr, context.DeadlineExceeded) {
-			// Post-fence with no provider outcome: delivery is ambiguous. The
-			// request is never replayed automatically; it settles
-			// action_required with a reason-specific recovery path.
-			protocol.emit(spec.vocabulary.failureKind, task.EventPayload{
-				"request_id": request.RequestID, "session_id": spec.providerSessionID, "mode": string(spec.mode),
-				"outcome": "action_required", "phase": spec.vocabulary.ambiguousPhase,
-				"error_code": string(owner.SteeringReasonDeliveryAmbiguous), "error": errorMessage,
-				"model_provider_id": request.ModelProviderID, "model": request.Model,
-				"requested_reasoning_effort": request.RequestedReasoningEffort,
-			})
-			return steeringExecution{state: owner.SteeringActionRequired, reason: owner.SteeringReasonDeliveryAmbiguous, message: errorMessage}
+		failure := classifyNativeSteerFailure(operationErr)
+		outcome := "failed"
+		phase := spec.vocabulary.failurePhase
+		if failure.state == owner.SteeringActionRequired {
+			outcome = "action_required"
+			phase = spec.vocabulary.ambiguousPhase
 		}
 		// Public Events carry only redacted, stable failure fields. Raw
-		// provider text stays out of the conversation surface; each owner's
-		// persistence sink applies its own allowlist.
+		// provider text stays out of the conversation surface.
 		protocol.emit(spec.vocabulary.failureKind, task.EventPayload{
 			"request_id": request.RequestID, "session_id": spec.providerSessionID, "mode": string(spec.mode),
-			"outcome": "failed", "phase": spec.vocabulary.failurePhase, "error_code": errorCode,
-			"error":             errorMessage,
+			"outcome": outcome, "phase": phase, "error_code": failure.code, "error": failure.message,
 			"model_provider_id": request.ModelProviderID, "model": request.Model,
 			"requested_reasoning_effort": request.RequestedReasoningEffort,
 		})
-		return steeringExecution{state: owner.SteeringFailed, reason: steerReasonFromFailureCode(errorCode), message: errorMessage}
+		return steeringExecution{state: failure.state, reason: failure.reason, message: failure.message}
 	}
-	payload := result.Payload()
-	payload["outcome"] = "applied"
-	payload["phase"] = spec.vocabulary.appliedPhase
-	// The provider result is a structured Runtime turn result, not a
-	// transcript message. Conversation contains only explicit user/runtime
-	// messages; provider control/result data stays on the owner Timeline.
-	protocol.emit(spec.vocabulary.appliedKind, payload)
-	return steeringExecution{state: owner.SteeringApplied, result: result.Payload()}
+
+	effectiveMode := result.Mode
+	if effectiveMode == "" {
+		effectiveMode = spec.mode
+	}
+	result.Mode = effectiveMode
+	result.RequestID = request.RequestID
+	// Applied projection is deliberately deferred. The dispatcher first commits
+	// the terminal Accepted Steering record, then projects this provider result.
+	return steeringExecution{
+		state: owner.SteeringApplied, result: result.Payload(), mode: effectiveMode,
+		continuationID: protocol.currentID(),
+	}
+}
+
+func payloadMode(payload task.EventPayload) runtime.ProviderSessionMode {
+	value, _ := payload["mode"].(string)
+	return runtime.ProviderSessionMode(strings.TrimSpace(value))
 }

--- a/internal/daemon/steer_executor_test.go
+++ b/internal/daemon/steer_executor_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"pentest/internal/owner"
+	"pentest/internal/runtime"
+	"pentest/internal/task"
+)
+
+func TestRunNativeSteerTurnDefersAppliedProjectionUntilDurableSettlement(t *testing.T) {
+	var persisted []task.EventPayload
+	execution := runNativeSteerTurn(context.Background(), steerExecutionSpec{
+		operation: func(_ context.Context, request runtime.ProviderSessionRequest, _ runtime.ProviderSessionEmit) (runtime.ProviderSessionResult, error) {
+			return runtime.ProviderSessionResult{
+				RequestID: request.RequestID, SessionID: "session-1", ProviderTurnID: "turn-1",
+				Mode: runtime.ProviderSessionModeInTurnSteer, Outcome: "acknowledged",
+			}, nil
+		},
+		request: runtime.ProviderSessionRequest{RequestID: "steer-1", Message: "focus"},
+		mode:    runtime.ProviderSessionModeInTurnSteer, providerSessionID: "session-1",
+		initialContinuationID: "continuation-1", vocabulary: taskSteerEventVocabulary,
+		persistEvent: func(_ string, _ task.EventKind, payload task.EventPayload) {
+			persisted = append(persisted, payload)
+		},
+	})
+	if execution.state != owner.SteeringApplied {
+		t.Fatalf("execution = %#v", execution)
+	}
+	for _, payload := range persisted {
+		if payload["outcome"] == "applied" {
+			t.Fatalf("applied projection preceded durable settlement: %#v", persisted)
+		}
+	}
+}
+
+func TestSteerEmitProtocolAdvancesForInterruptFallbackMode(t *testing.T) {
+	advanced := false
+	protocol := newSteerEmitProtocol("continuation-1", steerEmitProtocolSpec{
+		advanceOnSettled: true,
+		persistEvent:     func(string, task.EventKind, task.EventPayload) {},
+		advance: func(current string) (string, error) {
+			advanced = true
+			if current != "continuation-1" {
+				t.Fatalf("current continuation = %q", current)
+			}
+			return "continuation-2", nil
+		},
+	})
+	protocol.emit(task.EventKindSteering, task.EventPayload{
+		"mode":    string(runtime.ProviderSessionModeInterruptThenReplace),
+		"outcome": "settled",
+	})
+	if !advanced || protocol.currentID() != "continuation-2" {
+		t.Fatalf("fallback continuation = %q, advanced=%v", protocol.currentID(), advanced)
+	}
+}

--- a/internal/daemon/steer_executor_turn_kind_test.go
+++ b/internal/daemon/steer_executor_turn_kind_test.go
@@ -13,10 +13,10 @@ import (
 	"pentest/internal/task"
 )
 
-// A native steer delivery is a Harness Control Turn. The executor assigns the
-// kind from request lineage for both owners so a steer can never be
-// lineage-classified as operator work (ADR 0018).
-func TestNativeSteerSendsHarnessControlTurnKind(t *testing.T) {
+// An interrupt-then-replace steer creates a new Runtime Turn from operator
+// Conversation input, so the replacement must retain Work Turn semantics
+// under ADR 0018.
+func TestInterruptThenReplaceSteerSendsWorkTurnKind(t *testing.T) {
 	server, err := NewServer(Config{DBPath: filepath.Join(t.TempDir(), "pentest.db"), DisableBuiltinSkills: true})
 	if err != nil {
 		t.Fatal(err)
@@ -61,8 +61,8 @@ func TestNativeSteerSendsHarnessControlTurnKind(t *testing.T) {
 
 	waitForProviderRequests(t, session, 1)
 	for _, sent := range session.LastRequests() {
-		if sent.TurnKind != runtime.RuntimeTurnKindControl {
-			t.Fatalf("steer request %q TurnKind = %q, want %q", sent.RequestID, sent.TurnKind, runtime.RuntimeTurnKindControl)
+		if sent.TurnKind != runtime.RuntimeTurnKindWork {
+			t.Fatalf("steer request %q TurnKind = %q, want %q", sent.RequestID, sent.TurnKind, runtime.RuntimeTurnKindWork)
 		}
 	}
 }

--- a/internal/daemon/steering.go
+++ b/internal/daemon/steering.go
@@ -3,12 +3,14 @@ package daemon
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
 
 	"pentest/internal/owner"
 	"pentest/internal/runtime"
+	"pentest/internal/runtimeprofile"
 	"pentest/internal/session"
 	"pentest/internal/steering"
 	"pentest/internal/task"
@@ -27,9 +29,35 @@ type steeringExecution struct {
 	reason  owner.SteeringFailureReason
 	message string
 	result  map[string]any
+	mode    runtime.ProviderSessionMode
+	// continuationID is the writable Continuation after provider settlement.
+	// Applied Timeline projection is deferred until the durable record commits.
+	continuationID string
 	// failOwner marks the Task owner failed when a required Continuation
 	// transition fails after the provider accepted the steer.
 	failOwner bool
+}
+
+type steeringControlProjection struct {
+	requestID   string
+	state       string
+	errorCode   string
+	error       string
+	nonTerminal bool
+}
+
+func (server *Server) latestSteeringControl(kind owner.Kind, ownerID string) (steeringControlProjection, error) {
+	record, err := server.steering.Latest(kind, ownerID)
+	if err != nil || record == nil {
+		return steeringControlProjection{}, err
+	}
+	return steeringControlProjection{
+		requestID:   record.RequestID,
+		state:       steeringOutcomeFromRecord(record),
+		errorCode:   string(record.ErrorCode),
+		error:       record.ErrorMessage,
+		nonTerminal: !record.State.Terminal(),
+	}, nil
 }
 
 // steeringAdapter binds one Runtime Owner to the owner-neutral Accepted
@@ -50,6 +78,8 @@ type steeringAdapter struct {
 	// project appends the owner-local Timeline projection of one terminal
 	// settlement (used by settlement and recovery paths that did not dispatch).
 	project func(record owner.SteeringRecord, state owner.SteeringState, reason owner.SteeringFailureReason, message string)
+	// projectApplied runs only after the durable record reached applied.
+	projectApplied func(record owner.SteeringRecord, continuationID string, result map[string]any)
 }
 
 func (adapter *steeringAdapter) providerRequest(record *owner.SteeringRecord) runtime.ProviderSessionRequest {
@@ -59,6 +89,7 @@ func (adapter *steeringAdapter) providerRequest(record *owner.SteeringRecord) ru
 		ModelProviderID:          record.ModelProviderID,
 		Model:                    record.Model,
 		RequestedReasoningEffort: record.RequestedReasoningEffort,
+		ProviderTurnID:           record.ExpectedProviderTurnID,
 	}
 }
 
@@ -69,6 +100,9 @@ func taskSteeringAdapter(server *Server, taskID string, settlement providerContr
 		settlement: settlement,
 		project: func(record owner.SteeringRecord, state owner.SteeringState, reason owner.SteeringFailureReason, message string) {
 			projectTaskSteeringSettlement(server, record, state, reason, message)
+		},
+		projectApplied: func(record owner.SteeringRecord, continuationID string, result map[string]any) {
+			projectTaskSteeringApplied(server, record, continuationID, result)
 		},
 	}
 	adapter.resolveContinuation = func(ctx context.Context) (string, bool, error) {
@@ -129,6 +163,9 @@ func sessionSteeringAdapter(server *Server, sessionID string, settlement provide
 		settlement: settlement,
 		project: func(record owner.SteeringRecord, state owner.SteeringState, reason owner.SteeringFailureReason, message string) {
 			projectSessionSteeringSettlement(server, record, state, reason, message)
+		},
+		projectApplied: func(record owner.SteeringRecord, continuationID string, result map[string]any) {
+			projectSessionSteeringApplied(server, record, continuationID, result)
 		},
 	}
 	adapter.resolveContinuation = func(ctx context.Context) (string, bool, error) {
@@ -244,8 +281,17 @@ func (server *Server) dispatchAcceptedSteering(ctx context.Context, adapter *ste
 		cancel()
 		switch execution.state {
 		case owner.SteeringApplied:
-			if _, err := server.steering.MarkApplied(ctx, fenced.ID, execution.result); err != nil && !errors.Is(err, steering.ErrNotFound) {
+			effectiveMode := owner.SteeringMode(execution.mode)
+			if effectiveMode == "" {
+				effectiveMode = fenced.Mode
+			}
+			updated, err := server.steering.MarkApplied(ctx, fenced.ID, effectiveMode, execution.result)
+			if err != nil && !errors.Is(err, steering.ErrNotFound) {
 				server.logger.Printf("Accepted Steering applied: %v", err)
+				return
+			}
+			if err == nil && updated != nil && adapter.projectApplied != nil {
+				adapter.projectApplied(*updated, execution.continuationID, execution.result)
 			}
 		case owner.SteeringFailed:
 			server.settleSteeringRecord(ctx, adapter, *fenced, owner.SteeringFailed, execution.reason, execution.message)
@@ -441,21 +487,129 @@ func (server *Server) steeringAdapterFor(record owner.SteeringRecord) *steeringA
 	return sessionSteeringAdapter(server, record.OwnerID, server.sessionConclusionSettlementForID(record.OwnerID))
 }
 
+// steeringReplayIdentity contains only client-controlled idempotency fields.
+// Delivery mode and provider Turn fences are server-selected and may change
+// while the same durable request is being dispatched or safely falling back.
+type steeringReplayIdentity struct {
+	requestID                string
+	operatorMessage          string
+	clientSelectionIdentity  string
+	modelProviderID          string
+	model                    string
+	requestedReasoningEffort string
+}
+
+type steeringClientSelectionIdentity struct {
+	ModelProviderID          string `json:"model_provider_id"`
+	Model                    string `json:"model"`
+	RequestedReasoningEffort string `json:"requested_reasoning_effort"`
+}
+
+// canonicalSteeringClientSelectionIdentity preserves omitted selection fields
+// as empty values. This is different from the resolved Runtime Turn Selection:
+// idempotency compares exactly what the client controlled, while provider
+// defaults and fallback mode remain server-owned.
+func canonicalSteeringClientSelectionIdentity(modelProviderID, model, requestedReasoningEffort string) string {
+	effort := strings.TrimSpace(requestedReasoningEffort)
+	if effort != "" {
+		if normalized, err := runtimeprofile.NormalizeReasoningEffort(effort); err == nil {
+			effort = string(normalized)
+		}
+	}
+	encoded, _ := json.Marshal(steeringClientSelectionIdentity{
+		ModelProviderID:          strings.TrimSpace(modelProviderID),
+		Model:                    strings.TrimSpace(model),
+		RequestedReasoningEffort: effort,
+	})
+	return string(encoded)
+}
+
+func steeringReplayIdentityFromAccept(input steering.AcceptRequest) steeringReplayIdentity {
+	operatorMessage := input.OperatorMessage
+	if strings.TrimSpace(operatorMessage) == "" {
+		operatorMessage = input.Message
+	}
+	return steeringReplayIdentity{
+		requestID:                input.RequestID,
+		operatorMessage:          operatorMessage,
+		clientSelectionIdentity:  input.ClientSelectionIdentity,
+		modelProviderID:          input.ModelProviderID,
+		model:                    input.Model,
+		requestedReasoningEffort: input.RequestedReasoningEffort,
+	}
+}
+
 // steeringConflictMessage compares a repeated request against the durable
-// record and returns a conflict message, or "" when the repeat matches.
-func steeringConflictMessage(record *owner.SteeringRecord, message string, selection runtime.ProviderSessionRequest, mode owner.SteeringMode) string {
-	if strings.TrimSpace(record.Message) != strings.TrimSpace(message) {
+// client-controlled identity. New records compare the canonical raw selection,
+// including empty fields. Legacy records have no raw identity and retain the
+// former non-empty fallback comparison for upgrade compatibility.
+func steeringConflictMessage(record *owner.SteeringRecord, identity steeringReplayIdentity) string {
+	recordedMessage := record.OperatorMessage
+	if strings.TrimSpace(recordedMessage) == "" {
+		recordedMessage = record.Message
+	}
+	if strings.TrimSpace(recordedMessage) != strings.TrimSpace(identity.operatorMessage) {
 		return "steer request id already belongs to a different message"
 	}
-	if record.Mode != mode {
-		return "steer request id already belongs to a different steer mode"
+	if record.ClientSelectionIdentity != "" {
+		if record.ClientSelectionIdentity != identity.clientSelectionIdentity {
+			return "steer request id already belongs to a different turn selection"
+		}
+		return ""
 	}
-	if strings.TrimSpace(record.ModelProviderID) != strings.TrimSpace(selection.ModelProviderID) ||
-		strings.TrimSpace(record.Model) != strings.TrimSpace(selection.Model) ||
-		strings.TrimSpace(record.RequestedReasoningEffort) != strings.TrimSpace(selection.RequestedReasoningEffort) {
+	if value := strings.TrimSpace(identity.modelProviderID); value != "" && value != strings.TrimSpace(record.ModelProviderID) {
+		return "steer request id already belongs to a different turn selection"
+	}
+	if value := strings.TrimSpace(identity.model); value != "" && value != strings.TrimSpace(record.Model) {
+		return "steer request id already belongs to a different turn selection"
+	}
+	if value := strings.TrimSpace(identity.requestedReasoningEffort); value != "" && value != strings.TrimSpace(record.RequestedReasoningEffort) {
 		return "steer request id already belongs to a different turn selection"
 	}
 	return ""
+}
+
+type steeringRequestConflictError struct{ message string }
+
+func (err *steeringRequestConflictError) Error() string { return err.message }
+
+func (server *Server) findAcceptedSteeringReplayByIdentity(adapter *steeringAdapter, identity steeringReplayIdentity) (*owner.SteeringRecord, bool, error) {
+	record, err := server.steering.ByRequestID(adapter.kind, adapter.id, identity.requestID)
+	if errors.Is(err, steering.ErrNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if conflict := steeringConflictMessage(record, identity); conflict != "" {
+		return nil, false, &steeringRequestConflictError{message: conflict}
+	}
+	return record, true, nil
+}
+
+func (server *Server) findAcceptedSteeringReplay(adapter *steeringAdapter, input steering.AcceptRequest) (*owner.SteeringRecord, bool, error) {
+	return server.findAcceptedSteeringReplayByIdentity(adapter, steeringReplayIdentityFromAccept(input))
+}
+
+// acceptSteeringOrReplay is the shared Task/Session acceptance kernel. It owns
+// both the normal idempotency check and the concurrent unique-key race replay;
+// owner handlers only format their public response and projection callback.
+func (server *Server) acceptSteeringOrReplay(ctx context.Context, adapter *steeringAdapter, input steering.AcceptRequest, project func(*sql.Tx) (string, error)) (*owner.SteeringRecord, bool, error) {
+	if record, replayed, err := server.findAcceptedSteeringReplay(adapter, input); err != nil || replayed {
+		return record, replayed, err
+	}
+	record, err := server.acceptSteeringDurably(ctx, adapter, input, project)
+	if !errors.Is(err, steering.ErrDuplicateRequest) {
+		return record, false, err
+	}
+	replayed, found, replayErr := server.findAcceptedSteeringReplay(adapter, input)
+	if replayErr != nil {
+		return nil, false, replayErr
+	}
+	if !found {
+		return nil, false, steering.ErrDuplicateRequest
+	}
+	return replayed, true, nil
 }
 
 // steeringOutcomeFromRecord projects the durable state as the API outcome
@@ -501,4 +655,35 @@ func projectSessionSteeringSettlement(server *Server, record owner.SteeringRecor
 	}
 	payload["phase"] = phase
 	_, _ = server.sessions.AppendEvent(record.OwnerID, session.EventKindSteering, payload)
+}
+
+func appliedSteeringPayload(record owner.SteeringRecord, result map[string]any, phase string) task.EventPayload {
+	payload := make(task.EventPayload, len(result)+8)
+	for key, value := range result {
+		payload[key] = value
+	}
+	payload["request_id"] = record.RequestID
+	payload["session_id"] = record.SessionID
+	payload["mode"] = string(record.Mode)
+	payload["outcome"] = "applied"
+	payload["phase"] = phase
+	payload["model_provider_id"] = record.ModelProviderID
+	payload["model"] = record.Model
+	payload["requested_reasoning_effort"] = record.RequestedReasoningEffort
+	return payload
+}
+
+func projectTaskSteeringApplied(server *Server, record owner.SteeringRecord, continuationID string, result map[string]any) {
+	payload := appliedSteeringPayload(record, result, taskSteerEventVocabulary.appliedPhase)
+	payload["conversation_event_id"] = record.ConversationEventID
+	if continuationID != "" {
+		_, _ = server.tasks.AppendContinuationEvent(record.OwnerID, continuationID, taskSteerEventVocabulary.appliedKind, payload)
+		return
+	}
+	_, _ = server.tasks.AppendEvent(record.OwnerID, taskSteerEventVocabulary.appliedKind, payload)
+}
+
+func projectSessionSteeringApplied(server *Server, record owner.SteeringRecord, continuationID string, result map[string]any) {
+	payload := appliedSteeringPayload(record, result, sessionSteerEventVocabulary.appliedPhase)
+	server.persistSessionProviderEventForContinuation(record.OwnerID, continuationID, sessionSteerEventVocabulary.appliedKind, payload)
 }

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -1617,13 +1617,18 @@ func (server *Server) runtimeControlsForTask(found task.Task, latest *task.TaskC
 			break
 		}
 	}
+	steeringControl, steeringControlErr := server.latestSteeringControl(owner.KindTask, found.ID)
+	if steeringControlErr == nil {
+		controls.NativeSteerRequestID = steeringControl.requestID
+		controls.NativeSteerState = steeringControl.state
+		controls.NativeSteerErrorCode = steeringControl.errorCode
+		controls.NativeSteerError = steeringControl.error
+	}
 	if session, bound := server.providerSessions.get(found.ID); bound {
-		_, outcome, _ := nativeSteerStateForTask(found.ID, server.tasks)
-		if selectedMode, modeErr := nativeSteerMode(session.Capabilities()); modeErr == nil {
+		if selectedMode, modeErr := nativeSteerModeForSession(session, false); modeErr == nil {
 			controls.NativeSteerAvailable = active
 			controls.NativeSteerMode = string(selectedMode)
-			controls.NativeSteerState = outcome
-			if outcome == "requested" || outcome == "acknowledged" || outcome == "settled" || outcome == "started" {
+			if steeringControl.nonTerminal {
 				controls.NativeSteerAvailable = false
 			}
 			controls.InterruptSteerAvailable = controls.NativeSteerAvailable
@@ -1633,14 +1638,6 @@ func (server *Server) runtimeControlsForTask(found task.Task, latest *task.TaskC
 		} else {
 			controls.NativeSteerReason = modeErr.Error()
 			controls.InterruptSteerReason = controls.NativeSteerReason
-		}
-		if events, eventsErr := server.tasks.Events(found.ID); eventsErr == nil {
-			for index := len(events) - 1; index >= 0; index-- {
-				if requestID, ok := events[index].Payload["request_id"].(string); ok && requestID != "" && events[index].Kind == task.EventKindConversation && events[index].Payload["delivery"] == "native_steer" {
-					controls.NativeSteerRequestID = requestID
-					break
-				}
-			}
 		}
 		if controls.NativeSteerState == "" && active {
 			controls.NativeSteerState = "idle"
@@ -1690,25 +1687,6 @@ func providerPermissionRequestsForTask(events []task.Event) []task.ProviderPermi
 		return left.CreatedAt.Compare(right.CreatedAt)
 	})
 	return result
-}
-
-func nativeSteerStateForTask(taskID string, tasks *task.Service) (runtime.ProviderSessionMode, string, string) {
-	events, err := tasks.Events(taskID)
-	if err != nil {
-		return "", "", ""
-	}
-	var requestID string
-	for _, event := range events {
-		if event.Kind != task.EventKindConversation || event.Payload["delivery"] != "native_steer" {
-			continue
-		}
-		requestID, _ = event.Payload["request_id"].(string)
-	}
-	if requestID == "" {
-		return "", "", ""
-	}
-	mode, outcome, sessionID := nativeSteerState(events, requestID)
-	return mode, outcome, sessionID
 }
 
 func (server *Server) handleTaskEvents(response http.ResponseWriter, request *http.Request) {
@@ -2922,23 +2900,53 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 		writeError(response, http.StatusNotFound, "task not found")
 		return
 	}
-	if session, ok := server.providerSessions.get(taskID); ok {
-		server.handleProviderSessionSteer(response, request, found, session)
-		return
-	}
-
-	var input struct {
-		Directive string `json:"directive"`
-		taskContinuationSelectionInput
-	}
+	var input nativeSteerRequest
 	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
 		writeError(response, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if input.Directive == "" {
-		writeError(response, http.StatusBadRequest, "steering directive is required")
+	input.RequestID = strings.TrimSpace(input.RequestID)
+	if input.RequestID == "" {
+		input.RequestID = strings.TrimSpace(request.Header.Get("Idempotency-Key"))
+	}
+	if input.RequestID == "" {
+		input.RequestID = newNativeSteerRequestID()
+	}
+	input.Message = strings.TrimSpace(input.Message)
+	if input.Message == "" {
+		input.Message = strings.TrimSpace(input.Directive)
+	}
+	if input.Message == "" {
+		writeError(response, http.StatusBadRequest, "steer message is required")
 		return
 	}
+	adapter := taskSteeringAdapter(server, found.ID, server.taskConclusionSettlementForID(found.ID))
+	clientSelectionIdentity := canonicalSteeringClientSelectionIdentity(input.ModelProviderID, input.selectedModel(), input.ReasoningEffort)
+	replayIdentity := steeringReplayIdentity{
+		requestID: input.RequestID, operatorMessage: input.Message,
+		clientSelectionIdentity: clientSelectionIdentity,
+		modelProviderID:         input.ModelProviderID, model: input.selectedModel(),
+		requestedReasoningEffort: input.ReasoningEffort,
+	}
+	if record, replayed, replayErr := server.findAcceptedSteeringReplayByIdentity(adapter, replayIdentity); replayErr != nil || replayed {
+		if replayErr != nil {
+			var conflict *steeringRequestConflictError
+			if errors.As(replayErr, &conflict) {
+				writeError(response, http.StatusConflict, conflict.Error())
+			} else {
+				writeTaskError(response, replayErr)
+			}
+			return
+		}
+		writeTaskAcceptedSteering(response, record, "")
+		return
+	}
+	if providerSession, ok := server.providerSessions.get(taskID); ok {
+		server.handleProviderSessionSteer(response, request, found, providerSession, input)
+		return
+	}
+
+	input.Directive = input.Message
 	if profile, profileErr := server.resolveTaskRuntimeProfile(found); profileErr != nil {
 		writeError(response, http.StatusInternalServerError, "load runtime profile")
 		return
@@ -3062,27 +3070,8 @@ func (server *Server) handleSteerTask(response http.ResponseWriter, request *htt
 	})
 }
 
-func (server *Server) handleProviderSessionSteer(response http.ResponseWriter, request *http.Request, found task.Task, session runtime.ProviderSession) {
-	var input nativeSteerRequest
-	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
-		writeError(response, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-	input.RequestID = strings.TrimSpace(input.RequestID)
-	if input.RequestID == "" {
-		input.RequestID = strings.TrimSpace(request.Header.Get("Idempotency-Key"))
-	}
-	if input.RequestID == "" {
-		input.RequestID = newNativeSteerRequestID()
-	}
-	input.Message = strings.TrimSpace(input.Message)
-	if input.Message == "" {
-		input.Message = strings.TrimSpace(input.Directive)
-	}
-	if input.Message == "" {
-		writeError(response, http.StatusBadRequest, "steer message is required")
-		return
-	}
+func (server *Server) handleProviderSessionSteer(response http.ResponseWriter, request *http.Request, found task.Task, session runtime.ProviderSession, input nativeSteerRequest) {
+	clientSelectionIdentity := canonicalSteeringClientSelectionIdentity(input.ModelProviderID, input.selectedModel(), input.ReasoningEffort)
 	// Runtime Plugin / Runtime Profile switches need Config Projection and a
 	// restart. Model Provider changes stay native for Pi when the provider was
 	// projected at startup (ADR 0015); Codex/Claude still restart.
@@ -3098,39 +3087,35 @@ func (server *Server) handleProviderSessionSteer(response http.ResponseWriter, r
 		writeError(response, http.StatusConflict, "native steer requires an active Task")
 		return
 	}
-	mode, err := nativeSteerMode(session.Capabilities())
+
+	currentSelection, err := server.currentTurnSelection(found)
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, "resolve current turn selection")
+		return
+	}
+	runtimeProfile, err := server.resolveTaskRuntimeProfile(found)
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, "resolve Runtime Provider")
+		return
+	}
+	settlement := server.taskConclusionSettlementForID(found.ID)
+	prepared, err := prepareAcceptedNativeSteer(
+		request.Context(), session,
+		providerSelectionRequiresReplacement(runtimeProfile.Provider, currentSelection, selection),
+		input.ForceReplace, settlement,
+	)
 	if err != nil {
 		writeError(response, http.StatusConflict, err.Error())
 		return
 	}
-	if nativeSteerOperation(session, mode) == nil {
+	if nativeSteerOperation(session, prepared.Mode) == nil {
 		writeError(response, http.StatusConflict, "provider session does not support native steer")
 		return
 	}
-
-	// Repeated requests with the same request identity return the durable
-	// current outcome and never create a second queue item. Conflicting content
-	// under the same identity returns a conflict.
-	if record, err := server.steering.ByRequestID(owner.KindTask, found.ID, input.RequestID); err == nil {
-		if conflict := steeringConflictMessage(record, input.Message, selection, owner.SteeringMode(mode)); conflict != "" {
-			writeError(response, http.StatusConflict, conflict)
-			return
-		}
-		sessionID := record.SessionID
-		if sessionID == "" {
-			sessionID = session.SessionID()
-		}
-		writeJSON(response, http.StatusAccepted, struct {
-			RequestID string                      `json:"request_id"`
-			SessionID string                      `json:"session_id"`
-			Mode      runtime.ProviderSessionMode `json:"mode"`
-			Outcome   string                      `json:"outcome"`
-		}{RequestID: input.RequestID, SessionID: sessionID, Mode: runtime.ProviderSessionMode(record.Mode), Outcome: steeringOutcomeFromRecord(record)})
-		return
-	} else if !errors.Is(err, steering.ErrNotFound) {
-		writeError(response, http.StatusInternalServerError, "load accepted steering")
-		return
-	}
+	mode := prepared.Mode
+	expectedProviderTurnID := prepared.ExpectedProviderTurnID
+	releaseSteeringRequest := server.steering.AcquireRequest(owner.KindTask, found.ID, input.RequestID)
+	defer releaseSteeringRequest()
 
 	// Durable acceptance (#194, #200): the operator message and the dispatch
 	// record commit atomically before the request returns 202. The accepted
@@ -3144,15 +3129,20 @@ func (server *Server) handleProviderSessionSteer(response http.ResponseWriter, r
 		"model_provider_id": selection.ModelProviderID, "model": selection.Model,
 		"requested_reasoning_effort": selection.RequestedReasoningEffort,
 	}
-	adapter := taskSteeringAdapter(server, found.ID, server.taskConclusionSettlementForID(found.ID))
-	_, err = server.acceptSteeringDurably(request.Context(), adapter, steering.AcceptRequest{
+	if expectedProviderTurnID != "" {
+		conversationPayload["provider_turn_id"] = expectedProviderTurnID
+	}
+	record, _, err := server.acceptSteeringOrReplay(request.Context(), taskSteeringAdapter(server, found.ID, settlement), steering.AcceptRequest{
 		RequestID:                input.RequestID,
+		ClientSelectionIdentity:  clientSelectionIdentity,
+		OperatorMessage:          input.Message,
 		Message:                  input.Message,
 		Mode:                     owner.SteeringMode(mode),
 		ModelProviderID:          selection.ModelProviderID,
 		Model:                    selection.Model,
 		RequestedReasoningEffort: selection.RequestedReasoningEffort,
 		SessionID:                session.SessionID(),
+		ExpectedProviderTurnID:   expectedProviderTurnID,
 	}, func(tx *sql.Tx) (string, error) {
 		event, eventErr := server.tasks.AppendEventTx(tx, found.ID, task.EventKindConversation, conversationPayload)
 		if eventErr != nil {
@@ -3160,37 +3150,29 @@ func (server *Server) handleProviderSessionSteer(response http.ResponseWriter, r
 		}
 		return event.ID, nil
 	})
-	if errors.Is(err, steering.ErrDuplicateRequest) {
-		// A concurrent duplicate committed first. The same identity rules
-		// apply: matching content replays the durable outcome, conflicting
-		// content is a conflict.
-		replayed, replayErr := server.steering.ByRequestID(owner.KindTask, found.ID, input.RequestID)
-		if replayErr != nil {
-			writeError(response, http.StatusInternalServerError, "load accepted steering")
-			return
-		}
-		if conflict := steeringConflictMessage(replayed, input.Message, selection, owner.SteeringMode(mode)); conflict != "" {
-			writeError(response, http.StatusConflict, conflict)
-			return
-		}
-		writeJSON(response, http.StatusAccepted, struct {
-			RequestID string                      `json:"request_id"`
-			SessionID string                      `json:"session_id"`
-			Mode      runtime.ProviderSessionMode `json:"mode"`
-			Outcome   string                      `json:"outcome"`
-		}{RequestID: input.RequestID, SessionID: replayed.SessionID, Mode: runtime.ProviderSessionMode(replayed.Mode), Outcome: steeringOutcomeFromRecord(replayed)})
-		return
-	}
 	if err != nil {
+		var conflict *steeringRequestConflictError
+		if errors.As(err, &conflict) {
+			writeError(response, http.StatusConflict, conflict.Error())
+			return
+		}
 		writeTaskError(response, err)
 		return
+	}
+	writeTaskAcceptedSteering(response, record, session.SessionID())
+}
+
+func writeTaskAcceptedSteering(response http.ResponseWriter, record *owner.SteeringRecord, fallbackSessionID string) {
+	sessionID := strings.TrimSpace(record.SessionID)
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(fallbackSessionID)
 	}
 	writeJSON(response, http.StatusAccepted, struct {
 		RequestID string                      `json:"request_id"`
 		SessionID string                      `json:"session_id"`
 		Mode      runtime.ProviderSessionMode `json:"mode"`
 		Outcome   string                      `json:"outcome"`
-	}{RequestID: input.RequestID, SessionID: session.SessionID(), Mode: mode, Outcome: "accepted"})
+	}{RequestID: record.RequestID, SessionID: sessionID, Mode: runtime.ProviderSessionMode(record.Mode), Outcome: steeringOutcomeFromRecord(record)})
 }
 
 // nativeSteerOperationFunc is one provider session steer operation selected by
@@ -3282,27 +3264,6 @@ func (server *Server) executeNativeSteerOperation(ctx context.Context, found tas
 		},
 		failOwnerExecution: true,
 	})
-}
-
-// steerReasonFromFailureCode maps the redacted provider failure presentation
-// onto the closed Accepted Steering reason vocabulary. The projected event
-// error_code keeps the presentation code; the durable record stores the closed
-// reason.
-func steerReasonFromFailureCode(code string) owner.SteeringFailureReason {
-	switch code {
-	case "session_closed":
-		return owner.SteeringReasonSessionClosed
-	case "control_conflict":
-		return owner.SteeringReasonControlConflict
-	case "unsupported_reasoning_effort":
-		return owner.SteeringReasonUnsupportedReasoningEffort
-	case "provider_rejected":
-		return owner.SteeringReasonProviderRejected
-	case "provider_control_unavailable":
-		return owner.SteeringReasonProviderControlUnavailable
-	default:
-		return owner.SteeringReasonProviderRejected
-	}
 }
 
 type providerPermissionResponseRequest struct {
@@ -3936,32 +3897,6 @@ func nativeSteerIdempotencyConflict(prior task.Event, message string, selection 
 		return "steer request id already belongs to a different turn selection"
 	}
 	return ""
-}
-
-// nativeSteerFailurePresentation maps provider operation failures to stable,
-// redacted public codes/messages. Raw provider text never crosses this seam.
-func nativeSteerFailurePresentation(operationErr error) (code, message string) {
-	switch {
-	case errors.Is(operationErr, context.DeadlineExceeded):
-		return "timeout", "native steer timed out"
-	case errors.Is(operationErr, context.Canceled):
-		return "server_closing", "native steer canceled"
-	case errors.Is(operationErr, runtime.ErrProviderSessionClosed):
-		return "session_closed", "provider session is closed"
-	case errors.Is(operationErr, runtime.ErrProviderSessionControlConflict):
-		return "control_conflict", "provider session control conflict"
-	}
-	raw := ""
-	if cause := errors.Unwrap(operationErr); cause != nil {
-		raw = cause.Error()
-	} else if operationErr != nil {
-		raw = operationErr.Error()
-	}
-	lower := strings.ToLower(raw)
-	if strings.Contains(lower, "effort") || strings.Contains(lower, "reasoning") {
-		return "unsupported_reasoning_effort", "requested reasoning effort is not supported"
-	}
-	return "provider_rejected", "provider rejected the turn"
 }
 
 func configString(config map[string]any, key string) string {

--- a/internal/owner/steering.go
+++ b/internal/owner/steering.go
@@ -31,12 +31,12 @@ func (state SteeringState) Terminal() bool {
 	return state == SteeringApplied || state == SteeringFailed || state == SteeringActionRequired
 }
 
-
 // SteeringMode is the provider-native steer operation chosen at acceptance.
 type SteeringMode string
 
 const (
-	SteeringModeInTurnSteer         SteeringMode = "in_turn_steer"
+	SteeringModeSendTurn             SteeringMode = "send_turn"
+	SteeringModeInTurnSteer          SteeringMode = "in_turn_steer"
 	SteeringModeInterruptThenReplace SteeringMode = "interrupt_then_replace"
 )
 
@@ -73,6 +73,15 @@ const (
 	// SteeringReasonDeliveryAmbiguous is the action-required reason for a
 	// post-fence request with no durable outcome. It is never replayed.
 	SteeringReasonDeliveryAmbiguous SteeringFailureReason = "delivery_ambiguous"
+	// SteeringReasonTargetTurnCompleted means the accepted same-turn target
+	// settled before the provider received the steering request.
+	SteeringReasonTargetTurnCompleted SteeringFailureReason = "target_turn_completed"
+	// SteeringReasonTargetTurnChanged means a different Runtime Turn replaced
+	// the accepted same-turn target before provider delivery.
+	SteeringReasonTargetTurnChanged SteeringFailureReason = "target_turn_changed"
+	// SteeringReasonActiveTurnNotSteerable means the active review/compact-like
+	// Runtime Turn explicitly rejects native same-turn input.
+	SteeringReasonActiveTurnNotSteerable SteeringFailureReason = "active_turn_not_steerable"
 	// SteeringReasonOwnerStopped means Stop settled the queued request before
 	// delivery.
 	SteeringReasonOwnerStopped SteeringFailureReason = "owner_stopped"
@@ -95,7 +104,9 @@ func ValidSteeringFailureReason(reason SteeringFailureReason) bool {
 		SteeringReasonContinuationUnavailable, SteeringReasonProviderRejected,
 		SteeringReasonUnsupportedReasoningEffort, SteeringReasonSessionClosed,
 		SteeringReasonControlConflict, SteeringReasonDeliveryTimedOut,
-		SteeringReasonDeliveryAmbiguous, SteeringReasonOwnerStopped,
+		SteeringReasonDeliveryAmbiguous, SteeringReasonTargetTurnCompleted,
+		SteeringReasonTargetTurnChanged,
+		SteeringReasonActiveTurnNotSteerable, SteeringReasonOwnerStopped,
 		SteeringReasonOwnerFinished, SteeringReasonOwnerRuntimeLost,
 		SteeringReasonOwnerArchived:
 		return true
@@ -109,24 +120,30 @@ func ValidSteeringFailureReason(reason SteeringFailureReason) bool {
 // by OwnerKind and OwnerID. Conversation Events remain projections of the
 // request and outcome, never the dispatch source of truth.
 type SteeringRecord struct {
-	ID                       string            `json:"id"`
-	OwnerKind                Kind              `json:"owner_kind"`
-	OwnerID                  string            `json:"owner_id"`
-	RequestID                string            `json:"request_id"`
-	Message                  string            `json:"message"`
-	Mode                     SteeringMode      `json:"mode"`
-	ModelProviderID          string            `json:"model_provider_id,omitempty"`
-	Model                    string            `json:"model,omitempty"`
-	RequestedReasoningEffort string            `json:"requested_reasoning_effort,omitempty"`
-	State                    SteeringState     `json:"state"`
-	QueueOrder               int               `json:"queue_order"`
-	ConversationEventID      string            `json:"conversation_event_id,omitempty"`
-	ContinuationID           string            `json:"continuation_id,omitempty"`
-	SessionID                string            `json:"session_id,omitempty"`
-	SendStartedAt            *time.Time        `json:"send_started_at,omitempty"`
-	Result                   map[string]any    `json:"result,omitempty"`
+	ID        string `json:"id"`
+	OwnerKind Kind   `json:"owner_kind"`
+	OwnerID   string `json:"owner_id"`
+	RequestID string `json:"request_id"`
+	// ClientSelectionIdentity is the durable canonical identity of the raw
+	// client-controlled Turn Selection fields. It stays internal because the
+	// public response exposes the resolved selection fields separately.
+	ClientSelectionIdentity  string                `json:"-"`
+	OperatorMessage          string                `json:"operator_message"`
+	Message                  string                `json:"message"`
+	Mode                     SteeringMode          `json:"mode"`
+	ModelProviderID          string                `json:"model_provider_id,omitempty"`
+	Model                    string                `json:"model,omitempty"`
+	RequestedReasoningEffort string                `json:"requested_reasoning_effort,omitempty"`
+	State                    SteeringState         `json:"state"`
+	QueueOrder               int                   `json:"queue_order"`
+	ConversationEventID      string                `json:"conversation_event_id,omitempty"`
+	ContinuationID           string                `json:"continuation_id,omitempty"`
+	SessionID                string                `json:"session_id,omitempty"`
+	ExpectedProviderTurnID   string                `json:"expected_provider_turn_id,omitempty"`
+	SendStartedAt            *time.Time            `json:"send_started_at,omitempty"`
+	Result                   map[string]any        `json:"result,omitempty"`
 	ErrorCode                SteeringFailureReason `json:"error_code,omitempty"`
-	ErrorMessage             string            `json:"error_message,omitempty"`
-	CreatedAt                time.Time         `json:"created_at"`
-	UpdatedAt                time.Time         `json:"updated_at"`
+	ErrorMessage             string                `json:"error_message,omitempty"`
+	CreatedAt                time.Time             `json:"created_at"`
+	UpdatedAt                time.Time             `json:"updated_at"`
 }

--- a/internal/runtime/codex_assisted.go
+++ b/internal/runtime/codex_assisted.go
@@ -134,7 +134,8 @@ func (s *CodexProviderSession) HandleEvent(event SandboxBridgeEvent, emit Provid
 }
 
 func (s *CodexProviderSession) emitCodexRuntimeOutput(event SandboxBridgeEvent, emit ProviderSessionEmit) {
-	if strings.ToLower(strings.TrimSpace(event.Method)) != "item/completed" || len(event.Params) == 0 {
+	method := strings.ToLower(strings.TrimSpace(event.Method))
+	if (method != "item/started" && method != "item/completed") || len(event.Params) == 0 {
 		return
 	}
 	params := map[string]any{}
@@ -145,12 +146,26 @@ func (s *CodexProviderSession) emitCodexRuntimeOutput(event SandboxBridgeEvent, 
 	if !ok {
 		return
 	}
-	switch strings.ToLower(providerJSONValue(item, "type")) {
+	itemType := strings.ToLower(providerJSONValue(item, "type"))
+	text := string(event.Params)
+	switch itemType {
 	case "agentmessage":
-		if providerJSONValue(item, "text") == "" {
+		if method != "item/completed" || providerJSONValue(item, "text") == "" {
 			return
 		}
-	case "commandexecution", "mcptoolcall", "filechange", "websearch":
+	case "commandexecution", "mcptoolcall":
+	case "filechange", "websearch":
+		if method != "item/completed" {
+			return
+		}
+	case "reasoning":
+		if method != "item/completed" {
+			return
+		}
+		text = codexReasoningRuntimeOutput(params, item)
+		if text == "" {
+			return
+		}
 	default:
 		return
 	}
@@ -173,8 +188,49 @@ func (s *CodexProviderSession) emitCodexRuntimeOutput(event SandboxBridgeEvent, 
 	emit(task.EventKindRuntimeOutput, task.EventPayload{
 		"provider": s.provider, "provider_event": event.Method,
 		"session_id": sessionID, "provider_turn_id": turnID,
-		"stream": "codex_app_server", "text": string(event.Params),
+		"stream": "codex_app_server", "text": text,
 	})
+}
+
+func codexReasoningRuntimeOutput(params, item map[string]any) string {
+	summary, ok := item["summary"]
+	if !ok || strings.TrimSpace(providerReasoningSummary(summary)) == "" {
+		return ""
+	}
+	minimalItem := map[string]any{
+		"type":    "reasoning",
+		"id":      providerJSONValue(item, "id"),
+		"summary": summary,
+	}
+	minimal := map[string]any{"item": minimalItem}
+	if threadID := providerJSONValue(params, "threadId", "thread_id"); threadID != "" {
+		minimal["threadId"] = threadID
+	}
+	if turnID := providerJSONValue(params, "turnId", "turn_id"); turnID != "" {
+		minimal["turnId"] = turnID
+	}
+	encoded, err := json.Marshal(minimal)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func providerReasoningSummary(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, part := range typed {
+			if text, ok := part.(string); ok && strings.TrimSpace(text) != "" {
+				parts = append(parts, strings.TrimSpace(text))
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return ""
+	}
 }
 
 func (s *CodexProviderSession) acceptCodexAssisted(event codexAssistedEvent) {

--- a/internal/runtime/host_session_bridge.go
+++ b/internal/runtime/host_session_bridge.go
@@ -323,13 +323,9 @@ func (b *HostSessionBridge) readLoop(reader io.Reader) {
 			continue
 		}
 		if event.ID != "" {
-			var responseErr error
-			if len(event.Error) > 0 && string(event.Error) != "null" {
-				responseErr = &SandboxBridgeRPCError{RequestID: event.ID}
-			}
 			b.finish(event.ID, SandboxBridgeResponse{
 				JSONRPC: event.JSONRPC, ID: event.ID, Result: event.Result, Error: event.Error,
-			}, responseErr)
+			}, nil)
 			continue
 		}
 		if b.config.ProtocolEmit != nil {

--- a/internal/runtime/host_session_bridge_test.go
+++ b/internal/runtime/host_session_bridge_test.go
@@ -48,6 +48,36 @@ done
 	}
 }
 
+func TestHostSessionBridgeReturnsJSONRPCErrorAsResponse(t *testing.T) {
+	skipUnlessPOSIXProcessDoubles(t)
+	root := t.TempDir()
+	script := filepath.Join(root, "error-rpc.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  printf '{"jsonrpc":"2.0","id":"%s","error":{"code":-32601,"message":"Method not found"}}\n' "$id"
+done
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bridge, err := runtime.NewHostSessionBridge(runtime.HostSessionBridgeConfig{TaskID: "task-host-rpc-error", Program: script})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Close(context.Background())
+
+	response, err := bridge.Send(context.Background(), runtime.SandboxBridgeRequest{ID: "req-rpc-error", Method: "turn/steer"})
+	if err != nil {
+		t.Fatalf("JSON-RPC error was returned as a transport error: %v", err)
+	}
+	if string(response.Error) != `{"code":-32601,"message":"Method not found"}` {
+		t.Fatalf("response error = %s", response.Error)
+	}
+}
+
 func TestHostSessionBridgeRegistryBindsOneProcessPerTask(t *testing.T) {
 	skipUnlessPOSIXProcessDoubles(t)
 	root := t.TempDir()

--- a/internal/runtime/provider_adapters.go
+++ b/internal/runtime/provider_adapters.go
@@ -35,6 +35,10 @@ type providerWireMethods struct {
 	steer      string
 	permission string
 	params     func(string, string, ProviderSessionRequest) map[string]any
+	// steerParams is separate because provider-native same-turn steering can
+	// have a narrower schema than starting a new turn. When nil, params is used.
+	steerParams               func(string, string, ProviderSessionRequest) map[string]any
+	steerRequiresExpectedTurn bool
 	// prepareSend optionally issues setup wire methods before the primary send
 	// method (for example Pi set_model → set_thinking_level before prompt).
 	prepareSend func(context.Context, ProviderSessionTransport, string, string, string, ProviderSessionRequest) error
@@ -60,29 +64,32 @@ type providerSettlement struct {
 // providerSessionAdapter implements the shared lifecycle, idempotency, and
 // event semantics. Provider wrappers below only supply native wire mappings.
 type providerSessionAdapter struct {
-	mu                sync.Mutex
-	transport         ProviderSessionTransport
-	provider          string
-	methods           providerWireMethods
-	capabilities      runtimeplugin.Capabilities
-	sessionID         string
-	activeTurnID      string
-	closed            bool
-	active            bool
-	activeRequestID   string
-	activeMode        ProviderSessionMode
-	activeFingerprint string
-	calls             map[string]providerSessionCallResult
-	requests          map[string]providerSessionRequestIdentity
-	eventSink         ProviderSessionEmit
-	observationSink   ProviderSessionObserve
-	requestTurnKind   map[string]RuntimeTurnKind
-	providerTurnKind  map[string]RuntimeTurnKind
-	requestLineage    map[string]ProviderSessionTurnLineage
-	providerLineage   map[string]ProviderSessionTurnLineage
-	settlements       map[string]providerSettlement
-	settlementSeq     uint64
-	settlementChanged chan struct{}
+	mu                        sync.Mutex
+	transport                 ProviderSessionTransport
+	provider                  string
+	methods                   providerWireMethods
+	capabilities              runtimeplugin.Capabilities
+	sessionID                 string
+	activeTurnID              string
+	closed                    bool
+	active                    bool
+	activeRequestID           string
+	activeMode                ProviderSessionMode
+	activeFingerprint         string
+	calls                     map[string]providerSessionCallResult
+	requests                  map[string]providerSessionRequestIdentity
+	eventSink                 ProviderSessionEmit
+	observationSink           ProviderSessionObserve
+	requestTurnKind           map[string]RuntimeTurnKind
+	providerTurnKind          map[string]RuntimeTurnKind
+	requestLineage            map[string]ProviderSessionTurnLineage
+	providerLineage           map[string]ProviderSessionTurnLineage
+	settlements               map[string]providerSettlement
+	startGeneration           uint64
+	pendingStartGeneration    uint64
+	pendingStartTerminalTurns map[string]struct{}
+	settlementSeq             uint64
+	settlementChanged         chan struct{}
 }
 
 func newProviderSessionAdapter(provider string, transport ProviderSessionTransport, sessionID, activeTurnID string, capabilities runtimeplugin.Capabilities, methods providerWireMethods) *providerSessionAdapter {
@@ -124,7 +131,11 @@ func (s *providerSessionAdapter) BindContinuation(continuationID string) error {
 	return nil
 }
 
-func (s *providerSessionAdapter) Capabilities() runtimeplugin.Capabilities { return s.capabilities }
+func (s *providerSessionAdapter) Capabilities() runtimeplugin.Capabilities {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.capabilities
+}
 
 func (s *providerSessionAdapter) SetEventSink(sink ProviderSessionEmit) {
 	s.mu.Lock()
@@ -271,7 +282,107 @@ func (s *providerSessionAdapter) InterruptThenReplace(ctx context.Context, reque
 }
 
 func (s *providerSessionAdapter) SteerInTurn(ctx context.Context, request ProviderSessionRequest, emit ProviderSessionEmit) (ProviderSessionResult, error) {
-	return s.run(ctx, ProviderSessionModeInTurnSteer, ProviderSessionCapabilityInTurnSteer, request, emit, s.methods.steer)
+	request.RequestID = strings.TrimSpace(request.RequestID)
+	request.TurnKind = normalizeRuntimeTurnKind(request.TurnKind)
+	fingerprint := providerSessionRequestFingerprint(request)
+	if request.RequestID != "" {
+		if cached, ok, cacheErr := s.cached(request.RequestID, ProviderSessionModeInTurnSteer, fingerprint); cacheErr != nil {
+			return ProviderSessionResult{}, cacheErr
+		} else if ok {
+			return cached.result, cached.err
+		}
+	}
+	if s.methods.steerRequiresExpectedTurn {
+		s.mu.Lock()
+		closed, activeTurnID := s.closed, strings.TrimSpace(s.activeTurnID)
+		s.mu.Unlock()
+		if closed {
+			return ProviderSessionResult{}, ErrProviderSessionClosed
+		}
+		if activeTurnID == "" {
+			return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: ProviderSessionModeInTurnSteer, Cause: ErrProviderTurnUnavailable}
+		}
+		expectedTurnID := strings.TrimSpace(request.ProviderTurnID)
+		if expectedTurnID == "" {
+			return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: ProviderSessionModeInTurnSteer, Cause: ErrInvalidProviderSessionRequest}
+		} else if expectedTurnID != activeTurnID {
+			return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: ProviderSessionModeInTurnSteer, Cause: &ProviderTurnChangedError{
+				ExpectedTurnID: expectedTurnID,
+				ActiveTurnID:   activeTurnID,
+			}}
+		}
+	}
+	var deferredFailureKind task.EventKind
+	var deferredFailure task.EventPayload
+	steerEmit := func(kind task.EventKind, payload task.EventPayload) {
+		if payloadOutcomeValue(payload) == "failed" {
+			deferredFailureKind, deferredFailure = kind, cloneProviderEventPayload(payload)
+			return
+		}
+		s.forwardEvent(emit, kind, payload)
+	}
+	result, err := s.run(ctx, ProviderSessionModeInTurnSteer, ProviderSessionCapabilityInTurnSteer, request, steerEmit, s.methods.steer)
+	if !errors.Is(err, ErrProviderMethodUnavailable) || !s.Capabilities().InterruptThenReplace {
+		if deferredFailure != nil {
+			s.forwardEvent(emit, deferredFailureKind, deferredFailure)
+		}
+		return result, err
+	}
+
+	// A JSON-RPC method-not-found response proves that turn/steer did not apply
+	// the message. Fall back safely for this same Accepted Steering request. The
+	// provider adapter uses a deterministic internal identity because the public
+	// request id is already bound to the attempted in-turn operation; projected
+	// Events keep the original public identity.
+	fallbackRequest := request
+	fallbackRequest.RequestID = request.RequestID + ":interrupt-replace-fallback"
+	// The attempted same-turn steer is Harness control, but its safe fallback
+	// starts a replacement Turn from the operator message. That replacement is
+	// Work under ADR 0018.
+	fallbackRequest.TurnKind = RuntimeTurnKindWork
+	fallbackEmit := func(kind task.EventKind, payload task.EventPayload) {
+		projected := cloneProviderEventPayload(payload)
+		projected["request_id"] = request.RequestID
+		s.forwardEvent(emit, kind, projected)
+	}
+	fallback, fallbackErr := s.InterruptThenReplace(ctx, fallbackRequest, fallbackEmit)
+	if fallbackErr != nil {
+		return ProviderSessionResult{}, fallbackErr
+	}
+	fallback.RequestID = request.RequestID
+	publicFallbackRequest := request
+	publicFallbackRequest.TurnKind = RuntimeTurnKindWork
+	s.recordProviderSessionTurnKind(request.RequestID, fallback.ProviderTurnID, publicFallbackRequest.TurnKind)
+	s.recordProviderSessionTurnLineage(publicFallbackRequest, fallback.ProviderTurnID)
+	// Replace the cached method-unavailable outcome with the successful fallback
+	// so a direct retry of the same provider request remains idempotent even
+	// after the replacement Turn changes the active provider Turn identity.
+	s.store(request.RequestID, ProviderSessionModeInTurnSteer, fingerprint, fallback, nil)
+	return fallback, nil
+}
+
+func payloadOutcomeValue(payload task.EventPayload) string {
+	value, _ := payload["outcome"].(string)
+	return strings.TrimSpace(value)
+}
+
+func cloneProviderEventPayload(payload task.EventPayload) task.EventPayload {
+	cloned := make(task.EventPayload, len(payload))
+	for key, value := range payload {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func (s *providerSessionAdapter) forwardEvent(emit ProviderSessionEmit, kind task.EventKind, payload task.EventPayload) {
+	if emit == nil {
+		s.mu.Lock()
+		emit = s.eventSink
+		s.mu.Unlock()
+	}
+	if emit != nil {
+		emit(kind, payload)
+	}
 }
 
 func (s *providerSessionAdapter) RespondPermission(ctx context.Context, request ProviderSessionRequest, emit ProviderSessionEmit) (ProviderSessionResult, error) {
@@ -289,6 +400,9 @@ func (s *providerSessionAdapter) Close(ctx context.Context) error {
 		return ErrProviderSessionControlConflict
 	}
 	s.closed = true
+	s.activeTurnID = ""
+	s.pendingStartGeneration = 0
+	s.pendingStartTerminalTurns = nil
 	transport := s.transport
 	s.mu.Unlock()
 	if transport == nil {
@@ -302,6 +416,21 @@ func (s *providerSessionAdapter) ControlBusy() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.active
+}
+
+// TurnBusy reports whether a control RPC or provider Runtime Turn is active.
+func (s *providerSessionAdapter) TurnBusy() bool {
+	return s.TurnState().TurnBusy()
+}
+
+// TurnState returns one atomic provider session Turn snapshot.
+func (s *providerSessionAdapter) TurnState() ProviderSessionTurnState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return ProviderSessionTurnState{
+		SessionID: s.sessionID, ActiveTurnID: s.activeTurnID,
+		ActiveTurnKind: s.providerTurnKind[s.activeTurnID], ControlBusy: s.active,
+	}
 }
 
 // SessionClosed reports whether Close has completed on this handle.
@@ -391,8 +520,12 @@ func (s *providerSessionAdapter) run(ctx context.Context, mode ProviderSessionMo
 		s.emit(emit, mode, "failed", request.RequestID, s.currentTurn())
 		return ProviderSessionResult{}, err
 	}
-	s.recordProviderSessionTurnKind(request.RequestID, result.ProviderTurnID, request.TurnKind)
-	s.recordProviderSessionTurnLineage(request, result.ProviderTurnID)
+	// Same-turn steering correlates a control request with an existing provider
+	// Work Turn. It must not reclassify or replace that Turn's original lineage.
+	if mode != ProviderSessionModeInTurnSteer {
+		s.recordProviderSessionTurnKind(request.RequestID, result.ProviderTurnID, request.TurnKind)
+		s.recordProviderSessionTurnLineage(request, result.ProviderTurnID)
+	}
 	outcome := "acknowledged"
 	if mode == ProviderSessionModeSendTurn {
 		outcome = "started"
@@ -437,7 +570,11 @@ func (s *providerSessionAdapter) native(ctx context.Context, mode ProviderSessio
 			return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: mode, Cause: err}
 		}
 	}
-	params := s.methods.params(sessionID, activeTurnID, request)
+	paramsBuilder := s.methods.params
+	if mode == ProviderSessionModeInTurnSteer && s.methods.steerParams != nil {
+		paramsBuilder = s.methods.steerParams
+	}
+	params := paramsBuilder(sessionID, activeTurnID, request)
 	if mode == ProviderSessionModeInterruptTurn || mode == ProviderSessionModeInterruptThenReplace && strings.HasSuffix(wireID, ":interrupt") {
 		if request.ProviderTurnID != "" {
 			params["turnId"] = request.ProviderTurnID
@@ -448,12 +585,40 @@ func (s *providerSessionAdapter) native(ctx context.Context, mode ProviderSessio
 	if err != nil {
 		return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: mode, Cause: err}
 	}
+	startGeneration := uint64(0)
+	if method == s.methods.send && mode != ProviderSessionModeInTurnSteer {
+		s.mu.Lock()
+		s.startGeneration++
+		startGeneration = s.startGeneration
+		s.pendingStartGeneration = startGeneration
+		s.pendingStartTerminalTurns = make(map[string]struct{})
+		s.mu.Unlock()
+	}
+	clearPendingStart := func() {
+		if startGeneration == 0 {
+			return
+		}
+		s.mu.Lock()
+		if s.pendingStartGeneration == startGeneration {
+			s.pendingStartGeneration = 0
+			s.pendingStartTerminalTurns = nil
+		}
+		s.mu.Unlock()
+	}
 	response, err := transport.Send(ctx, SandboxBridgeRequest{ID: wireID, Method: method, Params: encoded})
 	if err != nil {
+		clearPendingStart()
 		return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: mode, Cause: err}
 	}
 	if len(response.Error) > 0 && string(response.Error) != "null" {
-		return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: mode, Cause: &SandboxBridgeRPCError{RequestID: wireID}}
+		clearPendingStart()
+		rpcErr := sandboxBridgeRPCError(wireID, response.Error)
+		if mode == ProviderSessionModeInTurnSteer && errors.Is(rpcErr, ErrProviderMethodUnavailable) {
+			s.mu.Lock()
+			s.capabilities.InTurnSteer = false
+			s.mu.Unlock()
+		}
+		return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: mode, Cause: rpcErr}
 	}
 	metadata := map[string]any{}
 	if len(response.Result) > 0 {
@@ -466,14 +631,56 @@ func (s *providerSessionAdapter) native(ctx context.Context, mode ProviderSessio
 	if turnID == "" {
 		turnID = activeTurnID
 	}
+	if mode == ProviderSessionModeInTurnSteer {
+		expectedTurnID := strings.TrimSpace(request.ProviderTurnID)
+		if expectedTurnID != "" && turnID != expectedTurnID {
+			return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: mode, Cause: &ProviderTurnChangedError{
+				ExpectedTurnID: expectedTurnID,
+				ActiveTurnID:   turnID,
+			}}
+		}
+	}
 	newSessionID := s.methods.sessionID(metadata)
 	if newSessionID == "" {
 		newSessionID = sessionID
 	}
 	s.mu.Lock()
-	s.sessionID, s.activeTurnID = newSessionID, turnID
+	s.sessionID = newSessionID
+	if mode != ProviderSessionModeInTurnSteer {
+		_, terminal := s.pendingStartTerminalTurns[providerSettlementKey(newSessionID, turnID)]
+		if s.pendingStartGeneration == startGeneration {
+			s.pendingStartGeneration = 0
+			s.pendingStartTerminalTurns = nil
+		}
+		if terminal {
+			s.activeTurnID = ""
+		} else {
+			s.activeTurnID = turnID
+		}
+	}
 	s.mu.Unlock()
 	return ProviderSessionResult{RequestID: request.RequestID, SessionID: newSessionID, ProviderTurnID: turnID, Mode: mode, Outcome: "acknowledged"}, nil
+}
+
+func sandboxBridgeRPCError(requestID string, raw json.RawMessage) *SandboxBridgeRPCError {
+	kind := SandboxBridgeRPCErrorUnknown
+	var envelope struct {
+		Code int `json:"code"`
+	}
+	_ = json.Unmarshal(raw, &envelope)
+	lower := strings.ToLower(string(raw))
+	switch {
+	case envelope.Code == -32601 || strings.Contains(lower, "method not found"):
+		kind = SandboxBridgeRPCErrorMethodUnavailable
+	case strings.Contains(lower, "activeturnnotsteerable") || strings.Contains(lower, "active_turn_not_steerable"):
+		kind = SandboxBridgeRPCErrorTurnNotSteerable
+	case strings.Contains(lower, "no active turn"):
+		kind = SandboxBridgeRPCErrorTargetTurnCompleted
+	case strings.Contains(lower, "expectedturnid") || strings.Contains(lower, "expected_turn_id") ||
+		strings.Contains(lower, "active turn mismatch"):
+		kind = SandboxBridgeRPCErrorTargetTurnChanged
+	}
+	return &SandboxBridgeRPCError{RequestID: requestID, Kind: kind}
 }
 
 func providerTurnSettled(metadata map[string]any) bool {
@@ -636,11 +843,6 @@ func (s *providerSessionAdapter) currentTurn() string {
 }
 
 func (s *providerSessionAdapter) emit(emit ProviderSessionEmit, mode ProviderSessionMode, outcome, requestID, turnID string) {
-	if emit == nil {
-		s.mu.Lock()
-		emit = s.eventSink
-		s.mu.Unlock()
-	}
 	kind := task.EventKindLifecycle
 	if mode == ProviderSessionModeInterruptTurn || mode == ProviderSessionModeInterruptThenReplace || mode == ProviderSessionModeInTurnSteer {
 		kind = task.EventKindSteering
@@ -648,9 +850,7 @@ func (s *providerSessionAdapter) emit(emit ProviderSessionEmit, mode ProviderSes
 	if strings.TrimSpace(turnID) == "" {
 		turnID = s.currentTurn()
 	}
-	if emit != nil {
-		emit(kind, task.EventPayload{"provider": s.provider, "request_id": requestID, "session_id": s.SessionID(), "provider_turn_id": turnID, "mode": string(mode), "outcome": outcome})
-	}
+	s.forwardEvent(emit, kind, task.EventPayload{"provider": s.provider, "request_id": requestID, "session_id": s.SessionID(), "provider_turn_id": turnID, "mode": string(mode), "outcome": outcome})
 }
 
 // HandleEvent maps provider notifications to the normalized lifecycle channel.
@@ -738,9 +938,12 @@ func (s *providerSessionAdapter) HandleEvent(event SandboxBridgeEvent, emit Prov
 	}
 	if currentSession == "" || currentSession == sessionID {
 		if terminal {
-			// A finished turn is no longer active. Keeping the completed id made
-			// idle interrupt_then_replace call interrupt with a stale turn and
-			// fail Claude ("active turn identity mismatch").
+			// A terminal notification can race the matching turn/start response.
+			// Keep only operation-local terminal identities for the one pending
+			// start generation; arbitrary historical Turn ids never accumulate.
+			if s.pendingStartGeneration != 0 && sessionID != "" && turnID != "" && len(s.pendingStartTerminalTurns) < 8 {
+				s.pendingStartTerminalTurns[providerSettlementKey(sessionID, turnID)] = struct{}{}
+			}
 			if currentTurn == "" || currentTurn == turnID {
 				s.activeTurnID = ""
 			}
@@ -832,7 +1035,7 @@ func NewCodexProviderSession(config CodexProviderSessionConfig) *CodexProviderSe
 		threadID = strings.TrimSpace(config.SessionID)
 	}
 	methods := providerWireMethods{
-		send: "turn/start", interrupt: "turn/interrupt", permission: "item/permission/respond",
+		send: "turn/start", interrupt: "turn/interrupt", steer: "turn/steer", permission: "item/permission/respond",
 		params: func(sessionID, turnID string, request ProviderSessionRequest) map[string]any {
 			params := map[string]any{
 				"threadId": sessionID,
@@ -862,7 +1065,23 @@ func NewCodexProviderSession(config CodexProviderSessionConfig) *CodexProviderSe
 			params["sandboxPolicy"] = map[string]any{"type": "dangerFullAccess"}
 			return params
 		},
-		turnID: nestedTurnID, sessionID: func(record map[string]any) string {
+		steerParams: func(sessionID, turnID string, request ProviderSessionRequest) map[string]any {
+			expectedTurnID := strings.TrimSpace(request.ProviderTurnID)
+			if expectedTurnID == "" {
+				expectedTurnID = strings.TrimSpace(turnID)
+			}
+			return map[string]any{
+				"threadId":       sessionID,
+				"expectedTurnId": expectedTurnID,
+				"input": []any{map[string]any{
+					"type": "text",
+					"text": request.Message,
+				}},
+				"clientUserMessageId": request.RequestID,
+			}
+		},
+		steerRequiresExpectedTurn: true,
+		turnID:                    nestedTurnID, sessionID: func(record map[string]any) string {
 			return providerJSONValue(record, "threadId", "thread_id", "sessionId", "session_id")
 		},
 	}

--- a/internal/runtime/provider_adapters_test.go
+++ b/internal/runtime/provider_adapters_test.go
@@ -140,6 +140,310 @@ func TestCodexProviderSessionMapsTurnStartAndInterrupt(t *testing.T) {
 	}
 }
 
+func TestCodexProviderSessionSteersTheExpectedActiveTurn(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"turn/steer": {Result: json.RawMessage(`{"turnId":"turn-live"}`)},
+	}}
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: transport, SessionID: "thread-1", ThreadID: "thread-1", ActiveTurnID: "turn-live",
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, InterruptTurn: true,
+			InterruptThenReplace: true, InTurnSteer: true,
+		},
+	})
+
+	result, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+		RequestID:                "steer-1",
+		Message:                  "focus on the auth path",
+		ProviderTurnID:           "turn-live",
+		Model:                    "must-not-be-sent",
+		RequestedReasoningEffort: "must-not-be-sent",
+	}, nil)
+	if err != nil {
+		t.Fatalf("steer active turn: %v", err)
+	}
+	if result.Mode != ProviderSessionModeInTurnSteer || result.ProviderTurnID != "turn-live" || result.Outcome != "acknowledged" {
+		t.Fatalf("result = %#v", result)
+	}
+	requests := transport.snapshot()
+	if len(requests) != 1 || requests[0].Method != "turn/steer" {
+		t.Fatalf("wire requests = %#v", requests)
+	}
+	var params map[string]any
+	if err := json.Unmarshal(requests[0].Params, &params); err != nil {
+		t.Fatal(err)
+	}
+	if params["threadId"] != "thread-1" || params["expectedTurnId"] != "turn-live" || params["clientUserMessageId"] != "steer-1" {
+		t.Fatalf("steer params = %#v", params)
+	}
+	input, ok := params["input"].([]any)
+	if !ok || len(input) != 1 {
+		t.Fatalf("steer input = %#v", params["input"])
+	}
+	item, ok := input[0].(map[string]any)
+	if !ok || item["type"] != "text" || item["text"] != "focus on the auth path" {
+		t.Fatalf("steer input item = %#v", input[0])
+	}
+	for _, forbidden := range []string{"turnId", "model", "effort", "approvalPolicy", "sandboxPolicy", "cwd"} {
+		if _, exists := params[forbidden]; exists {
+			t.Fatalf("turn/steer sent forbidden %q in %#v", forbidden, params)
+		}
+	}
+	if !session.TurnBusy() {
+		t.Fatal("same-turn steer cleared active Runtime Turn")
+	}
+}
+
+func TestCodexProviderSessionRejectsMissingExpectedTurnFence(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"turn/steer": {Result: json.RawMessage(`{"turnId":"turn-live"}`)},
+	}}
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: transport, SessionID: "thread-1", ThreadID: "thread-1", ActiveTurnID: "turn-live",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InTurnSteer: true},
+	})
+	_, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{RequestID: "steer-no-fence", Message: "focus"}, nil)
+	if !errors.Is(err, ErrInvalidProviderSessionRequest) {
+		t.Fatalf("steer error = %v, want invalid request", err)
+	}
+	if requests := transport.snapshot(); len(requests) != 0 {
+		t.Fatalf("missing fence reached provider transport: %#v", requests)
+	}
+}
+
+func TestCodexProviderSessionMapsStructuredNonSteerableError(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"turn/steer": {Error: json.RawMessage(`{"code":-32000,"message":"provider detail must stay private","data":{"reason":"activeTurnNotSteerable","turnKind":"review"}}`)},
+	}}
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: transport, SessionID: "thread-1", ThreadID: "thread-1", ActiveTurnID: "turn-review",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InterruptThenReplace: true, InTurnSteer: true},
+	})
+	_, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+		RequestID: "steer-review", Message: "focus", ProviderTurnID: "turn-review",
+	}, nil)
+	if !errors.Is(err, ErrProviderTurnNotSteerable) {
+		t.Fatalf("steer error = %v, want active Turn not steerable", err)
+	}
+	if requests := transport.snapshot(); len(requests) != 1 || requests[0].Method != "turn/steer" {
+		t.Fatalf("requests = %#v, want only turn/steer", requests)
+	}
+	if strings.Contains(err.Error(), "provider detail") {
+		t.Fatalf("typed error leaked provider message: %v", err)
+	}
+}
+
+func TestCodexProviderSessionFallsBackAfterSteerMethodNotFound(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"turn/steer":     {Error: json.RawMessage(`{"code":-32601,"message":"Method not found"}`)},
+		"turn/interrupt": {Result: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-live"}`)},
+		"turn/start":     {Result: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-replacement"}}`)},
+	}, notifications: map[string]SandboxBridgeEvent{
+		"turn/interrupt": {Method: "turn/completed", Params: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-live","status":"interrupted"}}`)},
+	}}
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: transport, SessionID: "thread-1", ThreadID: "thread-1", ActiveTurnID: "turn-live",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InterruptThenReplace: true, InTurnSteer: true},
+	})
+	bindFakeProviderEvents(transport, session)
+	var emits []task.EventPayload
+	result, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+		RequestID: "steer-old-server", Message: "focus", ProviderTurnID: "turn-live", TurnKind: RuntimeTurnKindControl,
+	}, func(_ task.EventKind, payload task.EventPayload) { emits = append(emits, payload) })
+	if err != nil {
+		t.Fatalf("steer fallback: %v", err)
+	}
+	if result.Mode != ProviderSessionModeInterruptThenReplace || result.RequestID != "steer-old-server" || result.ProviderTurnID != "turn-replacement" {
+		t.Fatalf("fallback result = %#v", result)
+	}
+	if kind, ok := session.ResolveProviderSessionTurnKind("steer-old-server", "turn-replacement"); !ok || kind != RuntimeTurnKindWork {
+		t.Fatalf("fallback replacement Turn kind = %q, ok=%v, want work", kind, ok)
+	}
+	if session.Capabilities().InTurnSteer {
+		t.Fatal("turn/steer capability remained enabled after method-not-found")
+	}
+	requests := transport.snapshot()
+	if len(requests) != 3 || requests[0].Method != "turn/steer" || requests[1].Method != "turn/interrupt" || requests[2].Method != "turn/start" {
+		t.Fatalf("fallback requests = %#v", requests)
+	}
+	for _, event := range emits {
+		if event["outcome"] == "failed" {
+			t.Fatalf("safe fallback projected a failed event: %#v", emits)
+		}
+		if event["request_id"] != "steer-old-server" {
+			t.Fatalf("fallback event lost public request identity: %#v", event)
+		}
+	}
+	replayed, replayErr := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+		RequestID: "steer-old-server", Message: "focus", ProviderTurnID: "turn-live", TurnKind: RuntimeTurnKindControl,
+	}, nil)
+	if replayErr != nil || replayed.Mode != ProviderSessionModeInterruptThenReplace || replayed.ProviderTurnID != "turn-replacement" {
+		t.Fatalf("fallback replay = %#v, err=%v", replayed, replayErr)
+	}
+	if got := len(transport.snapshot()); got != 3 {
+		t.Fatalf("fallback replay sent %d wire requests, want 3 total", got)
+	}
+}
+
+func TestCodexProviderSessionSteerResponseDoesNotResurrectCompletedTurn(t *testing.T) {
+	var session *CodexProviderSession
+	transport := &fakeProviderTransport{send: func(_ context.Context, request SandboxBridgeRequest) (SandboxBridgeResponse, error) {
+		if request.Method != "turn/steer" {
+			return SandboxBridgeResponse{}, errors.New("unexpected method " + request.Method)
+		}
+		session.HandleEvent(SandboxBridgeEvent{Method: "turn/completed", Params: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-live","status":"completed"}}`)}, nil)
+		return SandboxBridgeResponse{Result: json.RawMessage(`{"turnId":"turn-live"}`)}, nil
+	}}
+	session = NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: transport, SessionID: "thread-1", ThreadID: "thread-1", ActiveTurnID: "turn-live",
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, InterruptTurn: true,
+			InterruptThenReplace: true, InTurnSteer: true,
+		},
+	})
+
+	if _, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+		RequestID: "steer-race", ProviderTurnID: "turn-live", Message: "one more check",
+	}, nil); err != nil {
+		t.Fatalf("steer active turn: %v", err)
+	}
+	if session.TurnBusy() {
+		t.Fatal("turn/steer response resurrected a provider Turn completed before the response")
+	}
+}
+
+func TestCodexProviderSessionRejectsSteerWithoutTheExpectedActiveTurn(t *testing.T) {
+	tests := []struct {
+		name       string
+		activeTurn string
+		expected   string
+		wantErr    error
+	}{
+		{name: "no active turn", expected: "turn-finished", wantErr: ErrProviderTurnUnavailable},
+		{name: "target changed", activeTurn: "turn-new", expected: "turn-old", wantErr: ErrProviderTurnChanged},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &fakeProviderTransport{}
+			session := NewCodexProviderSession(CodexProviderSessionConfig{
+				Transport: transport, SessionID: "thread-1", ThreadID: "thread-1", ActiveTurnID: test.activeTurn,
+				Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InTurnSteer: true},
+			})
+			_, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+				RequestID: "steer-target", ProviderTurnID: test.expected, Message: "continue",
+			}, nil)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("error = %v, want %v", err, test.wantErr)
+			}
+			if calls := transport.snapshot(); len(calls) != 0 {
+				t.Fatalf("invalid target sent provider request: %#v", calls)
+			}
+		})
+	}
+}
+
+func TestCodexProviderSessionSteerPreservesTheActiveWorkTurnLineage(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"turn/start": {Result: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-live"}}`)},
+		"turn/steer": {Result: json.RawMessage(`{"turnId":"turn-live"}`)},
+	}}
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: transport, SessionID: "thread-1", ThreadID: "thread-1",
+		Capabilities: runtimeplugin.Capabilities{
+			PersistentSession: true, SendTurn: true, InterruptTurn: true,
+			InterruptThenReplace: true, InTurnSteer: true,
+		},
+	})
+	if _, err := session.SendTurn(context.Background(), ProviderSessionRequest{
+		RequestID: "work-1", Message: "inspect", TurnKind: RuntimeTurnKindWork,
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+		RequestID: "steer-control", ProviderTurnID: "turn-live", Message: "focus", TurnKind: RuntimeTurnKindControl,
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if kind, ok := session.ResolveProviderSessionTurnKind("", "turn-live"); !ok || kind != RuntimeTurnKindWork {
+		t.Fatalf("active provider Turn kind = %q, ok=%v", kind, ok)
+	}
+	lineage, ok := session.ResolveProviderSessionTurnLineage("", "turn-live")
+	if !ok || lineage.RequestID != "work-1" || lineage.ProviderTurnID != "turn-live" {
+		t.Fatalf("active provider Turn lineage = %#v, ok=%v", lineage, ok)
+	}
+}
+
+func TestCodexProviderSessionRejectsSteerResponseForAnotherTurn(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"turn/steer": {Result: json.RawMessage(`{"turnId":"turn-other"}`)},
+	}}
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: transport, SessionID: "thread-1", ThreadID: "thread-1", ActiveTurnID: "turn-live",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InTurnSteer: true},
+	})
+	_, err := session.SteerInTurn(context.Background(), ProviderSessionRequest{
+		RequestID: "steer-response-mismatch", ProviderTurnID: "turn-live", Message: "continue",
+	}, nil)
+	if !errors.Is(err, ErrProviderTurnChanged) {
+		t.Fatalf("error = %v, want provider Turn changed", err)
+	}
+	if state := session.TurnState(); state.ActiveTurnID != "turn-live" {
+		t.Fatalf("mismatched response changed active Turn: %#v", state)
+	}
+}
+
+func TestProviderSessionTurnBusyTracksActiveRuntimeTurn(t *testing.T) {
+	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
+		"turn/start": {Result: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1"}}`)},
+	}}
+	session := NewCodexProviderSession(CodexProviderSessionConfig{Transport: transport, SessionID: "thread-1", ThreadID: "thread-1"})
+
+	result, err := session.SendTurn(context.Background(), ProviderSessionRequest{RequestID: "send-busy", Message: "inspect"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ControlBusy() {
+		t.Fatal("ControlBusy remained true after turn/start returned")
+	}
+	if !session.TurnBusy() {
+		t.Fatal("TurnBusy = false while provider Runtime Turn is active")
+	}
+	if state := session.TurnState(); state.SessionID != "thread-1" || state.ActiveTurnID != "turn-1" || !state.TurnBusy() {
+		t.Fatalf("active Turn state = %#v", state)
+	}
+
+	session.HandleEvent(SandboxBridgeEvent{Method: "turn/completed", Params: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`)}, nil)
+	if session.TurnBusy() {
+		t.Fatalf("TurnBusy = true after matching terminal event for %q", result.ProviderTurnID)
+	}
+	if state := session.TurnState(); state.ActiveTurnID != "" || state.TurnBusy() {
+		t.Fatalf("completed Turn state = %#v", state)
+	}
+}
+
+func TestProviderSessionTurnBusyConsumesTerminalNotificationBeforeTurnStartResponse(t *testing.T) {
+	var session *CodexProviderSession
+	transport := &fakeProviderTransport{send: func(_ context.Context, request SandboxBridgeRequest) (SandboxBridgeResponse, error) {
+		if request.Method != "turn/start" {
+			return SandboxBridgeResponse{}, errors.New("unexpected method " + request.Method)
+		}
+		session.HandleEvent(SandboxBridgeEvent{Method: "turn/completed", Params: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-fast","status":"completed"}}`)}, nil)
+		return SandboxBridgeResponse{Result: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-fast"}}`)}, nil
+	}}
+	session = NewCodexProviderSession(CodexProviderSessionConfig{Transport: transport, SessionID: "thread-1", ThreadID: "thread-1"})
+
+	result, err := session.SendTurn(context.Background(), ProviderSessionRequest{RequestID: "send-fast", Message: "finish quickly"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ProviderTurnID != "turn-fast" {
+		t.Fatalf("provider turn = %q, want turn-fast", result.ProviderTurnID)
+	}
+	if session.TurnBusy() {
+		t.Fatal("TurnBusy = true after terminal notification raced before turn/start response")
+	}
+}
+
 func TestCodexProviderSessionMapsModelAndRequestedReasoningEffortOnTurnStart(t *testing.T) {
 	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
 		"turn/start": {Result: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-effort"}}`)},
@@ -379,7 +683,7 @@ func TestClaudeProviderSessionMapsModelProviderModelAndEffortOnInput(t *testing.
 	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{
 		"claude/input": {Result: json.RawMessage(`{"session_id":"claude-1","turn_id":"turn-effort"}`)},
 	}}
-	session := NewClaudeCodeProviderSession(ClaudeCodeProviderSessionConfig{Transport: transport, SessionID: "claude-1"})
+	session := NewClaudeCodeProviderSession(ClaudeCodeProviderSessionConfig{Transport: transport, SessionID: "claude-1", ActiveTurnID: "turn-live"})
 	bindFakeProviderEvents(transport, session)
 
 	_, err := session.SendTurn(context.Background(), ProviderSessionRequest{
@@ -901,13 +1205,12 @@ func TestProviderSessionAdapterErrorsAreTypedAndCapabilitiesAreHonest(t *testing
 		Transport: &fakeProviderTransport{}, SessionID: "thread-1",
 		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true, InTurnSteer: true},
 	})
-	if noSteer.Capabilities().InTurnSteer {
-		t.Fatal("codex should not claim direct in-turn steer")
+	if !noSteer.Capabilities().InTurnSteer {
+		t.Fatal("codex should advertise direct in-turn steer")
 	}
 	_, err = noSteer.SteerInTurn(context.Background(), ProviderSessionRequest{RequestID: "steer-1", Message: "hi"}, nil)
-	var unsupported *UnsupportedProviderSessionCapabilityError
-	if !errors.As(err, &unsupported) || unsupported.Capability != ProviderSessionCapabilityInTurnSteer {
-		t.Fatalf("steer error = %v", err)
+	if !errors.Is(err, ErrProviderTurnUnavailable) {
+		t.Fatalf("steer error = %v, want provider Turn unavailable", err)
 	}
 }
 
@@ -999,13 +1302,16 @@ func TestProviderSessionAdapterRejectTimeoutAndDuplicateAreTruthful(t *testing.T
 
 func TestProviderSessionAdapterCloseIsIdempotentAndTimeoutDoesNotLeakMessage(t *testing.T) {
 	transport := &fakeProviderTransport{responses: map[string]SandboxBridgeResponse{}}
-	session := NewClaudeCodeProviderSession(ClaudeCodeProviderSessionConfig{Transport: transport, SessionID: "claude-1"})
+	session := NewClaudeCodeProviderSession(ClaudeCodeProviderSessionConfig{Transport: transport, SessionID: "claude-1", ActiveTurnID: "turn-live"})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 	// A transport that honors the canceled context is covered by the shared
 	// operation wrapper; this assertion ensures Close remains a public control.
 	if err := session.Close(context.Background()); err != nil {
 		t.Fatalf("close: %v", err)
+	}
+	if session.TurnBusy() || session.TurnState().ActiveTurnID != "" {
+		t.Fatalf("closed session retained active Turn: %#v", session.TurnState())
 	}
 	if err := session.Close(context.Background()); err != nil {
 		t.Fatalf("repeat close: %v", err)
@@ -1190,19 +1496,43 @@ func TestCodexProviderSessionProjectsVisibleRuntimeOutput(t *testing.T) {
 		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"agentMessage","id":"item-msg","text":"VPN检测未通过"}}`),
 	}, emit)
 	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/started",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"commandExecution","id":"item-cmd","command":"curl http://10.0.100.58","status":"inProgress"}}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
 		Method: "item/completed",
 		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"commandExecution","id":"item-cmd","command":"curl http://10.0.100.58","aggregatedOutput":"curl: (52) Empty reply from server\n","status":"failed","exitCode":52}}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/started",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"mcpToolCall","id":"item-mcp","server":"browser","tool":"navigate","status":"inProgress"}}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/completed",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"mcpToolCall","id":"item-mcp","server":"browser","tool":"navigate","status":"completed","result":"ok"}}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/started",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"reasoning","id":"item-reasoning","summary":[],"content":["SECRET_RAW_REASONING"]}}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/completed",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"reasoning","id":"item-reasoning","summary":["Checked the active challenge.","Prepared the next command."],"content":["SECRET_RAW_REASONING"]}}`),
 	}, emit)
 	session.HandleEvent(SandboxBridgeEvent{
 		Method: "item/agentMessage/delta",
 		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","itemId":"item-msg","delta":"VPN"}`),
 	}, emit)
 	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/reasoning/summaryTextDelta",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","itemId":"item-reasoning","delta":"Checked"}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
 		Method: "item/completed",
 		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"userMessage","id":"item-user","content":[{"type":"text","text":"operator prompt"}]}}`),
 	}, emit)
 
-	if len(events) != 2 {
+	if len(events) != 6 {
 		t.Fatalf("runtime events = %#v", events)
 	}
 	for i, kind := range kinds {
@@ -1219,8 +1549,21 @@ func TestCodexProviderSessionProjectsVisibleRuntimeOutput(t *testing.T) {
 	if text, _ := events[0]["text"].(string); !strings.Contains(text, "VPN检测未通过") {
 		t.Fatalf("assistant text = %q", events[0]["text"])
 	}
-	if text, _ := events[1]["text"].(string); !strings.Contains(text, "curl http://10.0.100.58") || !strings.Contains(text, "Empty reply") {
-		t.Fatalf("command text = %q", events[1]["text"])
+	if events[1]["provider_event"] != "item/started" || events[2]["provider_event"] != "item/completed" {
+		t.Fatalf("command lifecycle = %#v %#v", events[1], events[2])
+	}
+	if text, _ := events[2]["text"].(string); !strings.Contains(text, "curl http://10.0.100.58") || !strings.Contains(text, "Empty reply") {
+		t.Fatalf("command text = %q", events[2]["text"])
+	}
+	if events[3]["provider_event"] != "item/started" || events[4]["provider_event"] != "item/completed" {
+		t.Fatalf("MCP lifecycle = %#v %#v", events[3], events[4])
+	}
+	text, _ := events[5]["text"].(string)
+	if events[5]["provider_event"] != "item/completed" || !strings.Contains(text, "Checked the active challenge.") {
+		t.Fatalf("completed reasoning summary = %#v", events[5])
+	}
+	if strings.Contains(text, "SECRET_RAW_REASONING") || strings.Contains(text, `"content"`) {
+		t.Fatalf("reasoning event leaked raw content: %s", text)
 	}
 }
 
@@ -1258,5 +1601,16 @@ func TestProviderSessionAdapterUsesDaemonEventSinkForUnsolicitedPermission(t *te
 	}
 	if _, leaked := events[0]["tool_input"]; leaked {
 		t.Fatalf("sink event leaked provider wire details: %#v", events[0])
+	}
+}
+
+func TestSandboxBridgeRPCErrorDistinguishesCompletedAndChangedTargets(t *testing.T) {
+	completed := sandboxBridgeRPCError("steer-completed", json.RawMessage(`{"code":-32000,"message":"no active turn"}`))
+	if !errors.Is(completed, ErrProviderTurnUnavailable) || errors.Is(completed, ErrProviderTurnChanged) {
+		t.Fatalf("completed target classification = %#v", completed)
+	}
+	changed := sandboxBridgeRPCError("steer-changed", json.RawMessage(`{"code":-32000,"message":"expectedTurnId does not match active turn"}`))
+	if !errors.Is(changed, ErrProviderTurnChanged) || errors.Is(changed, ErrProviderTurnUnavailable) {
+		t.Fatalf("changed target classification = %#v", changed)
 	}
 }

--- a/internal/runtime/provider_session.go
+++ b/internal/runtime/provider_session.go
@@ -46,10 +46,35 @@ var (
 	ErrProviderSessionClosed = errors.New("provider session is closed")
 	// ErrInvalidProviderSessionRequest reports missing stable request identity.
 	ErrInvalidProviderSessionRequest = errors.New("invalid provider session request")
+	// ErrProviderTurnUnavailable reports an in-turn operation without a live
+	// provider Runtime Turn to target.
+	ErrProviderTurnUnavailable = errors.New("provider Runtime Turn is unavailable")
+	// ErrProviderTurnChanged reports an in-turn operation whose expected Turn
+	// is no longer the provider session's active Turn.
+	ErrProviderTurnChanged = errors.New("provider Runtime Turn changed")
+	// ErrProviderTurnNotSteerable reports an active provider Turn whose kind
+	// explicitly rejects same-turn operator input, such as review or compact.
+	ErrProviderTurnNotSteerable = errors.New("active provider Runtime Turn is not steerable")
+	// ErrProviderMethodUnavailable reports a provider App Server that does not
+	// implement the requested native method.
+	ErrProviderMethodUnavailable = errors.New("provider method is unavailable")
 	// ErrProviderSessionRequestConflict reports reuse of a request id with a
 	// different operation payload.
 	ErrProviderSessionRequestConflict = errors.New("provider session request id is already bound to different content")
 )
+
+// ProviderTurnChangedError preserves the redacted expected/active identities
+// needed for deterministic steering recovery without exposing provider text.
+type ProviderTurnChangedError struct {
+	ExpectedTurnID string
+	ActiveTurnID   string
+}
+
+func (e *ProviderTurnChangedError) Error() string {
+	return fmt.Sprintf("expected provider Turn %q, active Turn is %q", e.ExpectedTurnID, e.ActiveTurnID)
+}
+
+func (e *ProviderTurnChangedError) Is(target error) bool { return target == ErrProviderTurnChanged }
 
 // ProviderSessionRequestConflictError identifies an idempotency-key payload
 // mismatch without exposing the payload itself.
@@ -155,6 +180,32 @@ type ProviderSession interface {
 	Close(context.Context) error
 }
 
+// ProviderSessionTurnState is one atomic snapshot of the provider session's
+// control and active Runtime Turn identity.
+type ProviderSessionTurnState struct {
+	SessionID      string
+	ActiveTurnID   string
+	ActiveTurnKind RuntimeTurnKind
+	ControlBusy    bool
+}
+
+// TurnBusy reports whether a control RPC or provider Runtime Turn is active.
+func (state ProviderSessionTurnState) TurnBusy() bool {
+	return state.ControlBusy || strings.TrimSpace(state.ActiveTurnID) != ""
+}
+
+// ProviderSessionTurnStateReporter exposes the active Turn identity required
+// to bind a durable same-turn Steering request.
+type ProviderSessionTurnStateReporter interface {
+	TurnState() ProviderSessionTurnState
+}
+
+// ProviderSessionTurnBusyReporter retains compatibility for provider handles
+// that report liveness without exposing active Turn identity.
+type ProviderSessionTurnBusyReporter interface {
+	TurnBusy() bool
+}
+
 // ProviderSessionContinuationBinder updates the request-level Continuation pin
 // on a Task-owned transport without replacing the provider session.
 type ProviderSessionContinuationBinder interface {
@@ -165,6 +216,7 @@ type ProviderSessionContinuationBinder interface {
 type FakeProviderSessionConfig struct {
 	SessionID         string
 	ActiveTurnID      string
+	ActiveTurnKind    RuntimeTurnKind
 	Capabilities      runtimeplugin.Capabilities
 	ManualAcknowledge bool
 	Failures          map[ProviderSessionMode]error
@@ -217,12 +269,21 @@ func NewFakeProviderSession(config FakeProviderSessionConfig) *FakeProviderSessi
 	if id == "" {
 		id = "fake-session"
 	}
+	activeTurnID := strings.TrimSpace(config.ActiveTurnID)
+	activeTurnKind := config.ActiveTurnKind
+	if activeTurnID != "" && activeTurnKind == "" {
+		activeTurnKind = RuntimeTurnKindWork
+	}
+	providerTurnKind := map[string]RuntimeTurnKind{}
+	if activeTurnID != "" {
+		providerTurnKind[activeTurnID] = activeTurnKind
+	}
 	return &FakeProviderSession{
 		id: id, capabilities: config.Capabilities,
-		activeTurnID: strings.TrimSpace(config.ActiveTurnID), turnNumber: 1,
+		activeTurnID: activeTurnID, turnNumber: 1,
 		manualAck: config.ManualAcknowledge, failures: config.Failures,
 		calls: map[string]*providerSessionCall{}, acknowledge: map[string]chan struct{}{},
-		requestTurnKind: map[string]RuntimeTurnKind{}, providerTurnKind: map[string]RuntimeTurnKind{},
+		requestTurnKind: map[string]RuntimeTurnKind{}, providerTurnKind: providerTurnKind,
 		requestLineage: map[string]ProviderSessionTurnLineage{}, providerLineage: map[string]ProviderSessionTurnLineage{},
 	}
 }
@@ -386,6 +447,19 @@ func (s *FakeProviderSession) InterruptThenReplace(ctx context.Context, request 
 }
 
 func (s *FakeProviderSession) SteerInTurn(ctx context.Context, request ProviderSessionRequest, emit ProviderSessionEmit) (ProviderSessionResult, error) {
+	s.mu.Lock()
+	activeTurnID := strings.TrimSpace(s.activeTurnID)
+	s.mu.Unlock()
+	if activeTurnID == "" {
+		return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: ProviderSessionModeInTurnSteer, Cause: ErrProviderTurnUnavailable}
+	}
+	if expected := strings.TrimSpace(request.ProviderTurnID); expected == "" {
+		return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: ProviderSessionModeInTurnSteer, Cause: ErrInvalidProviderSessionRequest}
+	} else if expected != activeTurnID {
+		return ProviderSessionResult{}, &ProviderSessionOperationError{Mode: ProviderSessionModeInTurnSteer, Cause: &ProviderTurnChangedError{
+			ExpectedTurnID: expected, ActiveTurnID: activeTurnID,
+		}}
+	}
 	return s.operate(ctx, ProviderSessionModeInTurnSteer, ProviderSessionCapabilityInTurnSteer, request, emit)
 }
 
@@ -405,6 +479,7 @@ func (s *FakeProviderSession) Close(context.Context) error {
 		return ErrProviderSessionControlConflict
 	}
 	s.closed = true
+	s.activeTurnID = ""
 	s.offline = true
 	// Explicit Close is operator Stop/cleanup, not unexpected exit.
 	s.unexpectedOffline = false
@@ -431,6 +506,21 @@ func (s *FakeProviderSession) ControlBusy() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.activeCall != ""
+}
+
+// TurnBusy reports whether a fake control call or provider Runtime Turn is active.
+func (s *FakeProviderSession) TurnBusy() bool {
+	return s.TurnState().TurnBusy()
+}
+
+// TurnState returns one atomic fake provider Turn snapshot.
+func (s *FakeProviderSession) TurnState() ProviderSessionTurnState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return ProviderSessionTurnState{
+		SessionID: s.id, ActiveTurnID: s.activeTurnID,
+		ActiveTurnKind: s.providerTurnKind[s.activeTurnID], ControlBusy: s.activeCall != "",
+	}
 }
 
 // SessionClosed reports whether Close has completed on this handle.
@@ -523,10 +613,12 @@ func (s *FakeProviderSession) operate(ctx context.Context, mode ProviderSessionM
 		s.activeTurnID = turnID
 	}
 	s.requestTurnKind[request.RequestID] = request.TurnKind
-	s.providerTurnKind[turnID] = request.TurnKind
 	lineage := providerSessionTurnLineage(request, turnID)
 	s.requestLineage[request.RequestID] = lineage
-	s.providerLineage[turnID] = lineage
+	if mode != ProviderSessionModeInTurnSteer {
+		s.providerTurnKind[turnID] = request.TurnKind
+		s.providerLineage[turnID] = lineage
+	}
 	var ack chan struct{}
 	if s.manualAck && modeNeedsAcknowledgement(mode) {
 		ack = make(chan struct{})

--- a/internal/runtime/provider_session_test.go
+++ b/internal/runtime/provider_session_test.go
@@ -56,6 +56,80 @@ func TestFakeProviderSessionEmitsBoundedObservations(t *testing.T) {
 	}
 }
 
+func TestFakeProviderSessionInTurnSteerPreservesWorkTurnLineage(t *testing.T) {
+	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID:    "session-1",
+		Capabilities: runtimeplugin.Capabilities{SendTurn: true, InTurnSteer: true},
+	})
+	work, err := session.SendTurn(context.Background(), runtime.ProviderSessionRequest{
+		RequestID: "work-1", Message: "inspect", TurnKind: runtime.RuntimeTurnKindWork,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, ok := session.ResolveProviderSessionTurnLineage("", work.ProviderTurnID)
+	if !ok || before.RequestID != "work-1" || before.Kind != runtime.RuntimeTurnKindWork {
+		t.Fatalf("work lineage before steer = %#v ok=%v", before, ok)
+	}
+	steered, err := session.SteerInTurn(context.Background(), runtime.ProviderSessionRequest{
+		RequestID: "steer-1", Message: "focus", ProviderTurnID: work.ProviderTurnID, TurnKind: runtime.RuntimeTurnKindControl,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if steered.ProviderTurnID != work.ProviderTurnID {
+		t.Fatalf("steered Turn = %q, want %q", steered.ProviderTurnID, work.ProviderTurnID)
+	}
+	after, ok := session.ResolveProviderSessionTurnLineage("", work.ProviderTurnID)
+	if !ok || after != before {
+		t.Fatalf("work lineage after steer = %#v ok=%v, want %#v", after, ok, before)
+	}
+}
+
+func TestFakeProviderSessionRejectsChangedInTurnTarget(t *testing.T) {
+	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-1", ActiveTurnID: "turn-live",
+		Capabilities: runtimeplugin.Capabilities{InTurnSteer: true},
+	})
+	_, err := session.SteerInTurn(context.Background(), runtime.ProviderSessionRequest{
+		RequestID: "steer-1", Message: "focus", ProviderTurnID: "turn-old",
+	}, nil)
+	if !errors.Is(err, runtime.ErrProviderTurnChanged) {
+		t.Fatalf("steer error = %v, want provider Turn changed", err)
+	}
+}
+
+func TestFakeProviderSessionTurnBusyTracksActiveRuntimeTurn(t *testing.T) {
+	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-1",
+		Capabilities: runtimeplugin.Capabilities{
+			SendTurn: true,
+		},
+	})
+	result, err := session.SendTurn(context.Background(), runtime.ProviderSessionRequest{RequestID: "send-1", Message: "inspect"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ControlBusy() {
+		t.Fatal("ControlBusy remained true after SendTurn returned")
+	}
+	if !session.TurnBusy() {
+		t.Fatal("TurnBusy = false while fake Runtime Turn is active")
+	}
+	if err := session.EmitObservation(runtime.ProviderSessionObservation{
+		Kind:           runtime.ProviderSessionObservationTurnCompleted,
+		SessionID:      "session-1",
+		ProviderTurnID: result.ProviderTurnID,
+		RequestID:      "send-1",
+		Status:         "completed",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if session.TurnBusy() {
+		t.Fatal("TurnBusy = true after matching fake terminal observation")
+	}
+}
+
 func TestFakeProviderSessionRejectsMalformedObservations(t *testing.T) {
 	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{SessionID: "session-1", ActiveTurnID: "turn-1"})
 	for _, observation := range []runtime.ProviderSessionObservation{
@@ -559,7 +633,7 @@ func TestFakeProviderSessionPermissionResponseAndTypedFailure(t *testing.T) {
 		t.Fatalf("permission result = %#v", permission)
 	}
 
-	_, err = session.SteerInTurn(context.Background(), runtime.ProviderSessionRequest{RequestID: "steer-1", Message: "redirect"}, recorder.emit)
+	_, err = session.SteerInTurn(context.Background(), runtime.ProviderSessionRequest{RequestID: "steer-1", Message: "redirect", ProviderTurnID: "turn-1"}, recorder.emit)
 	var failed *runtime.ProviderSessionOperationError
 	if !errors.As(err, &failed) || failed.Mode != runtime.ProviderSessionModeInTurnSteer {
 		t.Fatalf("steer error = %v, want typed operation error", err)
@@ -572,5 +646,18 @@ func TestFakeProviderSessionPermissionResponseAndTypedFailure(t *testing.T) {
 	}
 	if _, leaked := last["message"]; leaked {
 		t.Fatalf("failure event leaked user/provider data: %#v", last)
+	}
+}
+
+func TestFakeProviderSessionCloseClearsActiveTurn(t *testing.T) {
+	session := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{
+		SessionID: "session-1", ActiveTurnID: "turn-live",
+		Capabilities: runtimeplugin.Capabilities{PersistentSession: true, SendTurn: true},
+	})
+	if err := session.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if session.TurnBusy() || session.TurnState().ActiveTurnID != "" {
+		t.Fatalf("closed fake session retained active Turn: %#v", session.TurnState())
 	}
 }

--- a/internal/runtime/session_bridge.go
+++ b/internal/runtime/session_bridge.go
@@ -82,12 +82,42 @@ var (
 	ErrSandboxBridgeRequestConflict = errors.New("sandbox bridge request id is already bound to different content")
 )
 
+// SandboxBridgeRPCErrorKind is the stable, redacted class of one provider RPC
+// error. Raw provider message/data never crosses the runtime boundary.
+type SandboxBridgeRPCErrorKind string
+
+const (
+	SandboxBridgeRPCErrorUnknown             SandboxBridgeRPCErrorKind = "unknown"
+	SandboxBridgeRPCErrorMethodUnavailable   SandboxBridgeRPCErrorKind = "method_unavailable"
+	SandboxBridgeRPCErrorTargetTurnCompleted SandboxBridgeRPCErrorKind = "target_turn_completed"
+	SandboxBridgeRPCErrorTargetTurnChanged   SandboxBridgeRPCErrorKind = "target_turn_changed"
+	SandboxBridgeRPCErrorTurnNotSteerable    SandboxBridgeRPCErrorKind = "active_turn_not_steerable"
+)
+
 // SandboxBridgeRPCError reports a provider RPC failure without exposing its
 // potentially sensitive wire payload through daemon errors.
-type SandboxBridgeRPCError struct{ RequestID string }
+type SandboxBridgeRPCError struct {
+	RequestID string
+	Kind      SandboxBridgeRPCErrorKind
+}
 
 func (e *SandboxBridgeRPCError) Error() string {
 	return fmt.Sprintf("sandbox bridge request %q failed", e.RequestID)
+}
+
+func (e *SandboxBridgeRPCError) Is(target error) bool {
+	switch e.Kind {
+	case SandboxBridgeRPCErrorMethodUnavailable:
+		return target == ErrProviderMethodUnavailable
+	case SandboxBridgeRPCErrorTargetTurnCompleted:
+		return target == ErrProviderTurnUnavailable
+	case SandboxBridgeRPCErrorTargetTurnChanged:
+		return target == ErrProviderTurnChanged
+	case SandboxBridgeRPCErrorTurnNotSteerable:
+		return target == ErrProviderTurnNotSteerable
+	default:
+		return false
+	}
 }
 
 type bridgePending struct {
@@ -466,11 +496,7 @@ func (b *SandboxSessionBridge) readLoop(reader io.Reader) {
 			continue
 		}
 		if event.ID != "" {
-			var responseErr error
-			if len(event.Error) > 0 && string(event.Error) != "null" {
-				responseErr = &SandboxBridgeRPCError{RequestID: event.ID}
-			}
-			b.finish(event.ID, SandboxBridgeResponse{JSONRPC: event.JSONRPC, ID: event.ID, Result: event.Result, Error: event.Error}, responseErr)
+			b.finish(event.ID, SandboxBridgeResponse{JSONRPC: event.JSONRPC, ID: event.ID, Result: event.Result, Error: event.Error}, nil)
 			continue
 		}
 		if b.config.ProtocolEmit != nil {

--- a/internal/runtime/session_bridge_test.go
+++ b/internal/runtime/session_bridge_test.go
@@ -164,6 +164,27 @@ func TestSandboxSessionBridgeKeepsOneTaskContainerAcrossContinuations(t *testing
 	}
 }
 
+func TestSandboxSessionBridgeReturnsJSONRPCErrorAsResponse(t *testing.T) {
+	docker := newFakeBridgeDocker()
+	bridge := newStartedBridge(t, docker)
+	go func() {
+		scanner := bufio.NewScanner(docker.requestR)
+		if scanner.Scan() {
+			var request runtime.SandboxBridgeRequest
+			_ = json.Unmarshal(scanner.Bytes(), &request)
+			_, _ = docker.outputW.Write([]byte(`{"jsonrpc":"2.0","id":"` + request.ID + `","error":{"code":-32601,"message":"Method not found"}}` + "\n"))
+		}
+	}()
+
+	response, err := bridge.Send(context.Background(), runtime.SandboxBridgeRequest{ID: "request-rpc-error", Method: "turn/steer"})
+	if err != nil {
+		t.Fatalf("JSON-RPC error was returned as a transport error: %v", err)
+	}
+	if string(response.Error) != `{"code":-32601,"message":"Method not found"}` {
+		t.Fatalf("response error = %s", response.Error)
+	}
+}
+
 func TestFirstProviderAdaptersShareOneNonPTYBridgeTransport(t *testing.T) {
 	docker := newFakeBridgeDocker()
 	bridge := newStartedBridge(t, docker)

--- a/internal/runtimeoutput/coalesce.go
+++ b/internal/runtimeoutput/coalesce.go
@@ -1,5 +1,7 @@
 package runtimeoutput
 
+import "strings"
+
 // CoalesceStreaming merges adjacent thinking or text turns split by flush timing.
 func CoalesceStreaming(turns []Turn) []Turn {
 	if len(turns) == 0 {
@@ -14,24 +16,95 @@ func CoalesceStreaming(turns []Turn) []Turn {
 		prev := out[len(out)-1]
 		if canMergeStreamingText(prev, turn) {
 			out[len(out)-1] = Turn{
-				SourceID:     prev.SourceID,
-				SourceSeq:    turn.SourceSeq,
-				Kind:         prev.Kind,
-				Role:         prev.Role,
-				Text:         prev.Text + turn.Text,
-				Tool:         prev.Tool,
-				Input:        prev.Input,
-				Output:       prev.Output,
-				ToolCallID:   prev.ToolCallID,
-				Details:      prev.Details,
-				ContentIndex: prev.ContentIndex,
-				CreatedAt:    turn.CreatedAt,
+				SourceID:       prev.SourceID,
+				SourceSeq:      turn.SourceSeq,
+				ProviderItemID: prev.ProviderItemID,
+				LifecyclePhase: turn.LifecyclePhase,
+				Kind:           prev.Kind,
+				Role:           prev.Role,
+				Text:           prev.Text + turn.Text,
+				Tool:           prev.Tool,
+				Input:          prev.Input,
+				Output:         prev.Output,
+				ToolCallID:     prev.ToolCallID,
+				Details:        prev.Details,
+				ContentIndex:   prev.ContentIndex,
+				CreatedAt:      turn.CreatedAt,
 			}
 			continue
 		}
 		out = append(out, turn)
 	}
 	return out
+}
+
+// ReconcileLifecycle collapses duplicate projections of the same provider
+// item while preserving completed-only records from older Sessions.
+func ReconcileLifecycle(turns []Turn) []Turn {
+	out := make([]Turn, 0, len(turns))
+	toolUses := map[string]int{}
+	toolResults := map[string]int{}
+	thinking := map[string]int{}
+	for _, turn := range turns {
+		switch turn.Kind {
+		case KindToolUse:
+			if key := strings.TrimSpace(turn.ToolCallID); key != "" {
+				if index, ok := toolUses[key]; ok {
+					out[index] = mergeLifecycleTurn(out[index], turn)
+					continue
+				}
+				toolUses[key] = len(out)
+			}
+		case KindToolResult:
+			if key := strings.TrimSpace(turn.ToolCallID); key != "" {
+				if index, ok := toolResults[key]; ok {
+					out[index] = mergeLifecycleTurn(out[index], turn)
+					continue
+				}
+				toolResults[key] = len(out)
+			}
+		case KindThinking:
+			if key := strings.TrimSpace(turn.ProviderItemID); key != "" {
+				if index, ok := thinking[key]; ok {
+					out[index] = mergeLifecycleTurn(out[index], turn)
+					continue
+				}
+				thinking[key] = len(out)
+			}
+		}
+		out = append(out, turn)
+	}
+	return out
+}
+
+func mergeLifecycleTurn(previous, next Turn) Turn {
+	if previous.SourceID != "" {
+		next.SourceID = previous.SourceID
+	}
+	if previous.SourceSeq != 0 {
+		next.SourceSeq = previous.SourceSeq
+	}
+	if next.ProviderItemID == "" {
+		next.ProviderItemID = previous.ProviderItemID
+	}
+	if next.ToolCallID == "" {
+		next.ToolCallID = previous.ToolCallID
+	}
+	if next.Tool == "" {
+		next.Tool = previous.Tool
+	}
+	if len(next.Input) == 0 {
+		next.Input = previous.Input
+	}
+	if len(next.Details) == 0 {
+		next.Details = previous.Details
+	}
+	if !previous.CreatedAt.IsZero() {
+		next.CreatedAt = previous.CreatedAt
+	} else if next.CreatedAt.IsZero() {
+		next.CreatedAt = previous.CreatedAt
+	}
+	return next
 }
 
 func canMergeStreamingText(prev, next Turn) bool {

--- a/internal/runtimeoutput/identity.go
+++ b/internal/runtimeoutput/identity.go
@@ -1,0 +1,18 @@
+package runtimeoutput
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// StableProviderItemID returns one deterministic projection id for a provider
+// item and row kind. It is stable across Event windows and runtime-tail merges.
+func StableProviderItemID(providerItemID, rowKind string) string {
+	providerItemID = strings.TrimSpace(providerItemID)
+	if providerItemID == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(providerItemID))
+	return "provider-item-" + hex.EncodeToString(sum[:]) + "-" + strings.TrimSpace(rowKind)
+}

--- a/internal/runtimeoutput/parse.go
+++ b/internal/runtimeoutput/parse.go
@@ -9,6 +9,12 @@ import (
 // ParseLine normalizes one runtime stdout/stderr line into turns. The bool is
 // true when the line is treated as plain-text fallback rather than structured JSON.
 func ParseLine(text string, createdAt time.Time, opts ParseOptions) ([]Turn, bool) {
+	return ParseLineWithMeta(text, RecordMeta{}, createdAt, opts)
+}
+
+// ParseLineWithMeta normalizes one runtime line with durable provider-event
+// lifecycle metadata.
+func ParseLineWithMeta(text string, meta RecordMeta, createdAt time.Time, opts ParseOptions) ([]Turn, bool) {
 	trimmed := strings.TrimSpace(text)
 	if !strings.HasPrefix(trimmed, "{") {
 		return []Turn{{Kind: KindText, Text: trimmed, ContentIndex: -1, CreatedAt: createdAt}}, true
@@ -19,7 +25,7 @@ func ParseLine(text string, createdAt time.Time, opts ParseOptions) ([]Turn, boo
 		return []Turn{{Kind: KindText, Text: trimmed, ContentIndex: -1, CreatedAt: createdAt}}, true
 	}
 
-	turns := ParseRecord(record, opts, createdAt)
+	turns := ParseRecordWithMeta(record, meta, opts, createdAt)
 	if len(turns) == 0 {
 		return []Turn{{Kind: KindText, Text: trimmed, ContentIndex: -1, CreatedAt: createdAt}}, true
 	}
@@ -28,11 +34,17 @@ func ParseLine(text string, createdAt time.Time, opts ParseOptions) ([]Turn, boo
 
 // ParseRecord projects one provider JSON object into normalized turns.
 func ParseRecord(record map[string]any, opts ParseOptions, createdAt time.Time) []Turn {
+	return ParseRecordWithMeta(record, RecordMeta{}, opts, createdAt)
+}
+
+// ParseRecordWithMeta projects one provider JSON object with its durable
+// lifecycle metadata into normalized turns.
+func ParseRecordWithMeta(record map[string]any, meta RecordMeta, opts ParseOptions, createdAt time.Time) []Turn {
 	if turns := parseHermesACPRecord(record, opts, createdAt); len(turns) > 0 || isHermesACPRecord(record) {
 		return turns
 	}
 	if item, ok := mapValue(record, "item"); ok {
-		if turns := ParseRecord(item, opts, createdAt); len(turns) > 0 {
+		if turns := ParseRecordWithMeta(item, meta, opts, createdAt); len(turns) > 0 {
 			return turns
 		}
 	}
@@ -52,10 +64,12 @@ func ParseRecord(record map[string]any, opts ParseOptions, createdAt time.Time) 
 	case "assistant", "user", "message", "assistant_message", "agent_message", "agentmessage", "response.output_text", "output_text", "message_delta", "content_block_delta":
 		return parseMessageRecord(record, opts, roleFromType(recordType), createdAt)
 	case "commandexecution":
-		return parseCodexCommandExecution(record, createdAt)
+		return parseCodexCommandExecution(record, meta, createdAt)
 	case "mcptoolcall":
-		return parseCodexMCPToolCall(record, createdAt)
-	case "usermessage", "reasoning":
+		return parseCodexMCPToolCall(record, meta, createdAt)
+	case "reasoning":
+		return parseCodexReasoning(record, meta, opts, createdAt)
+	case "usermessage":
 		return nil
 	case "tool_call", "function_call", "tool_use":
 		return []Turn{toolUseTurn(record, createdAt)}
@@ -150,7 +164,7 @@ func parseContentBlocks(content []any, opts ParseOptions, role string, createdAt
 	return turns
 }
 
-func parseCodexCommandExecution(record map[string]any, createdAt time.Time) []Turn {
+func parseCodexCommandExecution(record map[string]any, meta RecordMeta, createdAt time.Time) []Turn {
 	command := firstText(record, "command")
 	output := firstText(record, "aggregatedOutput", "aggregated_output", "output")
 	id := firstText(record, "id")
@@ -158,31 +172,35 @@ func parseCodexCommandExecution(record map[string]any, createdAt time.Time) []Tu
 		return nil
 	}
 	use := Turn{
-		Kind:         KindToolUse,
-		Role:         roleAssistant,
-		Tool:         "command_execution",
-		ToolCallID:   id,
-		Input:        nilIfEmpty(map[string]any{"command": command}),
-		Details:      nilIfEmpty(map[string]any{"command": command}),
-		ContentIndex: -1,
-		CreatedAt:    createdAt,
+		ProviderItemID: id,
+		LifecyclePhase: codexLifecyclePhase(meta.ProviderEvent),
+		Kind:           KindToolUse,
+		Role:           roleAssistant,
+		Tool:           "command_execution",
+		ToolCallID:     id,
+		Input:          nilIfEmpty(map[string]any{"command": command}),
+		Details:        nilIfEmpty(map[string]any{"command": command}),
+		ContentIndex:   -1,
+		CreatedAt:      createdAt,
 	}
 	status := strings.ToLower(firstText(record, "status"))
 	if output == "" && (status == "" || status == "inprogress" || status == "in_progress") {
 		return []Turn{use}
 	}
 	return []Turn{use, Turn{
-		Kind:         KindToolResult,
-		Role:         roleTool,
-		Tool:         "command_execution",
-		ToolCallID:   id,
-		Output:       output,
-		ContentIndex: -1,
-		CreatedAt:    createdAt,
+		ProviderItemID: id,
+		LifecyclePhase: codexLifecyclePhase(meta.ProviderEvent),
+		Kind:           KindToolResult,
+		Role:           roleTool,
+		Tool:           "command_execution",
+		ToolCallID:     id,
+		Output:         output,
+		ContentIndex:   -1,
+		CreatedAt:      createdAt,
 	}}
 }
 
-func parseCodexMCPToolCall(record map[string]any, createdAt time.Time) []Turn {
+func parseCodexMCPToolCall(record map[string]any, meta RecordMeta, createdAt time.Time) []Turn {
 	name := firstText(record, "tool", "toolName", "tool_name", "name")
 	if name == "" {
 		return nil
@@ -194,26 +212,65 @@ func parseCodexMCPToolCall(record map[string]any, createdAt time.Time) []Turn {
 	}
 	id := firstText(record, "id")
 	use := Turn{
-		Kind:         KindToolUse,
-		Role:         roleAssistant,
-		Tool:         name,
-		ToolCallID:   id,
-		ContentIndex: -1,
-		CreatedAt:    createdAt,
+		ProviderItemID: id,
+		LifecyclePhase: codexLifecyclePhase(meta.ProviderEvent),
+		Kind:           KindToolUse,
+		Role:           roleAssistant,
+		Tool:           name,
+		ToolCallID:     id,
+		ContentIndex:   -1,
+		CreatedAt:      createdAt,
 	}
 	status := strings.ToLower(firstText(record, "status"))
 	if status == "" || status == "inprogress" || status == "in_progress" {
 		return []Turn{use}
 	}
 	return []Turn{use, Turn{
-		Kind:         KindToolResult,
-		Role:         roleTool,
-		Tool:         name,
-		ToolCallID:   id,
-		Output:       firstText(record, "aggregatedOutput", "aggregated_output", "output", "result", "content"),
-		ContentIndex: -1,
-		CreatedAt:    createdAt,
+		ProviderItemID: id,
+		LifecyclePhase: codexLifecyclePhase(meta.ProviderEvent),
+		Kind:           KindToolResult,
+		Role:           roleTool,
+		Tool:           name,
+		ToolCallID:     id,
+		Output:         firstText(record, "aggregatedOutput", "aggregated_output", "output", "result", "content"),
+		ContentIndex:   -1,
+		CreatedAt:      createdAt,
 	}}
+}
+
+func parseCodexReasoning(record map[string]any, meta RecordMeta, opts ParseOptions, createdAt time.Time) []Turn {
+	if !opts.IncludeReasoningSummaries {
+		return nil
+	}
+	id := firstText(record, "id")
+	phase := codexLifecyclePhase(meta.ProviderEvent)
+	if phase == "started" {
+		return nil
+	}
+	text := firstText(record, "summary")
+	if text == "" {
+		return nil
+	}
+	return []Turn{{
+		ProviderItemID: id,
+		LifecyclePhase: phase,
+		Kind:           KindThinking,
+		Role:           roleAssistant,
+		Text:           text,
+		ContentIndex:   -1,
+		CreatedAt:      createdAt,
+	}}
+}
+
+func codexLifecyclePhase(providerEvent string) string {
+	switch strings.ToLower(strings.TrimSpace(providerEvent)) {
+	case "item/started":
+		return "started"
+	case "item/completed":
+		return "completed"
+	default:
+		return ""
+	}
 }
 
 func toolUseTurn(record map[string]any, createdAt time.Time) Turn {

--- a/internal/runtimeoutput/parse_test.go
+++ b/internal/runtimeoutput/parse_test.go
@@ -1,6 +1,7 @@
 package runtimeoutput_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -111,6 +112,68 @@ func TestParseRecordCodexAppServerItems(t *testing.T) {
 	}
 	if command[1].Kind != runtimeoutput.KindToolResult || command[1].Output != "curl: (52) Empty reply from server\n" {
 		t.Fatalf("tool result = %#v", command[1])
+	}
+
+	started := runtimeoutput.ParseRecordWithMeta(map[string]any{
+		"item": map[string]any{
+			"type":    "commandExecution",
+			"id":      "item-cmd",
+			"command": "curl -sS http://10.0.100.58",
+			"status":  "inProgress",
+		},
+	}, runtimeoutput.RecordMeta{ProviderEvent: "item/started"}, runtimeoutput.ParseOptions{}, at)
+	if len(started) != 1 || started[0].Kind != runtimeoutput.KindToolUse || started[0].ProviderItemID != "item-cmd" || started[0].LifecyclePhase != "started" {
+		t.Fatalf("started command = %#v", started)
+	}
+	completed := runtimeoutput.ParseRecordWithMeta(map[string]any{
+		"item": map[string]any{
+			"type":             "commandExecution",
+			"id":               "item-cmd",
+			"command":          "curl -sS http://10.0.100.58",
+			"aggregatedOutput": "ok",
+			"status":           "completed",
+		},
+	}, runtimeoutput.RecordMeta{ProviderEvent: "item/completed"}, runtimeoutput.ParseOptions{}, at.Add(time.Second))
+	reconciled := runtimeoutput.ReconcileLifecycle(append(started, completed...))
+	if len(reconciled) != 2 || reconciled[0].Kind != runtimeoutput.KindToolUse || reconciled[1].Kind != runtimeoutput.KindToolResult {
+		t.Fatalf("reconciled command lifecycle = %#v", reconciled)
+	}
+
+	reasoningStarted := runtimeoutput.ParseRecordWithMeta(map[string]any{
+		"item": map[string]any{
+			"type":    "reasoning",
+			"id":      "item-reasoning",
+			"summary": []any{},
+			"content": []any{"SECRET_RAW_REASONING"},
+		},
+	}, runtimeoutput.RecordMeta{ProviderEvent: "item/started"}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, at)
+	reasoningCompleted := runtimeoutput.ParseRecordWithMeta(map[string]any{
+		"item": map[string]any{
+			"type":    "reasoning",
+			"id":      "item-reasoning",
+			"summary": []any{"Checked the target.", "Prepared the command."},
+			"content": []any{"SECRET_RAW_REASONING"},
+		},
+	}, runtimeoutput.RecordMeta{ProviderEvent: "item/completed"}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, at.Add(time.Second))
+	if len(reasoningStarted) != 0 {
+		t.Fatalf("started reasoning should stay hidden without a summary: %#v", reasoningStarted)
+	}
+	reasoning := runtimeoutput.ReconcileLifecycle(reasoningCompleted)
+	if len(reasoning) != 1 || reasoning[0].Kind != runtimeoutput.KindThinking || reasoning[0].Text != "Checked the target.\nPrepared the command." {
+		t.Fatalf("reasoning lifecycle = %#v", reasoning)
+	}
+	if strings.Contains(reasoning[0].Text, "SECRET_RAW_REASONING") {
+		t.Fatalf("reasoning leaked raw content: %#v", reasoning[0])
+	}
+	if empty := runtimeoutput.ParseRecordWithMeta(map[string]any{
+		"item": map[string]any{"type": "reasoning", "id": "empty", "summary": []any{}},
+	}, runtimeoutput.RecordMeta{ProviderEvent: "item/completed"}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, at); len(empty) != 0 {
+		t.Fatalf("empty completed reasoning invented text: %#v", empty)
+	}
+	if hidden := runtimeoutput.ParseRecordWithMeta(map[string]any{
+		"item": map[string]any{"type": "reasoning", "id": "hidden", "summary": []any{"summary"}},
+	}, runtimeoutput.RecordMeta{ProviderEvent: "item/completed"}, runtimeoutput.ParseOptions{}, at); len(hidden) != 0 {
+		t.Fatalf("reasoning ignored IncludeReasoningSummaries: %#v", hidden)
 	}
 }
 

--- a/internal/runtimeoutput/turn.go
+++ b/internal/runtimeoutput/turn.go
@@ -15,22 +15,31 @@ const (
 
 // Turn is one normalized fragment from a provider stdout/stderr JSON line.
 type Turn struct {
-	SourceID     string
-	SourceSeq    int
-	Kind         Kind
-	Role         string
-	Text         string
-	Tool         string
-	Input        map[string]any
-	Output       string
-	ToolCallID   string
-	Details      map[string]any
-	ContentIndex int // block index within provider content; -1 omits the numeric suffix
-	CreatedAt    time.Time
+	SourceID       string
+	SourceSeq      int
+	ProviderItemID string
+	LifecyclePhase string
+	Kind           Kind
+	Role           string
+	Text           string
+	Tool           string
+	Input          map[string]any
+	Output         string
+	ToolCallID     string
+	Details        map[string]any
+	ContentIndex   int // block index within provider content; -1 omits the numeric suffix
+	CreatedAt      time.Time
 }
 
 // ParseOptions controls which fragments are emitted from a provider record.
 type ParseOptions struct {
-	IncludeThinking bool
-	IncludeErrors   bool
+	IncludeThinking           bool
+	IncludeReasoningSummaries bool
+	IncludeErrors             bool
+}
+
+// RecordMeta carries durable provider-event context that is not part of the
+// provider JSON record itself.
+type RecordMeta struct {
+	ProviderEvent string
 }

--- a/internal/runtimeplugin/builtin.go
+++ b/internal/runtimeplugin/builtin.go
@@ -58,6 +58,7 @@ func BuiltinPlugins() []Plugin {
 				SendTurn:             true,
 				InterruptTurn:        true,
 				InterruptThenReplace: true,
+				InTurnSteer:          true,
 				PermissionResponse:   true,
 				ResumeSession:        true,
 			},

--- a/internal/runtimeplugin/plugin_test.go
+++ b/internal/runtimeplugin/plugin_test.go
@@ -196,10 +196,10 @@ func TestBuiltinPluginsDeclareIndependentProviderSessionCapabilities(t *testing.
 				!plugin.Capabilities.PermissionResponse || !plugin.Capabilities.ResumeSession {
 				t.Fatalf("provider-session capabilities = %#v", plugin.Capabilities)
 			}
-			if id == "pi" && !plugin.Capabilities.InTurnSteer {
-				t.Fatal("Pi RPC should advertise direct in-turn steer")
+			if (id == "pi" || id == "codex") && !plugin.Capabilities.InTurnSteer {
+				t.Fatalf("%s should advertise verified direct in-turn steer", id)
 			}
-			if id != "pi" && plugin.Capabilities.InTurnSteer {
+			if id != "pi" && id != "codex" && plugin.Capabilities.InTurnSteer {
 				t.Fatal("provider lacks a verified direct in-turn steer transport")
 			}
 			if plugin.Capabilities.AssistedConclusion {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -116,6 +116,10 @@ type RuntimeControls struct {
 	NativeResumeAvailable   bool                  `json:"native_resume_available"`
 	NativeSteerAvailable    bool                  `json:"native_steer_available"`
 	NativeSteerMode         string                `json:"native_steer_mode,omitempty"`
+	NativeSteerState        string                `json:"native_steer_state,omitempty"`
+	NativeSteerRequestID    string                `json:"native_steer_request_id,omitempty"`
+	NativeSteerErrorCode    string                `json:"native_steer_error_code,omitempty"`
+	NativeSteerError        string                `json:"native_steer_error,omitempty"`
 	QueueSteerAvailable     bool                  `json:"queue_steer_available"`
 	InterruptSteerAvailable bool                  `json:"interrupt_steer_available"`
 	NativeSessionCaptured   bool                  `json:"native_session_captured"`
@@ -1042,7 +1046,31 @@ func (s *Service) AppendEvent(id string, kind EventKind, payload EventPayload) (
 // transaction so it can be committed atomically with another owner-neutral
 // record (for example a durable Accepted Steering request).
 func (s *Service) AppendEventTx(tx *sql.Tx, sessionID string, kind EventKind, payload EventPayload) (Event, error) {
-	return appendEventTx(tx, sessionID, kind, payload, time.Now().UTC())
+	now := time.Now().UTC()
+	event, err := appendEventTx(tx, sessionID, kind, payload, now)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := touchSessionActivityTx(tx, sessionID, now); err != nil {
+		return Event{}, err
+	}
+	return event, nil
+}
+
+func touchSessionActivityTx(tx *sql.Tx, sessionID string, now time.Time) error {
+	result, err := tx.Exec(`UPDATE sessions SET updated_at=?,last_activity_at=? WHERE id=? AND lifecycle=?`,
+		formatTime(now), formatTime(now), sessionID, string(LifecycleOpen))
+	if err != nil {
+		return fmt.Errorf("update Session activity: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count Session activity update: %w", err)
+	}
+	if changed != 1 {
+		return ErrSessionNotOpen
+	}
+	return nil
 }
 
 // AppendConversationEvent stores one user/runtime conversation entry. It is
@@ -1087,58 +1115,87 @@ func (s *Service) AppendConversationInput(id, continuationID, role, text string,
 	return s.appendConversationInput(id, continuationID, input, role, text)
 }
 
-func (s *Service) appendConversationInput(id, continuationID string, input []Attachment, role, text string) ([]Event, Event, error) {
-	found, err := s.Get(id)
-	if err != nil {
-		return nil, Event{}, err
+// PreparedConversationInput stages attachment files and can append their safe
+// Event projections inside a caller-owned transaction. Commit keeps the files;
+// Rollback removes them. Both finalizers are idempotent.
+type PreparedConversationInput struct {
+	service        *Service
+	sessionID      string
+	continuationID string
+	role           string
+	text           string
+	workdir        string
+	copied         []copiedAttachment
+	finalized      bool
+}
+
+// PrepareConversationInput validates one input and stages its attachment files
+// without writing Events. The caller must call Commit after its transaction
+// commits, or Rollback on every failure path.
+func (s *Service) PrepareConversationInput(id, continuationID, role, text string, input []Attachment) (*PreparedConversationInput, error) {
+	role = strings.TrimSpace(role)
+	text = strings.TrimSpace(text)
+	if role == "" && len(input) == 0 {
+		return &PreparedConversationInput{service: s, sessionID: id, continuationID: continuationID, finalized: true}, nil
 	}
-	if found.Lifecycle != LifecycleOpen {
-		return nil, Event{}, ErrSessionNotOpen
-	}
-	if len(input) == 0 && role == "" {
-		return nil, Event{}, nil
+	if role == "" && text != "" || role != "" && text == "" {
+		return nil, ErrMissingInput
 	}
 	if len(input) > MaxAttachmentCount {
-		return nil, Event{}, fmt.Errorf("%w: too many attachments (max %d)", ErrInvalidAttachment, MaxAttachmentCount)
+		return nil, fmt.Errorf("%w: too many attachments (max %d)", ErrInvalidAttachment, MaxAttachmentCount)
+	}
+	found, err := s.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	if found.Lifecycle != LifecycleOpen {
+		return nil, ErrSessionNotOpen
 	}
 	workdir, err := s.managedWorkdir(id)
 	if err != nil {
-		return nil, Event{}, err
+		return nil, err
 	}
 	if filepath.Clean(found.Workdir) != filepath.Clean(workdir) {
-		return nil, Event{}, ErrInvalidWorkdir
+		return nil, ErrInvalidWorkdir
 	}
 	if continuationID != "" {
 		continuation, continuationErr := s.Continuation(continuationID)
 		if continuationErr != nil {
-			return nil, Event{}, continuationErr
+			return nil, continuationErr
 		}
 		if continuation.SessionID != id {
-			return nil, Event{}, ErrContinuationNotFound
+			return nil, ErrContinuationNotFound
 		}
 	}
 	copied, err := copyAttachments(workdir, input)
 	if err != nil {
-		return nil, Event{}, err
+		return nil, err
 	}
-	cleanup := true
-	defer func() {
-		if !cleanup {
-			return
-		}
-		for _, attachment := range copied {
-			_ = os.Remove(filepath.Join(workdir, attachment.Filename))
-		}
-	}()
+	return &PreparedConversationInput{
+		service: s, sessionID: id, continuationID: continuationID,
+		role: role, text: text, workdir: workdir, copied: copied,
+	}, nil
+}
 
-	now := time.Now().UTC()
-	tx, err := s.db.Begin()
-	if err != nil {
-		return nil, Event{}, fmt.Errorf("begin Session conversation input: %w", err)
+// AttachmentReferences returns the safe references that will be stored when
+// AppendTx commits. It is used to construct the provider-visible input before
+// the caller commits the shared transaction.
+func (prepared *PreparedConversationInput) AttachmentReferences() []AttachmentReference {
+	result := make([]AttachmentReference, 0, len(prepared.copied))
+	for _, attachment := range prepared.copied {
+		result = append(result, AttachmentReference{RelativePath: attachment.Filename, ContinuationID: prepared.continuationID})
 	}
-	defer func() { _ = tx.Rollback() }()
+	return result
+}
+
+// AppendTx writes attachment and Conversation Events inside a caller-owned
+// transaction. It does not finalize the staged files.
+func (prepared *PreparedConversationInput) AppendTx(tx *sql.Tx) ([]Event, Event, error) {
+	if prepared == nil || prepared.service == nil || prepared.finalized {
+		return nil, Event{}, errors.New("prepared Session conversation input is unavailable")
+	}
 	var lifecycle string
-	if err := tx.QueryRow(`SELECT lifecycle FROM sessions WHERE id=?`, id).Scan(&lifecycle); err != nil {
+	if err := tx.QueryRow(`SELECT lifecycle FROM sessions WHERE id=?`, prepared.sessionID).Scan(&lifecycle); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, Event{}, ErrNotFound
 		}
@@ -1147,33 +1204,83 @@ func (s *Service) appendConversationInput(id, continuationID string, input []Att
 	if Lifecycle(lifecycle) != LifecycleOpen {
 		return nil, Event{}, ErrSessionNotOpen
 	}
-	events := make([]Event, 0, len(copied))
-	for _, attachment := range copied {
-		event, err := appendEventTx(tx, id, EventKindAttachment, payloadWithContinuation(EventPayload{
+	if prepared.continuationID != "" {
+		var count int
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM session_continuations WHERE id=? AND session_id=?`, prepared.continuationID, prepared.sessionID).Scan(&count); err != nil {
+			return nil, Event{}, fmt.Errorf("validate Session continuation: %w", err)
+		}
+		if count != 1 {
+			return nil, Event{}, ErrContinuationNotFound
+		}
+	}
+	now := time.Now().UTC()
+	events := make([]Event, 0, len(prepared.copied))
+	for _, attachment := range prepared.copied {
+		event, err := appendEventTx(tx, prepared.sessionID, EventKindAttachment, payloadWithContinuation(EventPayload{
 			"filename": attachment.Filename, "relative_path": attachment.Filename,
 			"size": attachment.Size, "sha256": attachment.SHA256,
-		}, continuationID), now)
+		}, prepared.continuationID), now)
 		if err != nil {
 			return nil, Event{}, fmt.Errorf("store Session attachment Event: %w", err)
 		}
 		events = append(events, event)
 	}
 	var conversation Event
-	if role != "" {
-		conversation, err = appendEventTx(tx, id, EventKindConversation, payloadWithContinuation(EventPayload{
-			"role": role, "text": text,
-		}, continuationID), now)
+	var err error
+	if prepared.role != "" {
+		conversation, err = appendEventTx(tx, prepared.sessionID, EventKindConversation, payloadWithContinuation(EventPayload{
+			"role": prepared.role, "text": prepared.text,
+		}, prepared.continuationID), now)
 		if err != nil {
 			return nil, Event{}, fmt.Errorf("store Session conversation Event: %w", err)
 		}
 	}
-	if _, err := tx.Exec(`UPDATE sessions SET updated_at=?,last_activity_at=? WHERE id=?`, formatTime(now), formatTime(now), id); err != nil {
-		return nil, Event{}, fmt.Errorf("update Session activity: %w", err)
+	if err := touchSessionActivityTx(tx, prepared.sessionID, now); err != nil {
+		return nil, Event{}, err
+	}
+	return events, conversation, nil
+}
+
+// Commit keeps staged files after the caller transaction commits.
+func (prepared *PreparedConversationInput) Commit() {
+	if prepared != nil {
+		prepared.finalized = true
+	}
+}
+
+// Rollback removes staged files unless Commit already finalized the input.
+func (prepared *PreparedConversationInput) Rollback() {
+	if prepared == nil || prepared.finalized {
+		return
+	}
+	for _, attachment := range prepared.copied {
+		_ = os.Remove(filepath.Join(prepared.workdir, attachment.Filename))
+	}
+	prepared.finalized = true
+}
+
+func (s *Service) appendConversationInput(id, continuationID string, input []Attachment, role, text string) ([]Event, Event, error) {
+	prepared, err := s.PrepareConversationInput(id, continuationID, role, text, input)
+	if err != nil {
+		return nil, Event{}, err
+	}
+	defer prepared.Rollback()
+	if prepared.finalized {
+		return nil, Event{}, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, Event{}, fmt.Errorf("begin Session conversation input: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	events, conversation, err := prepared.AppendTx(tx)
+	if err != nil {
+		return nil, Event{}, err
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, Event{}, fmt.Errorf("commit Session conversation input: %w", err)
 	}
-	cleanup = false
+	prepared.Commit()
 	return events, conversation, nil
 }
 
@@ -1218,11 +1325,37 @@ func (s *Service) Timeline(id string) ([]Event, error) {
 // RecordRuntimeConfig stores the non-secret Runtime Turn Selection history for
 // a Session. Each explicit configuration change creates a new version.
 func (s *Service) RecordRuntimeConfig(sessionID, runtimeProfileID string, config map[string]any) (RuntimeConfigVersion, error) {
-	if _, err := s.Get(sessionID); err != nil {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return RuntimeConfigVersion{}, fmt.Errorf("begin Session Runtime config: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	version, err := s.RecordRuntimeConfigTx(tx, sessionID, runtimeProfileID, config)
+	if err != nil {
 		return RuntimeConfigVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return RuntimeConfigVersion{}, fmt.Errorf("commit Session Runtime config: %w", err)
+	}
+	return version, nil
+}
+
+// RecordRuntimeConfigTx appends one Runtime Turn Selection version inside a
+// caller-owned transaction. Accepted Steering uses this to keep its selection,
+// Conversation, attachments, and dispatch record atomic.
+func (s *Service) RecordRuntimeConfigTx(tx *sql.Tx, sessionID, runtimeProfileID string, config map[string]any) (RuntimeConfigVersion, error) {
+	if tx == nil {
+		return RuntimeConfigVersion{}, errors.New("Session Runtime config transaction is required")
 	}
 	if strings.TrimSpace(runtimeProfileID) == "" {
 		return RuntimeConfigVersion{}, ErrMissingRuntimeProfile
+	}
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM sessions WHERE id=?`, sessionID).Scan(&count); err != nil {
+		return RuntimeConfigVersion{}, fmt.Errorf("validate Session Runtime config owner: %w", err)
+	}
+	if count != 1 {
+		return RuntimeConfigVersion{}, ErrNotFound
 	}
 	encoded, err := json.Marshal(config)
 	if err != nil {
@@ -1230,11 +1363,6 @@ func (s *Service) RecordRuntimeConfig(sessionID, runtimeProfileID string, config
 	}
 	now := time.Now().UTC()
 	version := RuntimeConfigVersion{ID: "session-config-" + strings.TrimPrefix(newIDMust(), "session-"), SessionID: sessionID, RuntimeProfileID: runtimeProfileID, Config: config, CreatedAt: now}
-	tx, err := s.db.Begin()
-	if err != nil {
-		return RuntimeConfigVersion{}, fmt.Errorf("begin Session Runtime config: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
 	var max sql.NullInt64
 	if err := tx.QueryRow(`SELECT MAX(version) FROM session_runtime_config_versions WHERE session_id=?`, sessionID).Scan(&max); err != nil {
 		return RuntimeConfigVersion{}, fmt.Errorf("read Session Runtime config version: %w", err)
@@ -1242,9 +1370,6 @@ func (s *Service) RecordRuntimeConfig(sessionID, runtimeProfileID string, config
 	version.Version = int(max.Int64) + 1
 	if _, err := tx.Exec(`INSERT INTO session_runtime_config_versions (id,session_id,version,runtime_profile_id,config_json,created_at) VALUES (?,?,?,?,?,?)`, version.ID, sessionID, version.Version, runtimeProfileID, string(encoded), formatTime(now)); err != nil {
 		return RuntimeConfigVersion{}, fmt.Errorf("store Session Runtime config: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return RuntimeConfigVersion{}, fmt.Errorf("commit Session Runtime config: %w", err)
 	}
 	return version, nil
 }
@@ -1586,6 +1711,7 @@ func copyAttachments(workdir string, input []Attachment) ([]copiedAttachment, er
 	}
 	result := make([]copiedAttachment, 0, len(names))
 	created := make([]string, 0, len(names))
+	reserved := reservedAttachmentNames(names)
 	cleanup := func() {
 		for _, name := range created {
 			_ = os.Remove(name)
@@ -1625,21 +1751,66 @@ func copyAttachments(workdir string, input []Attachment) ([]copiedAttachment, er
 			}
 			return nil, fmt.Errorf("write Session attachment %q: %v", item.Filename, firstError(copyErr, closeReaderErr, closeFileErr))
 		}
-		destination := filepath.Join(workdir, item.Filename)
-		if filepath.Dir(destination) != filepath.Clean(workdir) {
-			_ = os.Remove(temporary.Name())
-			cleanup()
-			return nil, fmt.Errorf("%w: %q", ErrInvalidAttachment, item.Filename)
-		}
-		if err := os.Rename(temporary.Name(), destination); err != nil {
+		publishedName, err := publishStagedAttachment(workdir, item.Filename, temporary.Name(), reserved)
+		if err != nil {
 			_ = os.Remove(temporary.Name())
 			cleanup()
 			return nil, fmt.Errorf("publish Session attachment %q: %w", item.Filename, err)
 		}
+		destination := filepath.Join(workdir, publishedName)
 		created = append(created, destination)
-		result = append(result, copiedAttachment{Filename: item.Filename, Size: written, SHA256: hex.EncodeToString(digest.Sum(nil))})
+		result = append(result, copiedAttachment{Filename: publishedName, Size: written, SHA256: hex.EncodeToString(digest.Sum(nil))})
 	}
 	return result, nil
+}
+
+func reservedAttachmentNames(names []namedAttachment) map[string]struct{} {
+	reserved := make(map[string]struct{}, len(names))
+	for _, item := range names {
+		reserved[attachmentNameCollisionKey(item.Filename)] = struct{}{}
+	}
+	return reserved
+}
+
+// publishStagedAttachment reserves the destination with O_EXCL before copying
+// staged bytes. A concurrent upload can therefore force a new unique name but
+// can never replace an existing attachment.
+func publishStagedAttachment(workdir, preferredName, temporaryPath string, reserved map[string]struct{}) (string, error) {
+	name := preferredName
+	for {
+		destination := filepath.Join(workdir, name)
+		if filepath.Dir(destination) != filepath.Clean(workdir) {
+			return "", fmt.Errorf("%w: %q", ErrInvalidAttachment, name)
+		}
+		output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if errors.Is(err, os.ErrExist) {
+			reserved[attachmentNameCollisionKey(name)] = struct{}{}
+			name = uniqueAttachmentName(workdir, preferredName, reserved)
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		input, openErr := os.Open(temporaryPath)
+		if openErr != nil {
+			_ = output.Close()
+			_ = os.Remove(destination)
+			return "", openErr
+		}
+		_, copyErr := io.Copy(output, input)
+		closeInputErr := input.Close()
+		closeOutputErr := output.Close()
+		if copyErr != nil || closeInputErr != nil || closeOutputErr != nil {
+			_ = os.Remove(destination)
+			return "", firstError(copyErr, closeInputErr, closeOutputErr)
+		}
+		if err := os.Remove(temporaryPath); err != nil {
+			_ = os.Remove(destination)
+			return "", err
+		}
+		reserved[attachmentNameCollisionKey(name)] = struct{}{}
+		return name, nil
+	}
 }
 
 type namedAttachment struct {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"pentest/internal/store"
 )
@@ -196,6 +198,157 @@ func TestCreateSessionSafelyCopiesAttachmentsAndCleansPartialWrites(t *testing.T
 	}
 	if len(entries) != 1 || entries[0].Name() != created.ID {
 		t.Fatalf("failed create left Workdir entries: %#v", entries)
+	}
+}
+
+func TestCopyAttachmentsDoesNotOverwriteConcurrentSameName(t *testing.T) {
+	workdir := t.TempDir()
+	ready := make(chan struct{}, 2)
+	release := make(chan struct{})
+	attachment := func(content string) Attachment {
+		return Attachment{
+			Name: "evidence.txt", Size: int64(len(content)),
+			Open: func() (io.ReadCloser, error) {
+				ready <- struct{}{}
+				<-release
+				return io.NopCloser(strings.NewReader(content)), nil
+			},
+		}
+	}
+	type outcome struct {
+		attachments []copiedAttachment
+		err         error
+	}
+	results := make(chan outcome, 2)
+	var started sync.WaitGroup
+	started.Add(2)
+	for _, content := range []string{"alpha", "beta"} {
+		content := content
+		go func() {
+			started.Done()
+			attachments, err := copyAttachments(workdir, []Attachment{attachment(content)})
+			results <- outcome{attachments: attachments, err: err}
+		}()
+	}
+	started.Wait()
+	<-ready
+	<-ready
+	close(release)
+
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("concurrent attachment errors = %v, %v", first.err, second.err)
+	}
+	if len(first.attachments) != 1 || len(second.attachments) != 1 {
+		t.Fatalf("concurrent attachment results = %#v, %#v", first.attachments, second.attachments)
+	}
+	firstName, secondName := first.attachments[0].Filename, second.attachments[0].Filename
+	if attachmentNameCollisionKey(firstName) == attachmentNameCollisionKey(secondName) {
+		t.Fatalf("concurrent attachments reused filename %q", firstName)
+	}
+	contents := map[string]bool{}
+	for _, name := range []string{firstName, secondName} {
+		data, err := os.ReadFile(filepath.Join(workdir, name))
+		if err != nil {
+			t.Fatalf("read concurrent attachment %q: %v", name, err)
+		}
+		contents[string(data)] = true
+	}
+	if !contents["alpha"] || !contents["beta"] {
+		t.Fatalf("concurrent attachment contents = %#v", contents)
+	}
+}
+
+func TestAppendEventTxAdvancesSessionActivity(t *testing.T) {
+	dataRoot := t.TempDir()
+	db, err := store.Open(filepath.Join(dataRoot, "pentest.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	service := NewService(db, filepath.Join(dataRoot, "sessions"))
+	created, err := service.Create(CreateRequest{Input: "Initial message"})
+	if err != nil {
+		t.Fatalf("create Session: %v", err)
+	}
+	old := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := db.Exec(`UPDATE sessions SET updated_at=?,last_activity_at=? WHERE id=?`, formatTime(old), formatTime(old), created.ID); err != nil {
+		t.Fatalf("age Session activity: %v", err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin caller transaction: %v", err)
+	}
+	if _, err := service.AppendEventTx(tx, created.ID, EventKindConversation, EventPayload{"role": "user", "text": "steer"}); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("append Event in caller transaction: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit caller transaction: %v", err)
+	}
+	updated, err := service.Get(created.ID)
+	if err != nil {
+		t.Fatalf("read updated Session: %v", err)
+	}
+	if !updated.LastActivityAt.After(old) || !updated.UpdatedAt.After(old) {
+		t.Fatalf("Session activity was not advanced: %#v", updated)
+	}
+}
+
+func TestPreparedConversationInputRollbackRemovesFilesAndEvents(t *testing.T) {
+	dataRoot := t.TempDir()
+	db, err := store.Open(filepath.Join(dataRoot, "pentest.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	service := NewService(db, filepath.Join(dataRoot, "sessions"))
+	created, err := service.Create(CreateRequest{Input: "Initial message"})
+	if err != nil {
+		t.Fatalf("create Session: %v", err)
+	}
+
+	prepared, err := service.PrepareConversationInput(created.ID, "", "user", "Steer with evidence", []Attachment{
+		inMemoryAttachment("evidence.txt", "proof"),
+	})
+	if err != nil {
+		t.Fatalf("prepare conversation input: %v", err)
+	}
+	defer prepared.Rollback()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin caller transaction: %v", err)
+	}
+	if _, _, err := prepared.AppendTx(tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("append prepared input: %v", err)
+	}
+	if _, err := service.RecordRuntimeConfigTx(tx, created.ID, "profile-1", map[string]any{"model": "gpt-test"}); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("append Runtime config: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback caller transaction: %v", err)
+	}
+	prepared.Rollback()
+
+	events, err := service.Events(created.ID)
+	if err != nil {
+		t.Fatalf("list Session events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("rolled-back input left %d Events, want 1 initial Event", len(events))
+	}
+	versions, err := service.RuntimeConfigVersions(created.ID)
+	if err != nil {
+		t.Fatalf("list Session Runtime configs: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("rolled-back input left Runtime config versions: %#v", versions)
+	}
+	if _, err := os.Stat(filepath.Join(created.Workdir, "evidence.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rolled-back input left attachment, stat err=%v", err)
 	}
 }
 
@@ -435,6 +588,44 @@ func TestSessionContinuationsRetainRuntimeSelectionAndSeparateConversationFromTi
 	}
 	if len(versions) != 1 || versions[0].Config["reasoning_effort"] != "high" {
 		t.Fatalf("runtime config versions = %#v", versions)
+	}
+}
+
+func TestPublishStagedAttachmentDoesNotReplaceExistingFile(t *testing.T) {
+	workdir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workdir, "notes.txt"), []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	temporary, err := os.CreateTemp(workdir, ".staged-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := temporary.WriteString("new"); err != nil {
+		t.Fatal(err)
+	}
+	if err := temporary.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := publishStagedAttachment(workdir, "notes.txt", temporary.Name(), map[string]struct{}{
+		attachmentNameCollisionKey("notes.txt"): {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "notes-1.txt" {
+		t.Fatalf("published name = %q, want notes-1.txt", name)
+	}
+	existing, err := os.ReadFile(filepath.Join(workdir, "notes.txt"))
+	if err != nil || string(existing) != "existing" {
+		t.Fatalf("existing attachment = %q, err=%v", existing, err)
+	}
+	published, err := os.ReadFile(filepath.Join(workdir, name))
+	if err != nil || string(published) != "new" {
+		t.Fatalf("published attachment = %q, err=%v", published, err)
+	}
+	if _, err := os.Stat(temporary.Name()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staged file remained after publish: %v", err)
 	}
 }
 

--- a/internal/steering/steering.go
+++ b/internal/steering/steering.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"pentest/internal/owner"
@@ -34,28 +35,70 @@ var ErrInvalidReason = errors.New("invalid accepted steering reason")
 // AcceptRequest is the owner-neutral durable payload of one accepted steer.
 // Raw provider text never enters this record.
 type AcceptRequest struct {
-	RequestID                string
+	RequestID string
+	// OperatorMessage is the canonical Conversation text used for idempotency.
+	// Message may additionally contain provider-only attachment path context.
+	// ClientSelectionIdentity is the canonical identity of the raw
+	// client-controlled Model Provider, model, and Requested Reasoning Effort.
+	// Empty means a legacy record whose raw selection identity is unknown.
+	ClientSelectionIdentity  string
+	OperatorMessage          string
 	Message                  string
 	Mode                     owner.SteeringMode
 	ModelProviderID          string
 	Model                    string
 	RequestedReasoningEffort string
 	SessionID                string
+	ExpectedProviderTurnID   string
 }
 
 // Service persists Accepted Steering records. Task and Session owners share
 // the same table and the same transition vocabulary.
 type Service struct {
-	db *store.DB
+	db           *store.DB
+	requestMu    sync.Mutex
+	requestLocks map[string]*steeringRequestLock
+}
+
+type steeringRequestLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 func NewService(db *store.DB) *Service {
-	return &Service{db: db}
+	return &Service{db: db, requestLocks: make(map[string]*steeringRequestLock)}
 }
 
-const steeringRecordColumns = `id, owner_kind, owner_id, request_id, message, mode, model_provider_id, model,
+// AcquireRequest serializes acceptance side effects for one owner/request
+// identity. SQLite still enforces the durable uniqueness constraint; this guard
+// prevents Session attachment staging from creating duplicate projection Events
+// while two identical HTTP requests race inside one daemon.
+func (s *Service) AcquireRequest(kind owner.Kind, ownerID, requestID string) func() {
+	key := string(kind) + "\x00" + strings.TrimSpace(ownerID) + "\x00" + strings.TrimSpace(requestID)
+	s.requestMu.Lock()
+	lock := s.requestLocks[key]
+	if lock == nil {
+		lock = &steeringRequestLock{}
+		s.requestLocks[key] = lock
+	}
+	lock.refs++
+	s.requestMu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		s.requestMu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(s.requestLocks, key)
+		}
+		s.requestMu.Unlock()
+	}
+}
+
+const steeringRecordColumns = `id, owner_kind, owner_id, request_id, client_selection_identity, operator_message, message, mode, model_provider_id, model,
 	requested_reasoning_effort, state, queue_order, conversation_event_id, continuation_id, session_id,
-	send_started_at, result_json, error_code, error_message, created_at, updated_at`
+	expected_provider_turn_id, send_started_at, result_json, error_code, error_message, created_at, updated_at`
 
 // Accept durably records one Accepted Steering request together with its
 // conversation projection in one transaction. The projection callback appends
@@ -69,7 +112,10 @@ func (s *Service) Accept(ctx context.Context, kind owner.Kind, ownerID string, i
 	if strings.TrimSpace(ownerID) == "" || strings.TrimSpace(input.RequestID) == "" || strings.TrimSpace(input.Message) == "" {
 		return nil, fmt.Errorf("Accepted Steering requires owner, request identity, and message")
 	}
-	if input.Mode != owner.SteeringModeInTurnSteer && input.Mode != owner.SteeringModeInterruptThenReplace {
+	if strings.TrimSpace(input.OperatorMessage) == "" {
+		input.OperatorMessage = input.Message
+	}
+	if input.Mode != owner.SteeringModeSendTurn && input.Mode != owner.SteeringModeInTurnSteer && input.Mode != owner.SteeringModeInterruptThenReplace {
 		return nil, fmt.Errorf("invalid Accepted Steering mode %q", input.Mode)
 	}
 	now := time.Now().UTC()
@@ -88,15 +134,16 @@ func (s *Service) Accept(ctx context.Context, kind owner.Kind, ownerID string, i
 	}
 	id := newID()
 	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO accepted_steering (id, owner_kind, owner_id, request_id, message, mode, model_provider_id, model,
+		INSERT INTO accepted_steering (id, owner_kind, owner_id, request_id, client_selection_identity, operator_message, message, mode, model_provider_id, model,
 			requested_reasoning_effort, state, queue_order, conversation_event_id, continuation_id, session_id,
-			send_started_at, result_json, error_code, error_message, created_at, updated_at)
-		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(MAX(queue_order), 0) + 1, ?, '', ?, '', '{}', '', '', ?, ?
+			expected_provider_turn_id, send_started_at, result_json, error_code, error_message, created_at, updated_at)
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(MAX(queue_order), 0) + 1, ?, '', ?, ?, '', '{}', '', '', ?, ?
 			FROM accepted_steering WHERE owner_kind = ? AND owner_id = ?`,
-		id, string(kind), ownerID, strings.TrimSpace(input.RequestID), strings.TrimSpace(input.Message),
-		string(input.Mode), strings.TrimSpace(input.ModelProviderID), strings.TrimSpace(input.Model),
+		id, string(kind), ownerID, strings.TrimSpace(input.RequestID), strings.TrimSpace(input.ClientSelectionIdentity),
+		strings.TrimSpace(input.OperatorMessage), strings.TrimSpace(input.Message), string(input.Mode),
+		strings.TrimSpace(input.ModelProviderID), strings.TrimSpace(input.Model),
 		strings.TrimSpace(input.RequestedReasoningEffort), string(owner.SteeringPending),
-		conversationEventID, strings.TrimSpace(input.SessionID),
+		conversationEventID, strings.TrimSpace(input.SessionID), strings.TrimSpace(input.ExpectedProviderTurnID),
 		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano),
 		string(kind), ownerID,
 	); err != nil {
@@ -125,6 +172,22 @@ func (s *Service) ByRequestID(kind owner.Kind, ownerID, requestID string) (*owne
 	}
 	if err != nil {
 		return nil, fmt.Errorf("load Accepted Steering: %w", err)
+	}
+	return record, nil
+}
+
+// Latest returns the newest durable Accepted Steering record for one Runtime
+// Owner. Runtime Controls use this record as their source of truth; owner Events
+// are only Timeline and Conversation projections.
+func (s *Service) Latest(kind owner.Kind, ownerID string) (*owner.SteeringRecord, error) {
+	record, err := scanSteeringRecord(s.db.QueryRow(`SELECT `+steeringRecordColumns+`
+		FROM accepted_steering WHERE owner_kind=? AND owner_id=? ORDER BY queue_order DESC LIMIT 1`,
+		string(kind), ownerID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load latest Accepted Steering: %w", err)
 	}
 	return record, nil
 }
@@ -192,7 +255,10 @@ func (s *Service) MarkDispatchStarted(ctx context.Context, id, continuationID st
 
 // MarkApplied records the terminal delivered outcome with the redacted
 // provider result as delivery evidence.
-func (s *Service) MarkApplied(ctx context.Context, id string, result map[string]any) (*owner.SteeringRecord, error) {
+func (s *Service) MarkApplied(ctx context.Context, id string, mode owner.SteeringMode, result map[string]any) (*owner.SteeringRecord, error) {
+	if mode != owner.SteeringModeSendTurn && mode != owner.SteeringModeInTurnSteer && mode != owner.SteeringModeInterruptThenReplace {
+		return nil, fmt.Errorf("invalid applied Accepted Steering mode %q", mode)
+	}
 	evidence, err := json.Marshal(result)
 	if err != nil {
 		return nil, fmt.Errorf("encode Accepted Steering result: %w", err)
@@ -203,11 +269,12 @@ func (s *Service) MarkApplied(ctx context.Context, id string, result map[string]
 		}
 		stamp := time.Now().UTC().Format(time.RFC3339Nano)
 		if _, err := tx.ExecContext(ctx, `UPDATE accepted_steering
-			SET state=?, result_json=?, updated_at=? WHERE id=?`,
-			string(owner.SteeringApplied), string(evidence), stamp, id); err != nil {
+			SET state=?, mode=?, result_json=?, updated_at=? WHERE id=?`,
+			string(owner.SteeringApplied), string(mode), string(evidence), stamp, id); err != nil {
 			return err
 		}
 		current.State = owner.SteeringApplied
+		current.Mode = mode
 		current.Result = result
 		current.UpdatedAt = time.Now().UTC()
 		return nil
@@ -337,10 +404,11 @@ func (s *Service) transition(ctx context.Context, id string, apply steeringTrans
 
 // steeringScan is the raw row shape of the accepted_steering table.
 type steeringScan struct {
-	id, ownerKind, ownerID, requestID, message, mode                       string
-	modelProviderID, model, requestedReasoningEffort, state                string
-	queueOrder                                                             int
-	conversationEventID, continuationID, sessionID                         string
+	id, ownerKind, ownerID, requestID, clientSelectionIdentity               string
+	operatorMessage, message, mode, modelProviderID, model                   string
+	requestedReasoningEffort, state                                          string
+	queueOrder                                                               int
+	conversationEventID, continuationID, sessionID, expectedProviderTurnID   string
 	sendStartedAt, resultJSON, errorCode, errorMessage, createdAt, updatedAt string
 }
 
@@ -350,6 +418,8 @@ func (scan *steeringScan) decode() (*owner.SteeringRecord, error) {
 		OwnerKind:                owner.Kind(scan.ownerKind),
 		OwnerID:                  scan.ownerID,
 		RequestID:                scan.requestID,
+		ClientSelectionIdentity:  scan.clientSelectionIdentity,
+		OperatorMessage:          scan.operatorMessage,
 		Message:                  scan.message,
 		Mode:                     owner.SteeringMode(scan.mode),
 		ModelProviderID:          scan.modelProviderID,
@@ -360,6 +430,7 @@ func (scan *steeringScan) decode() (*owner.SteeringRecord, error) {
 		ConversationEventID:      scan.conversationEventID,
 		ContinuationID:           scan.continuationID,
 		SessionID:                scan.sessionID,
+		ExpectedProviderTurnID:   scan.expectedProviderTurnID,
 		ErrorCode:                owner.SteeringFailureReason(scan.errorCode),
 		ErrorMessage:             scan.errorMessage,
 	}
@@ -385,10 +456,10 @@ func (scan *steeringScan) decode() (*owner.SteeringRecord, error) {
 
 func (scan *steeringScan) targets() []any {
 	return []any{
-		&scan.id, &scan.ownerKind, &scan.ownerID, &scan.requestID, &scan.message, &scan.mode,
+		&scan.id, &scan.ownerKind, &scan.ownerID, &scan.requestID, &scan.clientSelectionIdentity, &scan.operatorMessage, &scan.message, &scan.mode,
 		&scan.modelProviderID, &scan.model, &scan.requestedReasoningEffort, &scan.state,
 		&scan.queueOrder, &scan.conversationEventID, &scan.continuationID, &scan.sessionID,
-		&scan.sendStartedAt, &scan.resultJSON, &scan.errorCode, &scan.errorMessage, &scan.createdAt, &scan.updatedAt,
+		&scan.expectedProviderTurnID, &scan.sendStartedAt, &scan.resultJSON, &scan.errorCode, &scan.errorMessage, &scan.createdAt, &scan.updatedAt,
 	}
 }
 

--- a/internal/steering/steering_test.go
+++ b/internal/steering/steering_test.go
@@ -23,7 +23,10 @@ func newTestService(t *testing.T) *Service {
 func TestAcceptAssignsFIFOQueueOrderPerOwner(t *testing.T) {
 	service := newTestService(t)
 	ctx := context.Background()
-	input := AcceptRequest{RequestID: "req-1", Message: "first", Mode: owner.SteeringModeInTurnSteer}
+	input := AcceptRequest{
+		RequestID: "req-1", Message: "first", Mode: owner.SteeringModeInTurnSteer,
+		ExpectedProviderTurnID: "turn-expected",
+	}
 	first, err := service.Accept(ctx, owner.KindTask, "task-1", input, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -39,12 +42,38 @@ func TestAcceptAssignsFIFOQueueOrderPerOwner(t *testing.T) {
 	if first.State != owner.SteeringPending || first.QueueOrder != 1 || second.QueueOrder != 2 {
 		t.Fatalf("task queue order = %d, %d (states %s, %s), want 1 then 2", first.QueueOrder, second.QueueOrder, first.State, second.State)
 	}
+	if first.ExpectedProviderTurnID != "turn-expected" || sessionFirst.ExpectedProviderTurnID != "turn-expected" {
+		t.Fatalf("expected provider Turn was not durable: task=%#v session=%#v", first, sessionFirst)
+	}
 	if sessionFirst.QueueOrder != 1 {
 		t.Fatalf("session queue order = %d, want owner-local order 1", sessionFirst.QueueOrder)
 	}
 	oldest, err := service.OldestPending(owner.KindTask, "task-1")
 	if err != nil || oldest == nil || oldest.RequestID != "req-1" {
 		t.Fatalf("oldest pending = %#v err=%v, want req-1", oldest, err)
+	}
+}
+
+func TestAcceptPersistsClientSelectionIdentity(t *testing.T) {
+	service := newTestService(t)
+	ctx := context.Background()
+	const identity = "{\"model_provider_id\":\"provider-1\",\"model\":\"model-1\",\"requested_reasoning_effort\":\"high\"}"
+	record, err := service.Accept(ctx, owner.KindTask, "task-1", AcceptRequest{
+		RequestID: "selection-identity", Message: "focus", Mode: owner.SteeringModeInTurnSteer,
+		ClientSelectionIdentity: identity,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.ClientSelectionIdentity != identity {
+		t.Fatalf("accepted client selection identity = %q, want %q", record.ClientSelectionIdentity, identity)
+	}
+	loaded, err := service.ByRequestID(owner.KindTask, "task-1", "selection-identity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ClientSelectionIdentity != identity {
+		t.Fatalf("loaded client selection identity = %q, want %q", loaded.ClientSelectionIdentity, identity)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -946,7 +946,125 @@ func migrations() []migration {
 		newMigration(59, "project_approval_workflows", migration59SQL, migration59Up),
 		newMigration(60, "blackboard_conclusion_directive_kind", migration60SQL, migration60Up),
 		newMigration(61, "slash_form_evidence_path_identities", migration61SQL, migration61Up),
+		newMigration(62, "accepted_steering_expected_provider_turn", migration62SQL, migration62Up),
+		newMigration(63, "accepted_steering_send_turn_mode", migration63SQL, migration63Up),
+		newMigration(64, "accepted_steering_operator_message", migration64SQL, migration64Up),
+		newMigration(65, "accepted_steering_client_selection_identity", migration65SQL, migration65Up),
 	}
+}
+
+// migration65SQL preserves the exact client-controlled Runtime Turn Selection
+// identity for Accepted Steering replay. Empty identifies a legacy record for
+// which the raw omitted-versus-explicit selection cannot be reconstructed.
+const migration65SQL = `
+ALTER TABLE accepted_steering ADD COLUMN client_selection_identity TEXT NOT NULL DEFAULT '';
+`
+
+func migration65Up(tx *sql.Tx) error {
+	present, err := storeTableHasColumn(tx, "accepted_steering", "client_selection_identity")
+	if err != nil {
+		return err
+	}
+	if present {
+		return nil
+	}
+	return execStatements(tx, migration65SQL)
+}
+
+// migration64SQL separates the canonical operator Conversation text from the
+// provider delivery message, which can contain resolved attachment paths.
+const migration64SQL = `
+ALTER TABLE accepted_steering ADD COLUMN operator_message TEXT NOT NULL DEFAULT '';
+UPDATE accepted_steering
+SET operator_message=COALESCE(
+	NULLIF(CASE owner_kind
+		WHEN 'session' THEN (
+			SELECT json_extract(payload_json,'$.text') FROM session_events
+			WHERE id=accepted_steering.conversation_event_id AND session_id=accepted_steering.owner_id
+		)
+		WHEN 'task' THEN (
+			SELECT json_extract(payload_json,'$.text') FROM task_events
+			WHERE id=accepted_steering.conversation_event_id AND task_id=accepted_steering.owner_id
+		)
+	END, ''),
+	message
+)
+WHERE operator_message='';
+`
+
+func migration64Up(tx *sql.Tx) error {
+	present, err := storeTableHasColumn(tx, "accepted_steering", "operator_message")
+	if err != nil {
+		return err
+	}
+	if present {
+		return nil
+	}
+	return execStatements(tx, migration64SQL)
+}
+
+// migration63SQL extends Accepted Steering to represent an operator message
+// sent while the persistent provider Session has no active Runtime Turn.
+const migration63SQL = `
+ALTER TABLE accepted_steering RENAME TO accepted_steering_v63;
+CREATE TABLE accepted_steering (
+	id TEXT PRIMARY KEY,
+	owner_kind TEXT NOT NULL CHECK (owner_kind IN ('task', 'session')),
+	owner_id TEXT NOT NULL,
+	request_id TEXT NOT NULL,
+	message TEXT NOT NULL,
+	mode TEXT NOT NULL CHECK (mode IN ('send_turn', 'in_turn_steer', 'interrupt_then_replace')),
+	model_provider_id TEXT NOT NULL DEFAULT '',
+	model TEXT NOT NULL DEFAULT '',
+	requested_reasoning_effort TEXT NOT NULL DEFAULT '',
+	state TEXT NOT NULL CHECK (state IN ('pending', 'dispatch_started', 'applied', 'failed', 'action_required')),
+	queue_order INTEGER NOT NULL,
+	conversation_event_id TEXT NOT NULL DEFAULT '',
+	continuation_id TEXT NOT NULL DEFAULT '',
+	session_id TEXT NOT NULL DEFAULT '',
+	expected_provider_turn_id TEXT NOT NULL DEFAULT '',
+	send_started_at TEXT NOT NULL DEFAULT '',
+	result_json TEXT NOT NULL DEFAULT '{}',
+	error_code TEXT NOT NULL DEFAULT '',
+	error_message TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	UNIQUE (owner_kind, owner_id, request_id)
+);
+INSERT INTO accepted_steering (
+	id, owner_kind, owner_id, request_id, message, mode, model_provider_id, model,
+	requested_reasoning_effort, state, queue_order, conversation_event_id, continuation_id, session_id,
+	expected_provider_turn_id, send_started_at, result_json, error_code, error_message, created_at, updated_at
+)
+SELECT
+	id, owner_kind, owner_id, request_id, message, mode, model_provider_id, model,
+	requested_reasoning_effort, state, queue_order, conversation_event_id, continuation_id, session_id,
+	expected_provider_turn_id, send_started_at, result_json, error_code, error_message, created_at, updated_at
+FROM accepted_steering_v63;
+DROP TABLE accepted_steering_v63;
+CREATE INDEX idx_accepted_steering_owner_queue
+	ON accepted_steering(owner_kind, owner_id, queue_order ASC);
+CREATE INDEX idx_accepted_steering_state
+	ON accepted_steering(state ASC);
+`
+
+func migration63Up(tx *sql.Tx) error { return execStatements(tx, migration63SQL) }
+
+// migration62SQL binds provider-native same-turn Steering to the exact active
+// provider Turn observed when the operator request was durably accepted.
+const migration62SQL = `
+ALTER TABLE accepted_steering ADD COLUMN expected_provider_turn_id TEXT NOT NULL DEFAULT '';
+`
+
+func migration62Up(tx *sql.Tx) error {
+	present, err := storeTableHasColumn(tx, "accepted_steering", "expected_provider_turn_id")
+	if err != nil {
+		return err
+	}
+	if present {
+		return nil
+	}
+	return execStatements(tx, migration62SQL)
 }
 
 // migration61SQL records the canonical slash-form identity cutover for

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1561,3 +1561,100 @@ func TestMigration58AddsChallengeOperationRecoverySettlement(t *testing.T) {
 		t.Fatalf("set action_required after migration 58: %v", err)
 	}
 }
+
+func TestMigration65MarksLegacyClientSelectionIdentityUnknown(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pentest.db")
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(`INSERT INTO accepted_steering (
+		id,owner_kind,owner_id,request_id,operator_message,message,mode,state,queue_order,created_at,updated_at
+	) VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+		"legacy-selection", "task", "task-1", "request-1", "focus", "focus", "in_turn_steer", "pending", 1, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DELETE FROM schema_migrations WHERE version=65`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE accepted_steering DROP COLUMN client_selection_identity`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	var identity string
+	if err := reopened.QueryRow(`SELECT client_selection_identity FROM accepted_steering WHERE id='legacy-selection'`).Scan(&identity); err != nil {
+		t.Fatal(err)
+	}
+	if identity != "" {
+		t.Fatalf("legacy client selection identity = %q, want unknown empty identity", identity)
+	}
+}
+
+func TestMigration64BackfillsOperatorMessageFromConversationEvent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pentest.db")
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(`INSERT INTO session_events (id,session_id,seq,kind,payload_json,created_at) VALUES (?,?,?,?,?,?)`,
+		"session-conversation-1", "session-1", 1, "conversation", `{"role":"user","text":"focus login"}`, stamp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO task_events (id,task_id,seq,kind,payload_json,created_at) VALUES (?,?,?,?,?,?)`,
+		"task-conversation-1", "task-1", 1, "conversation", `{"role":"user","text":"focus task"}`, stamp); err != nil {
+		t.Fatal(err)
+	}
+	insert := func(id, kind, ownerID, message, conversationID string) {
+		t.Helper()
+		if _, err := db.Exec(`INSERT INTO accepted_steering (
+			id,owner_kind,owner_id,request_id,operator_message,message,mode,model_provider_id,model,
+			requested_reasoning_effort,state,queue_order,conversation_event_id,continuation_id,session_id,
+			expected_provider_turn_id,send_started_at,result_json,error_code,error_message,created_at,updated_at
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			id, kind, ownerID, "request-"+id, message, message, "interrupt_then_replace", "", "", "",
+			"pending", 1, conversationID, "", "provider-session", "", "", `{}`, "", "", stamp, stamp); err != nil {
+			t.Fatal(err)
+		}
+	}
+	insert("steer-session", "session", "session-1", "focus login\n\nATTACHED FILES:\n- /work/login.txt", "session-conversation-1")
+	insert("steer-task", "task", "task-1", "focus task\n\nATTACHED FILES:\n- /work/task.txt", "task-conversation-1")
+	insert("steer-fallback", "session", "session-2", "provider fallback", "missing-conversation")
+	if _, err := db.Exec(`DELETE FROM schema_migrations WHERE version=64`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE accepted_steering DROP COLUMN operator_message`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	for id, want := range map[string]string{
+		"steer-session":  "focus login",
+		"steer-task":     "focus task",
+		"steer-fallback": "provider fallback",
+	} {
+		var got string
+		if err := reopened.QueryRow(`SELECT operator_message FROM accepted_steering WHERE id=?`, id).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Errorf("%s operator_message = %q, want %q", id, got, want)
+		}
+	}
+}

--- a/internal/store/store_v2_test.go
+++ b/internal/store/store_v2_test.go
@@ -135,7 +135,7 @@ func TestOrdinaryOpenRefusesUnknownEpochWithoutTouchingSQLiteState(t *testing.T)
 			prepare: func(t *testing.T, path string) func() {
 				return holdStoreEpochUpdateInWAL(t, path, "future_v3")
 			},
-			wantMigrationCount: 61,
+			wantMigrationCount: 65,
 			wantSidecars:       true,
 		},
 	}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -457,6 +457,8 @@ type RuntimeControls struct {
 	NativeSteerMode       string `json:"native_steer_mode,omitempty"`
 	NativeSteerState      string `json:"native_steer_state,omitempty"`
 	NativeSteerRequestID  string `json:"native_steer_request_id,omitempty"`
+	NativeSteerErrorCode  string `json:"native_steer_error_code,omitempty"`
+	NativeSteerError      string `json:"native_steer_error,omitempty"`
 	NativeSteerReason     string `json:"native_steer_reason,omitempty"`
 	ResumeAvailable       bool   `json:"resume_available"`
 	// FinishAvailable is true only when Runtime Activity is live and idle.

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -41,8 +41,9 @@ type Event struct {
 }
 
 var timelineParseOpts = runtimeoutput.ParseOptions{
-	IncludeThinking: true,
-	IncludeErrors:   true,
+	IncludeThinking:           true,
+	IncludeReasoningSummaries: true,
+	IncludeErrors:             true,
 }
 
 // Build projects owner events into coalesced timeline items.
@@ -51,7 +52,7 @@ func Build(events []Event) []Item {
 	nextSeq := 1
 	turns := make([]runtimeoutput.Turn, 0, len(events))
 	flushTurns := func() {
-		for _, item := range turnsToItems(runtimeoutput.CoalesceStreaming(turns)) {
+		for _, item := range turnsToItems(runtimeoutput.CoalesceStreaming(runtimeoutput.ReconcileLifecycle(turns))) {
 			if item.Seq <= 0 {
 				item.Seq = nextSeq
 			}
@@ -118,7 +119,9 @@ func Build(events []Event) []Item {
 			if runtimeoutput.ShouldIgnoreForTimeline(text) {
 				continue
 			}
-			lineTurns, _ := runtimeoutput.ParseLine(text, event.CreatedAt, timelineParseOpts)
+			lineTurns, _ := runtimeoutput.ParseLineWithMeta(text, runtimeoutput.RecordMeta{
+				ProviderEvent: stringValue(event.Payload, "provider_event"),
+			}, event.CreatedAt, timelineParseOpts)
 			for index := range lineTurns {
 				lineTurns[index].SourceID = event.ID
 				lineTurns[index].SourceSeq = event.Seq
@@ -244,7 +247,9 @@ func steeringItem(event Event) (Item, bool) {
 
 func turnToItem(turn runtimeoutput.Turn) (Item, bool) {
 	id := turn.SourceID
-	if id != "" {
+	if stable := runtimeoutput.StableProviderItemID(turn.ProviderItemID, string(turn.Kind)); stable != "" {
+		id = stable
+	} else if id != "" {
 		id = fmt.Sprintf("%s-%s-%d", id, turn.Kind, turn.ContentIndex)
 	}
 	switch turn.Kind {

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -36,6 +36,47 @@ func TestBuildParsesThinkingToolUseTextAndResult(t *testing.T) {
 	requireItem(t, got, 4, "text", "", "Done inspecting.")
 }
 
+func TestBuildReconcilesCodexItemLifecycle(t *testing.T) {
+	createdAt := time.Date(2026, 8, 26, 9, 0, 0, 0, time.UTC)
+	events := []timeline.Event{
+		{ID: "ev-1", Seq: 1, Kind: "runtime_output", Payload: map[string]any{
+			"provider_event": "item/started",
+			"text":           `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","status":"inProgress"}}`,
+		}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{
+			"provider_event": "item/started",
+			"text":           `{"item":{"type":"reasoning","id":"item-reasoning","summary":[]}}`,
+		}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: "runtime_output", Payload: map[string]any{
+			"provider_event": "item/completed",
+			"text":           `{"item":{"type":"reasoning","id":"item-reasoning","summary":["Checked the target."]}}`,
+		}, CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "ev-4", Seq: 4, Kind: "runtime_output", Payload: map[string]any{
+			"provider_event": "item/completed",
+			"text":           `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","aggregatedOutput":"200 OK","status":"completed"}}`,
+		}, CreatedAt: createdAt.Add(3 * time.Second)},
+	}
+
+	got := timeline.Build(events)
+	var toolUses, toolResults, thinking int
+	for _, item := range got {
+		switch item.Type {
+		case "tool_use":
+			toolUses++
+		case "tool_result":
+			toolResults++
+		case "thinking":
+			thinking++
+			if item.Content != "Checked the target." {
+				t.Fatalf("thinking = %#v", item)
+			}
+		}
+	}
+	if toolUses != 1 || toolResults != 1 || thinking != 1 {
+		t.Fatalf("Timeline lifecycle counts: tool_use=%d tool_result=%d thinking=%d items=%#v", toolUses, toolResults, thinking, got)
+	}
+}
+
 func TestBuildGivesMultipleItemsFromOneEventStableDistinctIDs(t *testing.T) {
 	createdAt := time.Date(2026, 8, 8, 10, 0, 0, 0, time.UTC)
 	items := timeline.Build([]timeline.Event{{

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	KindMessage       = "message"
+	KindThinking      = "thinking"
 	KindToolCall      = "tool_call"
 	KindToolResult    = "tool_result"
 	KindRuntimeOutput = "runtime_output"
@@ -132,6 +133,25 @@ func BuildWindow(subject Subject, events []Event, context WindowContext) []Entry
 // Continuation so a streamed sentence is one row, not one row per token.
 func appendOrCoalesceTranscript(entries, next []Entry) []Entry {
 	for _, entry := range next {
+		if entry.ID != "" {
+			replaced := false
+			for index := range entries {
+				if entries[index].ID == entry.ID {
+					// A completed provider item enriches the row projected when the
+					// item started. Keep the first projection's history position so
+					// Transcript Seq order and same-Seq page boundaries stay valid.
+					entry.Seq = entries[index].Seq
+					entry.Continuation = entries[index].Continuation
+					entry.CreatedAt = entries[index].CreatedAt
+					entries[index] = entry
+					replaced = true
+					break
+				}
+			}
+			if replaced {
+				continue
+			}
+		}
 		if n := len(entries); n > 0 && canMergeAssistantMessage(entries[n-1], entry) {
 			entries[n-1].Text += entry.Text
 			entries[n-1].Seq = entry.Seq
@@ -348,7 +368,9 @@ func parseRuntimeOutput(event Event, continuation int, adapter, text string) ([]
 		CreatedAt:    event.CreatedAt,
 		Stream:       stringValue(event.Payload, "stream"),
 	}
-	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{}, base.CreatedAt)
+	turns := runtimeoutput.ParseRecordWithMeta(record, runtimeoutput.RecordMeta{
+		ProviderEvent: stringValue(event.Payload, "provider_event"),
+	}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, base.CreatedAt)
 	if len(turns) == 0 {
 		return nil, false
 	}
@@ -374,14 +396,16 @@ func ParserForAdapter(adapter string, registry *runtimeplugin.Registry) string {
 // derived entries inherit. It is exported so runtime tails can reuse the same
 // parsing as the post-hoc transcript builder.
 func ParseRecord(record map[string]any, base Entry) []Entry {
-	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{}, base.CreatedAt)
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, base.CreatedAt)
 	return turnsToEntries(turns, base)
 }
 
 func turnsToEntries(turns []runtimeoutput.Turn, base Entry) []Entry {
 	entries := make([]Entry, 0, len(turns))
-	for _, turn := range turns {
+	for _, turn := range runtimeoutput.ReconcileLifecycle(turns) {
 		switch turn.Kind {
+		case runtimeoutput.KindThinking:
+			entries = append(entries, thinkingEntryFromTurn(turn, base, stableTurnEntryID(turn, base, "thinking")))
 		case runtimeoutput.KindText:
 			// Provider user records are internal prompt/session frames. Operator
 			// text is projected only from durable conversation or steering Events.
@@ -390,12 +414,19 @@ func turnsToEntries(turns []runtimeoutput.Turn, base Entry) []Entry {
 			}
 			entries = append(entries, messageEntry(base, entryID(base.ID, "-message", turn.ContentIndex), mapRuntimeRole(turn.Role), turn.Text))
 		case runtimeoutput.KindToolUse:
-			entries = append(entries, toolCallEntryFromTurn(turn, base, entryID(base.ID, "-tool-call", turn.ContentIndex)))
+			entries = append(entries, toolCallEntryFromTurn(turn, base, stableTurnEntryID(turn, base, "tool-call")))
 		case runtimeoutput.KindToolResult:
-			entries = append(entries, toolResultEntryFromTurn(turn, base, entryID(base.ID, "-tool-result", turn.ContentIndex)))
+			entries = append(entries, toolResultEntryFromTurn(turn, base, stableTurnEntryID(turn, base, "tool-result")))
 		}
 	}
 	return entries
+}
+
+func stableTurnEntryID(turn runtimeoutput.Turn, base Entry, kind string) string {
+	if stable := runtimeoutput.StableProviderItemID(turn.ProviderItemID, kind); stable != "" {
+		return fmt.Sprintf("continuation-%d-%s", base.Continuation, stable)
+	}
+	return entryID(base.ID, "-"+kind, turn.ContentIndex)
 }
 
 func entryID(baseID, suffix string, index int) string {
@@ -427,6 +458,19 @@ func messageEntry(base Entry, id, role, text string) Entry {
 		Role:         role,
 		Text:         text,
 		Stream:       base.Stream,
+		CreatedAt:    base.CreatedAt,
+	}
+}
+
+func thinkingEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry {
+	return Entry{
+		ID:           id,
+		Seq:          base.Seq,
+		Continuation: base.Continuation,
+		Kind:         KindThinking,
+		Role:         RoleAssistant,
+		Text:         turn.Text,
+		Status:       StatusCollapsed,
 		CreatedAt:    base.CreatedAt,
 	}
 }

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -90,14 +90,129 @@ func TestBuildParsesCodexAppServerItemsFromProviderSession(t *testing.T) {
 	}
 
 	got := transcript.Build(subject, events)
-	requireEntry(t, got, "ev-2-tool-call", "tool_call", "assistant", "")
-	requireEntry(t, got, "ev-2-tool-result", "tool_result", "tool", "curl: (52) Empty reply from server\n")
+	toolCall := firstEntryOfKind(t, got, transcript.KindToolCall)
+	if toolCall.Role != transcript.RoleAssistant {
+		t.Fatalf("tool call = %#v", toolCall)
+	}
+	toolResult := firstEntryOfKind(t, got, transcript.KindToolResult)
+	if toolResult.Role != transcript.RoleTool || toolResult.Text != "curl: (52) Empty reply from server\n" {
+		t.Fatalf("tool result = %#v", toolResult)
+	}
 	requireEntry(t, got, "ev-3-message", "message", "assistant", "VPN检测未通过")
 	for _, entry := range got {
 		if entry.Kind == "runtime_output" {
 			t.Fatalf("codex item collapsed to runtime fallback: %#v", entry)
 		}
 	}
+}
+
+func TestBuildReconcilesCodexStartedCompletedAndReasoningItems(t *testing.T) {
+	createdAt := time.Date(2026, 8, 26, 9, 0, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "session-1", Title: "Inspect", CreatedAt: createdAt}
+	events := []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "provider-session:thread-1"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/started", "stream": "codex_app_server",
+			"text": `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","status":"inProgress"}}`,
+		}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/started", "stream": "codex_app_server",
+			"text": `{"item":{"type":"reasoning","id":"item-reasoning","summary":[]}}`,
+		}, CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "ev-4", Seq: 4, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/completed", "stream": "codex_app_server",
+			"text": `{"item":{"type":"reasoning","id":"item-reasoning","summary":["Checked the target."]}}`,
+		}, CreatedAt: createdAt.Add(3 * time.Second)},
+		{ID: "ev-5", Seq: 5, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/completed", "stream": "codex_app_server",
+			"text": `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","aggregatedOutput":"200 OK","status":"completed"}}`,
+		}, CreatedAt: createdAt.Add(4 * time.Second)},
+	}
+
+	got := transcript.Build(subject, events)
+	var calls, results, thinking []transcript.Entry
+	for _, entry := range got {
+		switch entry.Kind {
+		case transcript.KindToolCall:
+			calls = append(calls, entry)
+		case transcript.KindToolResult:
+			results = append(results, entry)
+		case transcript.KindThinking:
+			thinking = append(thinking, entry)
+		}
+	}
+	if len(calls) != 1 || len(results) != 1 {
+		t.Fatalf("tool lifecycle calls=%#v results=%#v", calls, results)
+	}
+	if len(thinking) != 1 || thinking[0].Text != "Checked the target." || thinking[0].Role == transcript.RoleUser {
+		t.Fatalf("thinking entries = %#v", thinking)
+	}
+}
+
+func TestBuildPreservesStartedCommandPositionWhenCompletionArrivesAfterAnotherEntry(t *testing.T) {
+	createdAt := time.Date(2026, 8, 26, 9, 0, 0, 0, time.UTC)
+	events := []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "provider-session:thread-1"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/started", "stream": "codex_app_server",
+			"text": `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","status":"inProgress"}}`,
+		}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/completed", "stream": "codex_app_server",
+			"text": `{"item":{"type":"agentMessage","id":"item-message","text":"Still working."}}`,
+		}, CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "ev-4", Seq: 4, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/completed", "stream": "codex_app_server",
+			"text": `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","aggregatedOutput":"200 OK","status":"completed"}}`,
+		}, CreatedAt: createdAt.Add(3 * time.Second)},
+	}
+
+	got := transcript.Build(transcript.Subject{ID: "session-1", CreatedAt: createdAt}, events)
+	call := firstEntryOfKind(t, got, transcript.KindToolCall)
+	if call.Seq != 2 || !call.CreatedAt.Equal(createdAt.Add(time.Second)) {
+		t.Fatalf("completed command moved started call to seq/time %d/%s, want 2/%s", call.Seq, call.CreatedAt, createdAt.Add(time.Second))
+	}
+	for index := 1; index < len(got); index++ {
+		if got[index].Seq < got[index-1].Seq {
+			t.Fatalf("transcript seqs are not chronological: %#v", got)
+		}
+	}
+}
+
+func TestBuildWindowUsesStableCodexToolCallIdentityAcrossPages(t *testing.T) {
+	createdAt := time.Date(2026, 8, 26, 9, 0, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "session-1", CreatedAt: createdAt}
+	started := transcript.BuildWindow(subject, []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "provider-session:thread-1"}},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/started", "stream": "codex_app_server",
+			"text": `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","status":"inProgress"}}`,
+		}},
+	}, transcript.WindowContext{})
+	completed := transcript.BuildWindow(subject, []transcript.Event{{
+		ID: "ev-3", Seq: 3, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/completed", "stream": "codex_app_server",
+			"text": `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","aggregatedOutput":"200 OK","status":"completed"}}`,
+		},
+	}}, transcript.WindowContext{Continuation: 1, Adapter: "provider-session:thread-1"})
+
+	startedCall := firstEntryOfKind(t, started, transcript.KindToolCall)
+	completedCall := firstEntryOfKind(t, completed, transcript.KindToolCall)
+	if startedCall.ID != completedCall.ID {
+		t.Fatalf("tool call IDs differ across windows: %q != %q", startedCall.ID, completedCall.ID)
+	}
+	_ = firstEntryOfKind(t, completed, transcript.KindToolResult)
+}
+
+func firstEntryOfKind(t *testing.T, entries []transcript.Entry, kind string) transcript.Entry {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Kind == kind {
+			return entry
+		}
+	}
+	t.Fatalf("entry kind %q missing from %#v", kind, entries)
+	return transcript.Entry{}
 }
 
 func TestBuildProjectsNativeSteerControlsWithoutDuplicatingConversationMessage(t *testing.T) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -298,6 +298,10 @@ export interface SessionRuntimeControls {
   native_resume_available: boolean;
   native_steer_available: boolean;
   native_steer_mode?: string;
+  native_steer_state?: string;
+  native_steer_request_id?: string;
+  native_steer_error_code?: string;
+  native_steer_error?: string;
   queue_steer_available: boolean;
   interrupt_steer_available: boolean;
   native_session_captured: boolean;
@@ -672,6 +676,8 @@ export interface RuntimeControls {
   native_steer_mode?: "in_turn_steer" | "interrupt_then_replace" | string;
   native_steer_state?: "idle" | "requested" | "acknowledged" | "settled" | "started" | "applied" | "failed" | string;
   native_steer_request_id?: string;
+  native_steer_error_code?: string;
+  native_steer_error?: string;
   native_steer_reason?: string;
   resume_available: boolean;
   /** True only when Runtime Activity is live and idle. */

--- a/web/src/lib/runtimeOwner/adapter.ts
+++ b/web/src/lib/runtimeOwner/adapter.ts
@@ -36,7 +36,7 @@ export type RuntimeOwnerAdapter = {
   /** Sends a fresh message that starts a new continuation. */
   sendMessage(text: string, selection: ConversationSelection, attachments: File[]): Promise<RuntimeOwnerView>;
   /** Steers the live runtime; native picks the provider-native request shape. */
-  steer(input: { text: string; selection: ConversationSelection; requestID: string; native: boolean; attachments?: File[] }): Promise<unknown>;
+  steer(input: { text: string; selection: ConversationSelection; requestID: string; native: boolean; forceReplace?: boolean; attachments?: File[] }): Promise<unknown>;
   /** Queues an accepted steering request for the harness to deliver in order. */
   queueSteer(text: string, selection: ConversationSelection, attachments: File[]): Promise<unknown>;
   stop(): Promise<unknown>;
@@ -89,11 +89,11 @@ export function taskRuntimeOwnerAdapter(base: string): RuntimeOwnerAdapter {
     async sendMessage(text, selection) {
       return taskAsRuntimeOwner(await apiPost<Task>(`${base}/messages`, { message: text, ...selection }));
     },
-    steer: ({ text, selection, requestID, native }) =>
+    steer: ({ text, selection, requestID, native, forceReplace }) =>
       apiPost(
         `${base}/steer`,
         native
-          ? { request_id: requestID, message: text, ...selection }
+          ? { request_id: requestID, message: text, ...(forceReplace ? { force_replace: true } : {}), ...selection }
           : { directive: text, ...selection },
       ),
     queueSteer: (text, selection) => apiPost(`${base}/steer/queue`, { directive: text, ...selection }),
@@ -145,7 +145,9 @@ export function sessionRuntimeOwnerAdapter(base: string): RuntimeOwnerAdapter {
     loadOlderTranscript: (before) => apiGet<TaskTranscript>(`${base}/transcript?before=${before}`),
     loadOlderTimeline: (before) => apiGet<TaskTimeline>(`${base}/timeline?before=${before}`),
     sendMessage: (text, selection, attachments) => postSessionRuntimeMessage(`${base}/messages`, text, selection, attachments).then(sessionAsRuntimeOwner),
-    steer: ({ text, selection, attachments }) => postSessionRuntimeMessage(`${base}/steer`, text, selection, attachments ?? []),
+    steer: ({ text, selection, requestID, attachments, forceReplace }) => postSessionRuntimeMessage(
+      `${base}/steer`, text, selection, attachments ?? [], forceReplace ? { force_replace: true } : {}, requestID,
+    ),
     queueSteer: (text, selection, attachments) => postSessionRuntimeMessage(`${base}/steer/queue`, text, selection, attachments),
     stop: () => apiPost(`${base}/stop`, {}),
     finish: () => apiPost(`${base}/finish`, {}),
@@ -173,14 +175,17 @@ async function postSessionRuntimeMessage(
   message: string,
   selection: ConversationSelection,
   attachments: File[],
+  extra: Record<string, unknown> = {},
+  idempotencyKey = "",
 ): Promise<Session> {
+  const init = idempotencyKey ? { headers: { "Idempotency-Key": idempotencyKey } } : undefined;
   if (attachments.length === 0) {
-    return apiPost<Session>(path, { message, ...selection });
+    return apiPost<Session>(path, { message, ...selection, ...extra }, init);
   }
   const form = new FormData();
-  form.append("payload", JSON.stringify({ message, ...selection }));
+  form.append("payload", JSON.stringify({ message, ...selection, ...extra }));
   attachments.forEach((attachment) => form.append("attachments", attachment, attachment.name));
-  return apiPostForm<Session>(path, form);
+  return apiPostForm<Session>(path, form, init);
 }
 
 const DELETABLE = new Set(["completed", "failed", "stopped", "interrupted"]);
@@ -260,6 +265,10 @@ export function sessionAsRuntimeOwner(session: Session): RuntimeOwnerView {
       resume_available: session.lifecycle === "open",
       native_steer_available: controls.native_steer_available,
       native_steer_mode: controls.native_steer_mode,
+      native_steer_state: controls.native_steer_state,
+      native_steer_request_id: controls.native_steer_request_id,
+      native_steer_error_code: controls.native_steer_error_code,
+      native_steer_error: controls.native_steer_error,
       queue_steer_available: controls.queue_steer_available,
       interrupt_steer_available: controls.interrupt_steer_available,
       native_session_captured: controls.native_session_captured,

--- a/web/src/lib/runtimeOwner/conversationKernel.test.ts
+++ b/web/src/lib/runtimeOwner/conversationKernel.test.ts
@@ -168,10 +168,13 @@ describe("conversation send mode", () => {
     })).toBe("unavailable");
   });
 
-  it("labels modes for the composer", () => {
-    expect(conversationSendLabel("native")).toBe("Native interrupt & send");
-    expect(conversationSendLabel("native", "in_turn_steer")).toBe("Send message");
-    expect(conversationSendLabel("interrupt")).toBe("Interrupt and resume");
+  it("labels the real provider operation for the composer", () => {
+    expect(conversationSendLabel("native")).toBe("Send");
+    expect(conversationSendLabel("native", "send_turn")).toBe("Send");
+    expect(conversationSendLabel("native", "in_turn_steer")).toBe("Steer current turn");
+    expect(conversationSendLabel("native", "in_turn_steer", true)).toBe("Interrupt and send");
+    expect(conversationSendLabel("native", "interrupt_then_replace")).toBe("Interrupt and send");
+    expect(conversationSendLabel("interrupt")).toBe("Interrupt and send");
     expect(conversationSendLabel("queue")).toBe("Queue message");
     expect(conversationSendLabel("resume")).toBe("Resume and send");
     expect(conversationSendLabel("unavailable")).toBe("Send unavailable");

--- a/web/src/lib/runtimeOwner/conversationKernel.ts
+++ b/web/src/lib/runtimeOwner/conversationKernel.ts
@@ -20,6 +20,7 @@ export type ConversationKernelState = {
   selectedProviderID: string;
   runtimeProvider: string;
   nativeSteerMode?: string;
+  forceReplace?: boolean;
 };
 
 export type ConversationAction = {
@@ -56,7 +57,7 @@ export function resolveConversationAction(
     if (state.running && (state.nativeSteerAvailable || state.interruptSteerAvailable)) {
       return {
         run: async (message, selection, adapter, attachments) => {
-          await adapter.steer({ text: message, selection, requestID, native: true, attachments });
+          await adapter.steer({ text: message, selection, requestID, native: true, forceReplace: state.forceReplace, attachments });
         },
       };
     }
@@ -98,6 +99,7 @@ export function resolveConversationAction(
           selection,
           requestID,
           native: state.nativeSteerAvailable,
+          forceReplace: state.forceReplace,
         });
       },
     };
@@ -139,12 +141,14 @@ export function resolveConversationSendMode(input: {
   return input.queueSteerAvailable && input.resumeAvailable ? "resume" : "unavailable";
 }
 
-export function conversationSendLabel(mode: ConversationSendMode, nativeSteerMode?: string): string {
+export function conversationSendLabel(mode: ConversationSendMode, nativeSteerMode?: string, selectionChanged = false): string {
   switch (mode) {
     case "native":
-      return nativeSteerMode === "in_turn_steer" ? "Send message" : "Native interrupt & send";
+      if (selectionChanged || nativeSteerMode === "interrupt_then_replace") return "Interrupt and send";
+      if (nativeSteerMode === "in_turn_steer") return "Steer current turn";
+      return "Send";
     case "interrupt":
-      return "Interrupt and resume";
+      return "Interrupt and send";
     case "queue":
       return "Queue message";
     case "resume":

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -314,7 +314,7 @@ describe("SessionDetailPage", () => {
       screen.getByRole("textbox", { name: "Session message" }),
       "Replace the current direction",
     );
-    await user.click(screen.getByRole("button", { name: "Interrupt and resume" }));
+    await user.click(screen.getByRole("button", { name: "Interrupt and send" }));
 
     await waitFor(() => {
       const call = fetchMock.mock.calls.find(([input]) => String(input).endsWith("/api/sessions/session-interrupt/steer"));
@@ -326,6 +326,45 @@ describe("SessionDetailPage", () => {
         reasoning_effort: "high",
       }));
       expect((form.get("attachments") as File).name).toBe("interrupt-notes.txt");
+      expect(new Headers(call?.[1]?.headers).get("Idempotency-Key")).toBeTruthy();
+    });
+  });
+
+  it("shows Session action-required recovery and sends explicit replacement", async () => {
+    const fetchMock = mockApi({
+      "/api/sessions/session-action/transcript": { session_id: "session-action", entries: [] },
+      "/api/sessions/session-action/timeline": { session_id: "session-action", items: [] },
+      "/api/sessions/session-action": {
+        id: "session-action", title: "Recover steering", lifecycle: "open",
+        runtime_controls: {
+          native_steer_available: true, interrupt_steer_available: true, queue_steer_available: true,
+          native_steer_mode: "in_turn_steer", native_steer_state: "action_required",
+          native_steer_error_code: "target_turn_changed", native_steer_error: "target provider Runtime Turn changed",
+          native_session_captured: true, runtime_provider: "codex",
+        },
+        active_continuation: {
+          id: "continuation-action", session_id: "session-action", number: 1, runtime_profile_id: "profile-1",
+          runtime_provider: "codex", runner: "host", status: "running",
+          started_at: "2026-08-01T01:00:00Z", updated_at: "2026-08-01T01:00:00Z",
+        },
+        created_at: "2026-08-01T01:00:00Z", updated_at: "2026-08-01T01:00:00Z", last_activity_at: "2026-08-01T01:00:00Z",
+      },
+    });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/sessions/session-action"]}>
+        <Routes><Route path="/sessions/:sessionId" element={<SessionDetailPage />} /></Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("target provider Runtime Turn changed");
+    await user.click(screen.getByRole("button", { name: "Use interrupt and replace" }));
+    await user.type(screen.getByRole("textbox", { name: "Session message" }), "replace it");
+    await user.click(screen.getByRole("button", { name: "Interrupt and replace" }));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([input]) => String(input).endsWith("/api/sessions/session-action/steer"));
+      expect(JSON.parse(String(call?.[1]?.body))).toMatchObject({ message: "replace it", force_replace: true });
     });
   });
 

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -497,6 +497,30 @@ describe("TaskDetailPage", () => {
     expect(resultBody?.textContent).not.toContain("tool_call_id: call-1");
   });
 
+  it("renders reasoning as collapsed activity instead of an agent message", async () => {
+    stubTaskDetailApi({}, [
+      {
+        id: "thinking-1",
+        seq: 6,
+        continuation: 1,
+        kind: "thinking",
+        role: "assistant",
+        text: "Checked the active challenge and prepared the next command.",
+        created_at: "2026-08-26T09:00:01Z",
+      },
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText("Reasoning")).toBeInTheDocument();
+    const row = screen.getByTestId("transcript-thinking-row");
+    expect(row).not.toHaveAttribute("open");
+    expect(screen.getByText("Checked the active challenge and prepared the next command.")).toBeInTheDocument();
+    expect(screen.queryByTestId("transcript-message-bubble")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("You")).not.toBeInTheDocument();
+  });
+
   it("keeps agent messages and tool rows tight, only spacing out new user turns", async () => {
     stubTaskDetailApi({}, [
       {
@@ -798,6 +822,39 @@ describe("TaskDetailPage", () => {
     expect(screen.queryByTestId("steer-pending-badge")).not.toBeInTheDocument();
   });
 
+  it("shows action-required reason and lets the operator select replacement delivery", async () => {
+    const { fetchMock } = stubTaskDetailApi({
+      status: "running",
+      runtime_controls: {
+        native_steer_available: true,
+        interrupt_steer_available: true,
+        native_steer_mode: "in_turn_steer",
+        native_steer_state: "action_required",
+        native_steer_error_code: "active_turn_not_steerable",
+        native_steer_error: "active provider Runtime Turn is not steerable",
+        native_session_captured: true,
+        same_runtime_provider_only: true,
+        runtime_provider: "codex",
+      },
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("active provider Runtime Turn is not steerable");
+    await user.click(screen.getByRole("button", { name: "Use interrupt and replace" }));
+    await user.type(screen.getByRole("textbox", { name: "Task message" }), "continue in a replacement turn");
+    await user.click(screen.getByRole("button", { name: "Interrupt and replace" }));
+
+    const steerCall = fetchMock.mock.calls.find(([input]) =>
+      String(input).endsWith("/api/projects/project-1/tasks/task-1/steer"),
+    );
+    expect(JSON.parse(String(steerCall?.[1]?.body))).toMatchObject({
+      message: "continue in a replacement turn",
+      force_replace: true,
+    });
+  });
+
   it("lets the continuation summary shrink instead of overflowing the header", async () => {
     stubTaskDetailApi();
 
@@ -986,7 +1043,7 @@ describe("TaskDetailPage", () => {
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model" }), "mimo-v2-pro");
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation reasoning effort" }), "xhigh");
     await user.type(screen.getByPlaceholderText("Focus on admin.example.com next…"), "stronger turn");
-    await user.click(screen.getByRole("button", { name: /Native interrupt & send/ }));
+    await user.click(screen.getByRole("button", { name: /Interrupt and send/ }));
 
     const postPaths = fetchMock.mock.calls
       .filter(([, init]) => init?.method === "POST")
@@ -1057,7 +1114,7 @@ describe("TaskDetailPage", () => {
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation model" }), "claude-opus");
     await user.selectOptions(screen.getByRole("combobox", { name: "Continuation reasoning effort" }), "xhigh");
     await user.type(screen.getByPlaceholderText("Focus on admin.example.com next…"), "claude stronger turn");
-    await user.click(screen.getByRole("button", { name: /Native interrupt & send/ }));
+    await user.click(screen.getByRole("button", { name: /Interrupt and send/ }));
 
     const postPaths = fetchMock.mock.calls
       .filter(([, init]) => init?.method === "POST")
@@ -1138,7 +1195,7 @@ describe("TaskDetailPage", () => {
 
     await screen.findByText("Conversation should be hidden by default");
     await user.type(screen.getByPlaceholderText("Focus on admin.example.com next…"), "focus on admin");
-    await user.click(screen.getByRole("button", { name: /Native interrupt & send/ }));
+    await user.click(screen.getByRole("button", { name: /Interrupt and send/ }));
 
     const steerCall = fetchMock.mock.calls.find(([input]) =>
       String(input).endsWith("/api/projects/project-1/tasks/task-1/steer"),
@@ -1237,9 +1294,9 @@ describe("TaskDetailPage", () => {
     await user.type(screen.getByPlaceholderText("Focus on admin.example.com next…"), "continue with mimo on pi");
     // Pi must not present the restart-oriented provider-switch label.
     expect(screen.queryByRole("button", { name: "Switch provider and resume" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Steer current turn" })).toBeEnabled();
 
-    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await user.click(screen.getByRole("button", { name: "Steer current turn" }));
 
     const postPaths = fetchMock.mock.calls
       .filter(([, init]) => init?.method === "POST")

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, useRef, type KeyboardEvent, type ReactNode, type RefObject } from "react";
 import { flushSync } from "react-dom";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { Square, Send, Terminal, Activity, GitBranch, MessageSquare, Play, ChevronRight, Wrench, User, ArrowDown, ArrowUp, CheckCircle2, Trash2, CircleX, KeyRound, ListPlus, Loader2, Maximize2, Minimize2, Flag, RefreshCcw, TriangleAlert, Archive, ArchiveRestore, Pencil, Paperclip } from "lucide-react";
+import { Square, Send, Terminal, Activity, GitBranch, MessageSquare, Play, ChevronRight, Wrench, User, ArrowDown, ArrowUp, CheckCircle2, Trash2, CircleX, KeyRound, ListPlus, Loader2, Maximize2, Minimize2, Flag, RefreshCcw, TriangleAlert, Archive, ArchiveRestore, Pencil, Paperclip, Brain } from "lucide-react";
 import { apiGet, type FinishReadiness, type ModelProvider, type ProviderPermissionRequest, type RuntimeActivity, type RuntimePlugin, type RuntimeProfile, type TaskTranscriptEntry } from "@/lib/api";
 import { Button, Badge, Input, Select, Textarea } from "@/components/ui";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -48,6 +48,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
   const [actionError, setActionError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [steering, setSteering] = useState("");
+  const [forceReplaceNext, setForceReplaceNext] = useState(false);
   const [continuationModelProvider, setContinuationModelProvider] = useState("");
   const [continuationModelOverride, setContinuationModelOverride] = useState("");
   const [continuationReasoningEffort, setContinuationReasoningEffort] = useState("high");
@@ -597,9 +598,11 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
         selectedProviderID: continuationModelProvider.trim(),
         runtimeProvider: currentRuntimeProvider ?? "",
         nativeSteerMode: owner.runtimeControls?.native_steer_mode,
+        forceReplace: forceReplaceNext,
       }, requestID);
       await action.run(message, modelPayload, ownerAdapter, owner.capabilities.attachments ? attachments : []);
       setSteering("");
+      setForceReplaceNext(false);
       if (owner.capabilities.attachments) {
         setAttachments([]);
         if (attachmentInput.current) attachmentInput.current.value = "";
@@ -757,9 +760,23 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
     !piNativeCrossProvider;
   const providerSwitchAvailable = owner.kind === "session" || queueSteerAvailable;
   const queueActionAvailable = queueSteerAvailable;
-  const sendActionLabel = providerSwitchRequested
-    ? providerSwitchAvailable ? "Switch provider and resume" : "Provider switch unavailable"
-    : conversationSendLabel(sendMode, nativeSteerMode);
+  const currentTurnModel = controls?.turn_selection?.model?.trim() ?? "";
+  const currentTurnEffort = controls?.turn_selection?.reasoning_effort?.trim() ?? "";
+  const selectedTurnModel = continuationModelOverride.trim();
+  const selectedTurnEffort = continuationReasoningEffort.trim();
+  const turnSelectionChanged = !providerSwitchRequested && currentRuntimeProvider === "codex" && (
+    (selectedTurnModel !== "" && selectedTurnModel !== currentTurnModel) ||
+    (selectedTurnEffort !== "" && selectedTurnEffort !== currentTurnEffort)
+  );
+  const sendActionLabel = forceReplaceNext
+    ? "Interrupt and replace"
+    : providerSwitchRequested
+      ? providerSwitchAvailable ? "Switch provider and resume" : "Provider switch unavailable"
+      : conversationSendLabel(sendMode, nativeSteerMode, turnSelectionChanged);
+  const steerActionRequired = controls?.native_steer_state === "action_required";
+  const replacementRecoveryAvailable = steerActionRequired && interruptSteerAvailable && [
+    "active_turn_not_steerable", "target_turn_changed", "target_turn_completed",
+  ].includes(controls?.native_steer_error_code ?? "");
   const focusMode = searchParams.get("focus") === "1";
 
   return (
@@ -1066,6 +1083,10 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
           sendActionLabel={sendActionLabel}
           actionError={actionError}
           steerState={controls?.native_steer_state}
+          steerError={controls?.native_steer_error}
+          replacementRecoveryAvailable={replacementRecoveryAvailable}
+          replacementSelected={forceReplaceNext}
+          onUseReplacement={() => setForceReplaceNext(true)}
           continuationModelProviders={continuationModelProviders}
           continuationModelProvider={continuationModelProvider}
           continuationModelOverride={continuationModelOverride}
@@ -1296,6 +1317,10 @@ function RuntimeOwnerComposer({
   sendActionLabel,
   actionError,
   steerState,
+  steerError,
+  replacementRecoveryAvailable,
+  replacementSelected,
+  onUseReplacement,
   continuationModelProviders,
   continuationModelProvider,
   continuationModelOverride,
@@ -1327,6 +1352,10 @@ function RuntimeOwnerComposer({
   sendActionLabel: string;
   actionError: string | null;
   steerState?: string;
+  steerError?: string;
+  replacementRecoveryAvailable: boolean;
+  replacementSelected: boolean;
+  onUseReplacement: () => void;
   continuationModelProviders: ModelProvider[];
   continuationModelProvider: string;
   continuationModelOverride: string;
@@ -1343,6 +1372,16 @@ function RuntimeOwnerComposer({
     <div data-testid="task-composer" className="fixed inset-x-0 bottom-0 z-30 shrink-0 bg-background/95 px-3 py-2 shadow-[0_-8px_24px] shadow-black/15 backdrop-blur-sm sm:px-4 md:static md:z-10 md:shadow-none">
       <div className="mx-auto max-w-3xl space-y-2">
         {actionError && <p role="alert" className="text-xs text-destructive">{actionError}</p>}
+        {steerState === "action_required" && (
+          <div role="alert" className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs">
+            <span>{steerError || "Steering needs operator action."}</span>
+            {replacementRecoveryAvailable && (
+              <Button type="button" size="sm" variant="outline" onClick={onUseReplacement} disabled={replacementSelected}>
+                {replacementSelected ? "Replacement selected" : "Use interrupt and replace"}
+              </Button>
+            )}
+          </div>
+        )}
         <div className="overflow-hidden rounded-lg border border-border bg-card shadow-sm focus-within:border-ring">
           <Textarea
             aria-label={`${ownerLabel} message`}
@@ -1688,15 +1727,17 @@ function TranscriptRow({ entry }: { entry: TaskTranscriptEntry }) {
 function CollapsedTranscriptRow({ entry }: { entry: TaskTranscriptEntry }) {
   const isError = entry.kind === "tool_result" && (entry.details as { is_error?: boolean } | undefined)?.is_error === true;
   const Icon =
-    entry.kind === "runtime_output"
-      ? Terminal
+    entry.kind === "thinking"
+      ? Brain
+      : entry.kind === "runtime_output"
+        ? Terminal
       : entry.kind === "tool_result"
         ? isError
           ? CircleX
           : CheckCircle2
         : Wrench;
   return (
-    <details data-testid="transcript-tool-row" className="group border-b border-border/50 last:border-b-0">
+    <details data-testid={entry.kind === "thinking" ? "transcript-thinking-row" : "transcript-tool-row"} className="group border-b border-border/50 last:border-b-0">
       <summary className="-mx-1 flex min-h-9 cursor-pointer list-none items-center gap-2 rounded-sm px-1 py-1.5 text-sm transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
         <Icon className={`h-4 w-4 shrink-0 ${isError ? "text-destructive" : "text-muted-foreground"}`} />
@@ -1741,7 +1782,7 @@ function ToolCallDetails({ entry }: { entry: TaskTranscriptEntry }) {
 }
 
 function isCollapsedTranscriptEntry(entry: TaskTranscriptEntry) {
-  return entry.kind === "tool_call" || entry.kind === "tool_result" || entry.kind === "runtime_output";
+  return entry.kind === "thinking" || entry.kind === "tool_call" || entry.kind === "tool_result" || entry.kind === "runtime_output";
 }
 
 function collapsedBody(entry: TaskTranscriptEntry) {

--- a/web/src/pages/taskDetailView.test.ts
+++ b/web/src/pages/taskDetailView.test.ts
@@ -44,6 +44,19 @@ describe("collapsedTranscriptTitle", () => {
     };
     expect(collapsedTranscriptTitle(entry)).toBe("Result · ECONNREFUSED");
   });
+
+  it("uses a neutral title for reasoning summaries", () => {
+    const entry: TaskTranscriptEntry = {
+      id: "thinking-1",
+      seq: 3,
+      continuation: 1,
+      kind: "thinking",
+      role: "assistant",
+      text: "Checked the target and prepared the command.",
+      created_at: "",
+    };
+    expect(collapsedTranscriptTitle(entry)).toBe("Reasoning");
+  });
 });
 
 describe("toolCallFields", () => {

--- a/web/src/pages/taskDetailView.ts
+++ b/web/src/pages/taskDetailView.ts
@@ -5,6 +5,7 @@ import type { TaskTranscriptEntry } from "@/lib/api";
 // the client only renders what the server already parsed.
 
 export function collapsedTranscriptTitle(entry: TaskTranscriptEntry): string {
+  if (entry.kind === "thinking") return "Reasoning";
   if (entry.kind === "tool_call") {
     const toolName = entry.tool_name || "Tool";
     const preview = toolInputPreview(entry);


### PR DESCRIPTION
## Summary
- Add runtime-native steering across daemon, runtime, session, timeline, transcript, and provider session layers
- Support durable steering acceptance, assisted delegation, continuation, task resumption, and native steer failure handling
- Update provider adapters and session assemblers for Claude, Codex, Hermes, and Pi
- Extend task and session detail views with steering and runtime state handling
- Document the runtime-native steering design and update project context

## Testing
- Added and updated Go unit tests for steering, runtime activity, provider sessions, task continuation, persistence, timelines, transcripts, and session control
- Added and updated frontend tests for conversation state, task details, session details, and runtime owner behavior
- Not run (not requested)