### PR TITLE
Persist streamed reasoning across runtimes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 Always read CONTEXT.md, unconditionally.
 Use TDD
 
+## Workspace file safety
+
+Treat every existing workspace file and directory as user-owned, including untracked content. Get the user's explicit authorization before deleting, overwriting, restoring, or cleaning it. A path name or `git status` state is not proof that content is a test artifact. To identify generated content, use a before-and-after workspace snapshot or a documented generator contract. If an accidental destructive change occurs, stop other work, disclose the exact action, and prioritize recovery.
+
 Update `CONTEXT.md` when the user explicitly resolves a domain ambiguity.
 Always talk in ASD-STE100 Simplified Technical English(or Chines if user talks in Chinese). Always read CONTEXT.md files, and use their ubiquitous language.
 ## Agent skills

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -328,6 +328,10 @@ _Avoid_: effective effort, supported effort, reasoning token count
 The reasoning level a **Runtime** reports that it actually applied after any native validation or downgrade. It remains unknown when the **Runtime** does not report it.
 _Avoid_: requested effort, assumed effort, profile default
 
+**Runtime Reasoning Entry**:
+A durable, streamable `reasoning` row in one **Runtime Owner** Transcript that projects reasoning text the **Runtime** emitted during one **Runtime Turn**. Partial deltas coalesce by stable provider-item identity, remain interleaved with messages and Tool activity, expand while live, and remain replayable after the Turn settles. Raw reasoning emitted by a provider is retained through the normal runtime-output redaction and history-window controls; a provider summary is only a fallback when raw reasoning is absent.
+_Avoid_: Reasoning Effort, Runtime Activity Indicator, inferred hidden reasoning, temporary typing indicator, Task Event summary
+
 **Model Provider Protocol**:
 The model-service API contract a **Model Provider Endpoint** supports and a **Runtime Plugin** knows how to project for a **Runtime**.
 _Avoid_: runtime provider, endpoint URL, model name
@@ -1138,6 +1142,10 @@ _Avoid_: transcript, export, source of truth
 - **Reasoning Effort** has exactly five user-selectable values: `low`, `medium`, `high`, `xhigh`, and `max`; there is no Auto or Runtime Default choice.
 - A missing stored **Reasoning Effort** resolves to `high` without requiring existing **Runtime Profiles** to be rewritten.
 - Every **Runtime Turn** sends its resolved **Requested Reasoning Effort** explicitly instead of inheriting sticky effort state from the **Runtime**.
+- A **Runtime Reasoning Entry** belongs to one **Runtime Turn** and does not prove the **Effective Reasoning Effort** used by that Turn.
+- Every emitted raw reasoning delta is retained through a Runtime Reasoning Entry; when the provider emits no raw reasoning, an emitted provider summary may supply the entry text instead.
+- Runtime Reasoning Entries retain provider order relative to messages and Tool activity, coalesce repeated projections of one stable provider item, and participate in the same bounded history and detail retrieval as other Transcript entries.
+- A retained Runtime Reasoning Entry is included in the **Hosted Transcript Stream** and does not change the **Runtime Activity Indicator**.
 - A **Task** keeps one **Runtime Plugin** family; changing from Codex, Claude Code, Pi, or Hermes requires a different **Task**.
 - Codex and Claude Code apply model and **Reasoning Effort** changes natively when the **Model Provider** is unchanged.
 - Native **Runtime Turn Selection** changes do not create a **Task Runtime Configuration Version**.
@@ -1624,6 +1632,7 @@ _Avoid_: transcript, export, source of truth
 - TSecBench transient-error recovery is not allowed to endanger the host process; resolved: the **Hosted Challenge Client** returns bounded structured failures without automatic mutation retries, and the Runtime decides whether to retry or switch challenges.
 - A **Hosted Evaluation Run** is not restart-resumable; resolved: Project and Task creation remain non-idempotent, every hosted container process is one fresh run, and any unexpected process exit fails that run without bootstrap recovery.
 - Hosted stdout masking is not persistent Runtime redaction; resolved: the **Hosted Transcript Stream** masks exact `BENCHMARK_TOKEN` and model API key values only when it writes stdout, while internal Task Events, Transcript source records, and diagnostic state retain the accepted disclosure risk.
+- Runtime reasoning is not temporary UI-only liveness text or summary-only output; resolved: every raw reasoning delta a provider emits becomes a durable **Runtime Reasoning Entry**, including Codex raw content from third-party models, with provider summary used only when raw reasoning is absent.
 - TSecBench container termination is not graceful CyberPenda shutdown; resolved: the hosted PID catches and ignores termination signals, does not stop the Task or close the daemon, and stays alive until the platform forcibly terminates the container.
 - Hosted operational diagnostics are not mixed with the **Hosted Transcript Stream**; resolved: standard output contains JSONL Transcript records only, while Hosted Controller and daemon logs use standard error.
 - Real TSecBench local-mode acceptance is not an autonomous solving benchmark; resolved: after the deployer connects the host VPN, validate list, start, submit, and close against the real platform without requiring the Runtime to solve a challenge.

--- a/cmd/pentest-claude-sdk-bridge/bridge.mjs
+++ b/cmd/pentest-claude-sdk-bridge/bridge.mjs
@@ -77,10 +77,15 @@ function extractAttemptResultJSON(text) {
   return trimmed;
 }
 
-function safeContentBlock(block) {
+function safeContentBlock(block, index, reasoningSegmentID) {
   if (!block || typeof block !== "object") return null;
   if (block.type === "text" && typeof block.text === "string") {
     return { type: "text", text: block.text };
+  }
+  if (block.type === "thinking" && typeof block.thinking === "string" && typeof reasoningSegmentID === "function") {
+    const id = reasoningSegmentID(index);
+    if (!id) return null;
+    return { type: "thinking", id, thinking: block.thinking };
   }
   if (block.type === "tool_use") {
     const id = stringValue(block, "id");
@@ -101,14 +106,31 @@ function safeContentBlock(block) {
   return null;
 }
 
-function safeRuntimeRecord(event) {
+function safeRuntimeRecord(event, reasoningSegmentID) {
   if (!event || typeof event !== "object") return null;
   if (event.type !== "assistant" && event.type !== "user") return null;
   const role = stringValue(event.message, "role") || event.type;
   const rawContent = Array.isArray(event.message?.content) ? event.message.content : [];
-  const content = rawContent.map(safeContentBlock).filter(Boolean);
+  const content = rawContent.map((block, index) => safeContentBlock(block, index, reasoningSegmentID)).filter(Boolean);
   if (content.length === 0) return null;
   return { type: event.type, message: { role, content } };
+}
+
+// safeThinkingDeltaRecord projects only provider-native thinking deltas. Text
+// deltas keep their existing completed-message projection so this feature does
+// not change assistant-message streaming semantics.
+function safeThinkingDeltaRecord(event, reasoningSegmentID) {
+  if (event?.type !== "stream_event" || typeof reasoningSegmentID !== "function") return null;
+  const streamEvent = event.event;
+  if (streamEvent?.type !== "content_block_delta" || !Number.isInteger(streamEvent.index)) return null;
+  const delta = streamEvent.delta;
+  if (delta?.type !== "thinking_delta" || typeof delta.thinking !== "string" || delta.thinking.length === 0) return null;
+  return {
+    type: "content_block_delta",
+    index: streamEvent.index,
+    item_id: reasoningSegmentID(streamEvent.index),
+    delta: { type: "thinking_delta", thinking: delta.thinking },
+  };
 }
 
 // applyTurnSelection delivers the resolved model and Requested Reasoning Effort
@@ -149,6 +171,16 @@ export async function runBridge({ input, output, diagnostics, sdk, cwd = "/task/
   // Last assistant text observed during a control turn. Some providers leave
   // result.result empty while still streaming the final JSON as assistant text.
   let controlAssistantText = "";
+  let reasoningSegmentCounter = 0;
+  const reasoningSegmentIDs = new Map();
+  const reasoningSegmentID = (index) => {
+    if (!activeTurnID) return "";
+    if (!reasoningSegmentIDs.has(index)) {
+      reasoningSegmentCounter += 1;
+      reasoningSegmentIDs.set(index, `${activeTurnID}-reasoning-${reasoningSegmentCounter}`);
+    }
+    return reasoningSegmentIDs.get(index);
+  };
   const terminalEventIDs = new Set();
   const terminalEventOrder = [];
   const toolNames = new Map();
@@ -239,6 +271,10 @@ export async function runBridge({ input, output, diagnostics, sdk, cwd = "/task/
       cwd,
       resume: resume || undefined,
       permissionMode,
+      // The SDK emits stream_event frames only when partial messages are
+      // enabled. CyberPenda consumes thinking deltas and keeps other partial
+      // content on its existing completed-message path.
+      includePartialMessages: true,
     };
     applyHostedContextWindow(options);
     if (permissionMode === "bypassPermissions") {
@@ -277,7 +313,12 @@ export async function runBridge({ input, output, diagnostics, sdk, cwd = "/task/
             }
             sessionID = eventSessionID;
           }
-          const runtimeRecord = safeRuntimeRecord(event);
+          const streamEvent = event?.type === "stream_event" ? event.event : null;
+          if (streamEvent?.type === "content_block_start" && streamEvent.content_block?.type === "thinking" && Number.isInteger(streamEvent.index)) {
+            reasoningSegmentID(streamEvent.index);
+          }
+          const runtimeRecord = safeRuntimeRecord(event, reasoningSegmentID);
+          const thinkingDeltaRecord = safeThinkingDeltaRecord(event, reasoningSegmentID);
           emitToolMetadata(event);
           if (activeTurnKind === "control" && Array.isArray(event?.message?.content)) {
             for (const block of event.message.content) {
@@ -286,6 +327,14 @@ export async function runBridge({ input, output, diagnostics, sdk, cwd = "/task/
               }
             }
           }
+          if (thinkingDeltaRecord) {
+            emit("claude/runtime_output", {
+              session_id: sessionID,
+              turn_id: activeTurnID,
+              stream: event.type,
+              text: JSON.stringify(thinkingDeltaRecord),
+            });
+          }
           if (runtimeRecord) {
             emit("claude/runtime_output", {
               session_id: sessionID,
@@ -293,6 +342,7 @@ export async function runBridge({ input, output, diagnostics, sdk, cwd = "/task/
               stream: event.type,
               text: JSON.stringify(runtimeRecord),
             });
+            if (event.type === "assistant") reasoningSegmentIDs.clear();
           }
           if (event?.type === "result") {
             const terminalEventID = bounded(event, 1024, "uuid", "message_id", "id");
@@ -331,6 +381,8 @@ export async function runBridge({ input, output, diagnostics, sdk, cwd = "/task/
             activeTurnKind = "work";
             interruptedTurnID = "";
             controlAssistantText = "";
+            reasoningSegmentIDs.clear();
+            reasoningSegmentCounter = 0;
             toolNames.clear();
             emittedToolUses.clear();
             emittedToolResults.clear();
@@ -348,6 +400,8 @@ export async function runBridge({ input, output, diagnostics, sdk, cwd = "/task/
           activeTurnKind = "work";
           interruptedTurnID = "";
           controlAssistantText = "";
+          reasoningSegmentIDs.clear();
+          reasoningSegmentCounter = 0;
           toolNames.clear();
           emittedToolUses.clear();
           emittedToolResults.clear();

--- a/cmd/pentest-claude-sdk-bridge/bridge.test.mjs
+++ b/cmd/pentest-claude-sdk-bridge/bridge.test.mjs
@@ -418,10 +418,12 @@ test("rejects unsupported effort without pushing the turn input", async () => {
   await bridge.done;
 });
 
-test("emits a safe runtime output projection for visible Claude content", async () => {
+test("retains reasoning in the safe runtime output projection", async () => {
   const bridge = harness();
   bridge.send({ id: "setup", method: "claude/initialize", params: {} });
   await bridge.waitFor((frame) => frame.id === "setup");
+  bridge.send({ id: "turn-1", method: "claude/input", params: { message: "inspect" } });
+  await bridge.waitFor((frame) => frame.id === "turn-1");
 
   bridge.sdk.queries[0].emit({
     type: "assistant",
@@ -429,7 +431,7 @@ test("emits a safe runtime output projection for visible Claude content", async 
       role: "assistant",
       content: [
         { type: "text", text: "I will inspect the app." },
-        { type: "thinking", thinking: "private reasoning must not cross the bridge" },
+        { type: "thinking", thinking: "inspect auth before choosing a tool" },
         { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "curl http://localhost" } },
       ],
     },
@@ -443,10 +445,62 @@ test("emits a safe runtime output projection for visible Claude content", async 
       role: "assistant",
       content: [
         { type: "text", text: "I will inspect the app." },
+        { type: "thinking", id: "turn-1-reasoning-1", thinking: "inspect auth before choosing a tool" },
         { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "curl http://localhost" } },
       ],
     },
   });
+  bridge.input.end();
+  await bridge.done;
+});
+
+test("forwards token-level Claude thinking stream events with a stable item id", async () => {
+  const bridge = harness();
+  bridge.send({ id: "setup", method: "claude/initialize", params: {} });
+  await bridge.waitFor((frame) => frame.id === "setup");
+  bridge.send({ id: "turn-1", method: "claude/input", params: { message: "inspect" } });
+  await bridge.waitFor((frame) => frame.id === "turn-1");
+
+  assert.equal(bridge.sdk.queries[0].options.includePartialMessages, true);
+  bridge.sdk.queries[0].emit({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "thinking_delta", thinking: "checking " },
+    },
+  });
+
+  const output = await bridge.waitFor((frame) => frame.method === "claude/runtime_output");
+  assert.equal(output.params.stream, "stream_event");
+  assert.deepEqual(JSON.parse(output.params.text), {
+    type: "content_block_delta",
+    index: 0,
+    item_id: "turn-1-reasoning-1",
+    delta: { type: "thinking_delta", thinking: "checking " },
+  });
+  // A completed assistant block ends the first segment. Reusing content index
+  // zero later in the same Runtime Turn creates a new stable segment id.
+  bridge.sdk.queries[0].emit({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "thinking", thinking: "checking auth" }] },
+  });
+  await bridge.waitFor((frame) => frame.method === "claude/runtime_output" && JSON.parse(frame.params.text).type === "assistant");
+  bridge.sdk.queries[0].emit({
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "thinking_delta", thinking: "after tool" },
+    },
+  });
+  const secondSegment = await bridge.waitFor((frame) => {
+    if (frame.method !== "claude/runtime_output") return false;
+    const record = JSON.parse(frame.params.text);
+    return record.type === "content_block_delta" && record.delta?.thinking === "after tool";
+  });
+  assert.equal(JSON.parse(secondSegment.params.text).item_id, "turn-1-reasoning-2");
+
   bridge.input.end();
   await bridge.done;
 });

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -192,6 +192,7 @@ func TestBuildNativeResumeArgsUsesClaudeCodeRuntimePluginContract(t *testing.T) 
 		"--strict-mcp-config", "--mcp-config", "/task/workdir/.mcp.json",
 		"-p",
 		"--output-format", "stream-json",
+		"--include-partial-messages",
 		"--verbose",
 		"--permission-mode", "bypassPermissions",
 		"--dangerously-skip-permissions",

--- a/internal/daemon/finish_task_resume_test.go
+++ b/internal/daemon/finish_task_resume_test.go
@@ -240,18 +240,32 @@ func launchFinishTask(t *testing.T, server *Server, created task.Task) {
 	if !ok {
 		t.Fatalf("finish fixture provider session %T cannot complete its initial Turn", bound)
 	}
-	state := providerSessionTurnState(bound)
-	if strings.TrimSpace(state.ActiveTurnID) == "" {
-		t.Fatal("finish fixture launch did not create an active provider Turn")
-	}
+	turnID := waitForProviderTurn(t, server, created.ID, bound)
 	if err := emitter.EmitObservation(runtime.ProviderSessionObservation{
 		Kind:           runtime.ProviderSessionObservationTurnCompleted,
-		ProviderTurnID: state.ActiveTurnID,
+		ProviderTurnID: turnID,
 		Status:         "completed",
 	}); err != nil {
 		t.Fatalf("complete initial provider Turn: %v", err)
 	}
 	waitForLiveIdle(t, server, created)
+}
+
+func waitForProviderTurn(t *testing.T, server *Server, taskID string, bound runtime.ProviderSession) string {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		state := providerSessionTurnState(bound)
+		if turnID := strings.TrimSpace(state.ActiveTurnID); turnID != "" {
+			return turnID
+		}
+		if !server.harness.IsActive(taskID) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("finish fixture launch did not create an active provider Turn; harness_active=%v state=%#v", server.harness.IsActive(taskID), providerSessionTurnState(bound))
+	return ""
 }
 
 func waitForLiveIdle(t *testing.T, server *Server, created task.Task) {
@@ -1012,6 +1026,11 @@ type delayedFinishCloseSession struct {
 	closeEntered chan struct{}
 	allowClose   chan struct{}
 	once         sync.Once
+	allowOnce    sync.Once
+}
+
+func (s *delayedFinishCloseSession) releaseClose() {
+	s.allowOnce.Do(func() { close(s.allowClose) })
 }
 
 func (s *delayedFinishCloseSession) Close(ctx context.Context) error {
@@ -1046,6 +1065,7 @@ func TestFinishTaskShutdownHappensBeforeReconciliation(t *testing.T) {
 	adapter := runtime.NewProviderSessionRunAdapter(session, session.closed)
 	factory := &finishSessionFactory{session: session, adapter: adapter}
 	server, created, _ := newFinishTaskFixture(t, factory)
+	t.Cleanup(session.releaseClose)
 
 	counter := &countingFinishReconciler{inner: nil}
 	// Preserve production recon when present; still count calls for order.
@@ -1077,7 +1097,7 @@ func TestFinishTaskShutdownHappensBeforeReconciliation(t *testing.T) {
 		t.Fatal("Task completed before provider resources closed")
 	}
 
-	close(session.allowClose)
+	session.releaseClose()
 	var resp *httptest.ResponseRecorder
 	select {
 	case resp = <-done:

--- a/internal/daemon/provider_session_control.go
+++ b/internal/daemon/provider_session_control.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"pentest/internal/adapters"
 	"pentest/internal/runtime"
 	"pentest/internal/runtimeprofile"
 	"pentest/internal/session"
@@ -230,8 +231,9 @@ func (server *Server) persistSessionProviderSessionEvent(sessionID string, kind 
 }
 
 func sessionProviderEventPayload(kind task.EventKind, payload task.EventPayload, continuationID string) (session.EventKind, session.EventPayload) {
+	payload = task.EventPayload(adapters.Redact(map[string]any(payload)))
 	redacted := session.EventPayload{}
-	for _, key := range []string{"provider", "provider_event", "request_id", "session_id", "provider_turn_id", "mode", "outcome", "permission_request_id", "permission_decision", "error_code", "phase"} {
+	for _, key := range []string{"provider", "provider_event", "request_id", "session_id", "provider_turn_id", "provider_item_id", "mode", "outcome", "permission_request_id", "permission_decision", "error_code", "phase"} {
 		if value, ok := payload[key]; ok {
 			redacted[key] = value
 		}
@@ -282,8 +284,9 @@ func (server *Server) persistSessionProviderEventForContinuation(sessionID, cont
 // the current Continuation at receipt time, so raw protocol payload cannot be
 // persisted or leak into the Task Conversation.
 func (server *Server) persistProviderSessionEvent(taskID string, kind task.EventKind, payload task.EventPayload) {
+	payload = task.EventPayload(adapters.Redact(map[string]any(payload)))
 	redacted := task.EventPayload{}
-	for _, key := range []string{"provider", "provider_event", "request_id", "session_id", "provider_turn_id", "mode", "outcome", "permission_request_id"} {
+	for _, key := range []string{"provider", "provider_event", "request_id", "session_id", "provider_turn_id", "provider_item_id", "mode", "outcome", "permission_request_id", "phase"} {
 		if value, ok := payload[key]; ok {
 			redacted[key] = value
 		}

--- a/internal/daemon/provider_session_control_test.go
+++ b/internal/daemon/provider_session_control_test.go
@@ -142,8 +142,9 @@ func TestProviderRuntimeOutputPersistsOnlyTranscriptFields(t *testing.T) {
 
 	server.persistProviderSessionEvent(created.ID, task.EventKindRuntimeOutput, task.EventPayload{
 		"provider": "claude_code", "provider_event": "claude/runtime_output",
-		"session_id": "claude-1", "provider_turn_id": "turn-1",
-		"stream": "assistant", "text": `{"type":"assistant","message":{"content":[{"type":"text","text":"ready"}]}}`,
+		"session_id": "claude-1", "provider_turn_id": "turn-1", "provider_item_id": "turn-1-thinking-0",
+		"phase":  "streaming",
+		"stream": "assistant", "text": `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"use bearer secret-provider-token-123456 next"}]}}`,
 		"raw": "must not persist",
 	})
 
@@ -156,6 +157,13 @@ func TestProviderRuntimeOutputPersistsOnlyTranscriptFields(t *testing.T) {
 	}
 	if events[0].Payload["stream"] != "assistant" || events[0].Payload["text"] == "" {
 		t.Fatalf("runtime output payload = %#v", events[0].Payload)
+	}
+	if events[0].Payload["provider_item_id"] != "turn-1-thinking-0" || events[0].Payload["phase"] != "streaming" {
+		t.Fatalf("runtime output lost reasoning correlation fields: %#v", events[0].Payload)
+	}
+	text, _ := events[0].Payload["text"].(string)
+	if strings.Contains(text, "secret-provider-token-123456") || !strings.Contains(text, "bearer [REDACTED]") {
+		t.Fatalf("runtime output reasoning was not shape-redacted: %q", text)
 	}
 	if _, leaked := events[0].Payload["raw"]; leaked {
 		t.Fatalf("runtime output leaked raw provider payload: %#v", events[0].Payload)

--- a/internal/daemon/session_runtime_handlers_test.go
+++ b/internal/daemon/session_runtime_handlers_test.go
@@ -529,6 +529,28 @@ func TestRejectedSessionRuntimeTurnsDoNotPersistAttachments(t *testing.T) {
 	}
 }
 
+func TestSessionProviderRuntimeOutputKeepsReasoningCorrelationFields(t *testing.T) {
+	kind, payload := sessionProviderEventPayload(task.EventKindRuntimeOutput, task.EventPayload{
+		"provider": "claude_code", "provider_event": "claude/runtime_output",
+		"session_id": "claude-1", "provider_turn_id": "turn-1", "provider_item_id": "turn-1-thinking-0",
+		"phase": "streaming", "stream": "stream_event", "text": `{"type":"content_block_delta","delta":{"thinking":"bearer secret-session-token-123456"}}`,
+		"raw": "must not persist",
+	}, "continuation-1")
+	if kind != session.EventKindRuntimeOutput {
+		t.Fatalf("provider runtime output kind = %q, want %q", kind, session.EventKindRuntimeOutput)
+	}
+	if payload["provider_item_id"] != "turn-1-thinking-0" || payload["phase"] != "streaming" || payload["continuation_id"] != "continuation-1" {
+		t.Fatalf("provider runtime output lost reasoning correlation: %#v", payload)
+	}
+	text, _ := payload["text"].(string)
+	if strings.Contains(text, "secret-session-token-123456") || !strings.Contains(text, "bearer [REDACTED]") {
+		t.Fatalf("session reasoning was not shape-redacted: %q", text)
+	}
+	if _, leaked := payload["raw"]; leaked {
+		t.Fatalf("provider runtime output leaked raw payload: %#v", payload)
+	}
+}
+
 func TestSessionProviderResultsRemainOnTimelineOutsideConversation(t *testing.T) {
 	kind, payload := sessionProviderEventPayload(task.EventKindConversation, task.EventPayload{
 		"provider": "codex", "request_id": "request-1", "outcome": "applied", "phase": "provider_turn_applied",

--- a/internal/runtime/claude_assisted.go
+++ b/internal/runtime/claude_assisted.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"pentest/internal/blackboardconclusion"
+	"pentest/internal/runtimeoutput"
 )
 
 const maxClaudeAssistedDedupKeys = 4096
@@ -40,13 +41,24 @@ func (s *ClaudeCodeProviderSession) SetAttemptResultValidationFailureSink(sink P
 }
 
 // HandleEvent consumes only the closed Claude assisted protocol before
-// delegating ordinary runtime-output and lifecycle projection. Provider wire
+// delegating ordinary runtime-output and lifecycle projection. Thinking
+// stream deltas batch into cumulative runtime output; every other event first
+// flushes the pending batch so durable order follows wire order. Provider wire
 // payloads never become observations or validated Attempt results directly.
 func (s *ClaudeCodeProviderSession) HandleEvent(event SandboxBridgeEvent, emit ProviderSessionEmit) {
 	method := strings.ToLower(strings.TrimSpace(event.Method))
 	params := map[string]any{}
 	if len(event.Params) > 0 && json.Unmarshal(event.Params, &params) != nil {
 		return
+	}
+	if method == "claude/runtime_output" && s.tryBatchClaudeReasoningOutput(event, params, emit) {
+		return
+	}
+	completedReasoningRecord := method == "claude/runtime_output" && claudeRuntimeOutputHasReasoning(params)
+	if method == "claude/turn/completed" {
+		s.completeClaudeReasoning(emit, params)
+	} else {
+		s.reasoning.Barrier()
 	}
 	switch method {
 	case "claude/tool/used", "claude/tool/result", "claude/turn/completed":
@@ -56,6 +68,137 @@ func (s *ClaudeCodeProviderSession) HandleEvent(event SandboxBridgeEvent, emit P
 		return
 	}
 	s.providerSessionAdapter.HandleEvent(event, emit)
+	if completedReasoningRecord {
+		// The full assistant record has the same stable thinking-block id and
+		// replaces the streamed delta row. Its projection closes the segment.
+		s.reasoning.Reset()
+	}
+}
+
+// tryBatchClaudeReasoningOutput accumulates one thinking stream delta into the
+// session batcher. Flushed batches carry the cumulative text keyed by the
+// bridge-synthesized thinking item id so transcript projections grow one
+// stable reasoning entry in place. It reports whether the event was consumed.
+func (s *ClaudeCodeProviderSession) tryBatchClaudeReasoningOutput(event SandboxBridgeEvent, params map[string]any, emit ProviderSessionEmit) bool {
+	text := providerJSONValue(params, "text")
+	if text == "" {
+		return false
+	}
+	var record map[string]any
+	if json.Unmarshal([]byte(text), &record) != nil {
+		return false
+	}
+	if providerJSONValue(record, "type") != "content_block_delta" {
+		return false
+	}
+	delta, ok := record["delta"].(map[string]any)
+	if !ok {
+		return false
+	}
+	// Thinking text must stay untrimmed: a trailing space often separates words.
+	thought := claudeThinkingDeltaText(delta)
+	itemID := providerJSONValue(record, "item_id", "itemId")
+	if thought == "" || itemID == "" {
+		return false
+	}
+	turnID := providerJSONValue(params, "turn_id", "turnId")
+	if turnID == "" {
+		turnID = s.currentTurn()
+	}
+	sessionID := providerJSONValue(params, "session_id", "sessionId")
+	if sessionID == "" {
+		sessionID = s.SessionID()
+	}
+	stream := providerJSONValue(params, "stream")
+	providerEvent := event.Method
+	s.reasoning.Add(itemID, func(cumulative string) {
+		s.emitBatchedClaudeThinking(emit, sessionID, turnID, itemID, stream, providerEvent, cumulative)
+	}, thought)
+	return true
+}
+
+// claudeThinkingDeltaText extracts a thinking stream delta without trimming
+// so word boundaries survive delta batching.
+func claudeThinkingDeltaText(delta map[string]any) string {
+	for _, key := range []string{"thinking", "reasoning", "reasoning_content"} {
+		if text, ok := delta[key].(string); ok && text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func claudeRuntimeOutputHasReasoning(params map[string]any) bool {
+	text := providerJSONValue(params, "text")
+	if text == "" {
+		return false
+	}
+	var record map[string]any
+	if json.Unmarshal([]byte(text), &record) != nil {
+		return false
+	}
+	message, ok := record["message"].(map[string]any)
+	if !ok {
+		return false
+	}
+	content, ok := message["content"].([]any)
+	if !ok {
+		return false
+	}
+	for _, block := range content {
+		if typed, ok := block.(map[string]any); ok {
+			kind := strings.ToLower(providerJSONValue(typed, "type"))
+			if kind == "thinking" || kind == "reasoning" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *ClaudeCodeProviderSession) completeClaudeReasoning(emit ProviderSessionEmit, params map[string]any) {
+	itemID, text, ok := s.reasoning.Complete()
+	if !ok {
+		return
+	}
+	turnID := providerJSONValue(params, "turn_id", "turnId")
+	if turnID == "" {
+		turnID = s.currentTurn()
+	}
+	sessionID := providerJSONValue(params, "session_id", "sessionId")
+	if sessionID == "" {
+		sessionID = s.SessionID()
+	}
+	s.emitClaudeReasoningRecord(emit, sessionID, turnID, itemID, "stream_event", "claude/runtime_output", text, runtimeoutput.ReasoningPhaseCompleted)
+}
+
+func (s *ClaudeCodeProviderSession) emitBatchedClaudeThinking(emit ProviderSessionEmit, sessionID, turnID, itemID, stream, providerEvent, cumulative string) {
+	s.emitClaudeReasoningRecord(emit, sessionID, turnID, itemID, stream, providerEvent, cumulative, runtimeoutput.ReasoningPhaseStreaming)
+}
+
+func (s *ClaudeCodeProviderSession) emitClaudeReasoningRecord(emit ProviderSessionEmit, sessionID, turnID, itemID, stream, providerEvent, cumulative, phase string) {
+	if cumulative == "" {
+		return
+	}
+	encoded, err := json.Marshal(map[string]any{
+		"type":    "content_block_delta",
+		"index":   0,
+		"item_id": itemID,
+		"phase":   phase,
+		"delta":   map[string]any{"type": "thinking_delta", "thinking": cumulative},
+	})
+	if err != nil {
+		return
+	}
+	s.emitReasoningRuntimeOutput(emit, reasoningRuntimeOutput{
+		ProviderEvent: providerEvent,
+		SessionID:     sessionID,
+		TurnID:        turnID,
+		ItemID:        itemID,
+		Stream:        stream,
+		Phase:         phase,
+		Text:          string(encoded),
+	})
 }
 
 func (s *ClaudeCodeProviderSession) correlatedClaudeLineage(params map[string]any) (ProviderSessionTurnLineage, string, string, string, bool) {

--- a/internal/runtime/codex_assisted.go
+++ b/internal/runtime/codex_assisted.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"pentest/internal/blackboardconclusion"
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/task"
 )
 
@@ -25,10 +26,11 @@ const (
 	codexAssistedTerminal   codexAssistedEventKind = "terminal"
 )
 
-// codexAssistedEvent is the complete in-memory provider boundary. It contains
-// only bounded correlation metadata and, for a possible control result, at most
-// one decoder-sized assistant message. Tool arguments/results and reasoning are
-// deliberately discarded while parsing the App Server notification.
+// codexAssistedEvent is the complete in-memory assisted-observation boundary.
+// It contains only bounded correlation metadata and, for a possible control
+// result, at most one decoder-sized assistant message. Tool arguments/results
+// and reasoning never enter this semantic observation type; the separate
+// runtime-output projection retains transcript-visible reasoning.
 type codexAssistedEvent struct {
 	kind      codexAssistedEventKind
 	sessionID string
@@ -98,11 +100,22 @@ func (s *CodexProviderSession) InterruptThenReplace(ctx context.Context, request
 }
 
 // HandleEvent keeps the existing interactive lifecycle channel while adding a
-// separate closed semantic-observation channel. Item payloads never enter Task
-// events; only turn/permission notifications are sent through the lifecycle
-// normalizer.
+// separate closed semantic-observation channel. Bounded item projections enter
+// runtime_output Task Events, while only turn/permission notifications enter
+// the lifecycle normalizer. Reasoning deltas stream as batched runtime output;
+// any other event first flushes the pending reasoning batch so durable order
+// follows wire order.
 func (s *CodexProviderSession) HandleEvent(event SandboxBridgeEvent, emit ProviderSessionEmit) {
 	method := strings.ToLower(strings.TrimSpace(event.Method))
+	if method == "item/reasoning/summarytextdelta" {
+		s.acceptCodexReasoningDelta(event, emit)
+		return
+	}
+	if method == "turn/completed" {
+		s.completeCodexReasoning(emit, event.Params)
+	} else {
+		s.reasoning.Barrier()
+	}
 	if strings.HasPrefix(method, "item/") {
 		s.emitCodexRuntimeOutput(event, emit)
 	} else {
@@ -164,7 +177,18 @@ func (s *CodexProviderSession) emitCodexRuntimeOutput(event SandboxBridgeEvent, 
 		}
 		text = codexReasoningRuntimeOutput(params, item)
 		if text == "" {
-			return
+			itemID, cumulative, ok := s.reasoning.Complete()
+			if !ok {
+				return
+			}
+			text = codexCompletedReasoningRuntimeOutput(params, itemID, cumulative)
+			if text == "" {
+				return
+			}
+		} else {
+			// The completed item provides the final cumulative text and closes the
+			// streaming segment. Clear the batcher base after the prior Barrier.
+			s.reasoning.Reset()
 		}
 	default:
 		return
@@ -192,15 +216,38 @@ func (s *CodexProviderSession) emitCodexRuntimeOutput(event SandboxBridgeEvent, 
 	})
 }
 
+func codexCompletedReasoningRuntimeOutput(params map[string]any, itemID, content string) string {
+	if itemID == "" || content == "" {
+		return ""
+	}
+	return codexReasoningRuntimeOutput(params, map[string]any{
+		"type":    "reasoning",
+		"id":      itemID,
+		"content": []any{content},
+	})
+}
+
 func codexReasoningRuntimeOutput(params, item map[string]any) string {
-	summary, ok := item["summary"]
-	if !ok || strings.TrimSpace(providerReasoningSummary(summary)) == "" {
+	content, hasContent := item["content"]
+	summary, hasSummary := item["summary"]
+	// Raw reasoning content is durable transcript content. Third-party model
+	// summaries are not the real thinking, so content is kept and preferred;
+	// the summary stays as the fallback. Shape-based redaction still applies
+	// when the event is stored.
+	hasText := (hasContent && strings.TrimSpace(providerReasoningText(content)) != "") ||
+		(hasSummary && strings.TrimSpace(providerReasoningText(summary)) != "")
+	if !hasText {
 		return ""
 	}
 	minimalItem := map[string]any{
-		"type":    "reasoning",
-		"id":      providerJSONValue(item, "id"),
-		"summary": summary,
+		"type": "reasoning",
+		"id":   providerJSONValue(item, "id"),
+	}
+	if hasContent {
+		minimalItem["content"] = content
+	}
+	if hasSummary {
+		minimalItem["summary"] = summary
 	}
 	minimal := map[string]any{"item": minimalItem}
 	if threadID := providerJSONValue(params, "threadId", "thread_id"); threadID != "" {
@@ -216,21 +263,105 @@ func codexReasoningRuntimeOutput(params, item map[string]any) string {
 	return string(encoded)
 }
 
-func providerReasoningSummary(value any) string {
+// providerReasoningText joins string parts and text-bearing object parts of a
+// reasoning content or summary list.
+func providerReasoningText(value any) string {
 	switch typed := value.(type) {
 	case string:
 		return strings.TrimSpace(typed)
 	case []any:
 		parts := make([]string, 0, len(typed))
 		for _, part := range typed {
-			if text, ok := part.(string); ok && strings.TrimSpace(text) != "" {
-				parts = append(parts, strings.TrimSpace(text))
+			if text, ok := part.(string); ok {
+				if strings.TrimSpace(text) != "" {
+					parts = append(parts, strings.TrimSpace(text))
+				}
+				continue
+			}
+			if partMap, ok := part.(map[string]any); ok {
+				if text := providerJSONValue(partMap, "text", "content"); strings.TrimSpace(text) != "" {
+					parts = append(parts, strings.TrimSpace(text))
+				}
 			}
 		}
 		return strings.Join(parts, "\n")
 	default:
 		return ""
 	}
+}
+
+// acceptCodexReasoningDelta accumulates one reasoning summary text delta into
+// the session batcher. Flushed batches carry the cumulative text so transcript
+// projections grow one stable reasoning entry in place.
+func (s *CodexProviderSession) acceptCodexReasoningDelta(event SandboxBridgeEvent, emit ProviderSessionEmit) {
+	params := map[string]any{}
+	if len(event.Params) == 0 || json.Unmarshal(event.Params, &params) != nil {
+		return
+	}
+	itemID := providerJSONValue(params, "itemId", "item_id")
+	// Delta text must stay untrimmed: a trailing space often separates words.
+	delta, _ := params["delta"].(string)
+	if itemID == "" || delta == "" {
+		return
+	}
+	turnID := providerJSONValue(params, "turnId", "turn_id")
+	if turnID == "" {
+		turnID = s.currentTurn()
+	}
+	sessionID := providerJSONValue(params, "threadId", "thread_id")
+	if sessionID == "" {
+		sessionID = s.SessionID()
+	}
+	s.reasoning.Add(itemID, func(cumulative string) {
+		s.emitBatchedCodexReasoning(emit, sessionID, turnID, itemID, cumulative)
+	}, delta)
+}
+
+func (s *CodexProviderSession) completeCodexReasoning(emit ProviderSessionEmit, raw json.RawMessage) {
+	itemID, content, ok := s.reasoning.Complete()
+	if !ok {
+		return
+	}
+	params := map[string]any{}
+	_ = json.Unmarshal(raw, &params)
+	sessionID := providerJSONValue(params, "threadId", "thread_id")
+	if sessionID == "" {
+		sessionID = s.SessionID()
+	}
+	turnID := providerJSONValue(params, "turnId", "turn_id")
+	if turn, ok := params["turn"].(map[string]any); ok && turnID == "" {
+		turnID = providerJSONValue(turn, "id", "turnId", "turn_id")
+	}
+	if turnID == "" {
+		turnID = s.currentTurn()
+	}
+	text := codexCompletedReasoningRuntimeOutput(params, itemID, content)
+	if text == "" {
+		return
+	}
+	s.emitCodexReasoningRecord(emit, sessionID, turnID, itemID, "item/completed", text, runtimeoutput.ReasoningPhaseCompleted)
+}
+
+func (s *CodexProviderSession) emitBatchedCodexReasoning(emit ProviderSessionEmit, sessionID, turnID, itemID, cumulative string) {
+	encoded, err := json.Marshal(map[string]any{
+		"item": map[string]any{"type": "reasoning", "id": itemID, "summary": []string{cumulative}},
+	})
+	if err != nil {
+		return
+	}
+	s.emitCodexReasoningRecord(emit, sessionID, turnID, itemID, "item/reasoning/summaryTextDelta", string(encoded), runtimeoutput.ReasoningPhaseStreaming)
+}
+
+func (s *CodexProviderSession) emitCodexReasoningRecord(emit ProviderSessionEmit, sessionID, turnID, itemID, providerEvent, text, phase string) {
+	s.emitReasoningRuntimeOutput(emit, reasoningRuntimeOutput{
+		ProviderEvent: providerEvent,
+		SessionID:     sessionID,
+		TurnID:        turnID,
+		ItemID:        itemID,
+		Stream:        "codex_app_server",
+		Phase:         phase,
+		Text:          text,
+	})
 }
 
 func (s *CodexProviderSession) acceptCodexAssisted(event codexAssistedEvent) {

--- a/internal/runtime/hermes_assisted.go
+++ b/internal/runtime/hermes_assisted.go
@@ -2,10 +2,12 @@ package runtime
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"sync"
 
 	"pentest/internal/blackboardconclusion"
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/task"
 )
 
@@ -27,6 +29,8 @@ type hermesAssistedState struct {
 	delivered             map[string]bool
 	deliveredOrder        []string
 	toolNames             map[string]string
+	activeThoughtKey      string
+	thoughtSegment        int
 }
 
 var hermesAssistedStates sync.Map
@@ -59,8 +63,9 @@ func (s *HermesProviderSession) SetAttemptResultValidationFailureSink(sink Provi
 }
 
 // HandleEvent maps Hermes ACP session/update notifications onto the bounded
-// assisted observation and closed Attempt result seams. Raw tool payloads and
-// reasoning never become observations or Task events.
+// assisted observation and closed Attempt result seams. Agent thought chunks
+// stream as batched runtime output so operator reasoning stays visible; raw
+// tool payloads never become observations.
 func (s *HermesProviderSession) HandleEvent(event SandboxBridgeEvent, emit ProviderSessionEmit) {
 	method := strings.ToLower(strings.TrimSpace(event.Method))
 	params := map[string]any{}
@@ -72,23 +77,113 @@ func (s *HermesProviderSession) HandleEvent(event SandboxBridgeEvent, emit Provi
 	switch kind {
 	case "agent_message_chunk":
 		s.captureHermesAttemptCandidate(params, update)
+		s.completeHermesThought(emit, params, event)
 		s.emitHermesRuntimeOutput(event, params, emit)
 		return
+	case "agent_thought_chunk":
+		s.acceptHermesThoughtChunk(event, params, update, emit)
+		return
 	case "tool_call":
+		s.completeHermesThought(emit, params, event)
 		s.emitHermesToolObservation(params, update, ProviderSessionObservationToolUse)
 		s.emitHermesRuntimeOutput(event, params, emit)
 		return
 	case "tool_call_update":
+		s.completeHermesThought(emit, params, event)
 		s.emitHermesToolObservation(params, update, ProviderSessionObservationToolResult)
 		s.emitHermesRuntimeOutput(event, params, emit)
 		return
 	case "turn_ended":
+		s.completeHermesThought(emit, params, event)
 		s.projectHermesTerminalLifecycle(event, params, hermesACPStopStatus(update), emit)
 		s.finishHermesAssistedTurn(params, update)
 		return
 	default:
+		s.completeHermesThought(emit, params, event)
 		s.providerSessionAdapter.HandleEvent(event, emit)
 	}
+}
+
+// acceptHermesThoughtChunk accumulates one agent thought chunk into the
+// session batcher. Flushed batches carry the cumulative text keyed by turn so
+// transcript projections grow one stable reasoning entry in place.
+func (s *HermesProviderSession) acceptHermesThoughtChunk(event SandboxBridgeEvent, params, update map[string]any, emit ProviderSessionEmit) {
+	// Thought text must stay untrimmed: a trailing space often separates words.
+	text := hermesThoughtText(update)
+	if text == "" {
+		return
+	}
+	turnID := providerJSONValue(params, "turn_id", "turnId")
+	if turnID == "" {
+		turnID = s.currentTurn()
+	}
+	sessionID := providerJSONValue(params, "sessionId", "session_id")
+	if sessionID == "" {
+		sessionID = s.SessionID()
+	}
+	key := s.hermesThoughtSegmentKey(turnID)
+	s.reasoning.Add(key, func(cumulative string) {
+		s.emitBatchedHermesThought(emit, sessionID, turnID, key, cumulative, event)
+	}, text)
+}
+
+func (s *HermesProviderSession) hermesThoughtSegmentKey(turnID string) string {
+	state := s.assistedState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.activeThoughtKey == "" {
+		state.thoughtSegment++
+		state.activeThoughtKey = "hermes-thought-" + turnID + "-" + strconv.Itoa(state.thoughtSegment)
+	}
+	return state.activeThoughtKey
+}
+
+func (s *HermesProviderSession) completeHermesThought(emit ProviderSessionEmit, params map[string]any, event SandboxBridgeEvent) {
+	key, text, ok := s.reasoning.Complete()
+	state := s.assistedState()
+	state.mu.Lock()
+	state.activeThoughtKey = ""
+	state.mu.Unlock()
+	if !ok {
+		return
+	}
+	turnID := providerJSONValue(params, "turn_id", "turnId")
+	if turnID == "" {
+		turnID = s.currentTurn()
+	}
+	sessionID := providerJSONValue(params, "sessionId", "session_id")
+	if sessionID == "" {
+		sessionID = s.SessionID()
+	}
+	s.emitHermesThoughtRecord(emit, sessionID, turnID, key, text, runtimeoutput.ReasoningPhaseCompleted, event)
+}
+
+func (s *HermesProviderSession) emitBatchedHermesThought(emit ProviderSessionEmit, sessionID, turnID, key, cumulative string, event SandboxBridgeEvent) {
+	s.emitHermesThoughtRecord(emit, sessionID, turnID, key, cumulative, runtimeoutput.ReasoningPhaseStreaming, event)
+}
+
+func (s *HermesProviderSession) emitHermesThoughtRecord(emit ProviderSessionEmit, sessionID, turnID, key, cumulative, phase string, event SandboxBridgeEvent) {
+	if cumulative == "" {
+		return
+	}
+	encoded, err := json.Marshal(map[string]any{
+		"sessionUpdate": "agent_thought_chunk",
+		"text":          cumulative,
+		"item_id":       key,
+		"phase":         phase,
+	})
+	if err != nil {
+		return
+	}
+	s.emitReasoningRuntimeOutput(emit, reasoningRuntimeOutput{
+		ProviderEvent: event.Method,
+		SessionID:     sessionID,
+		TurnID:        turnID,
+		ItemID:        key,
+		Stream:        "hermes_acp",
+		Phase:         phase,
+		Text:          string(encoded),
+	})
 }
 
 func (s *HermesProviderSession) emitHermesRuntimeOutput(event SandboxBridgeEvent, params map[string]any, emit ProviderSessionEmit) {
@@ -295,6 +390,20 @@ func hermesACPAssistantText(update map[string]any) string {
 		return ""
 	}
 	return providerJSONValue(content, "text")
+}
+
+// hermesThoughtText extracts an agent thought chunk without trimming so
+// word boundaries survive delta batching.
+func hermesThoughtText(update map[string]any) string {
+	if text, ok := update["text"].(string); ok && text != "" {
+		return text
+	}
+	if content, ok := update["content"].(map[string]any); ok {
+		if text, ok := content["text"].(string); ok {
+			return text
+		}
+	}
+	return ""
 }
 
 func hermesACPToolResultStatus(update map[string]any) string {

--- a/internal/runtime/hermes_assisted_test.go
+++ b/internal/runtime/hermes_assisted_test.go
@@ -221,3 +221,82 @@ func TestHermesInvalidControlResultReportsOnlyBoundedFailure(t *testing.T) {
 		t.Fatalf("validation failure = %#v", got)
 	}
 }
+
+func TestHermesProviderSessionStreamsThoughtChunks(t *testing.T) {
+	var events []task.EventPayload
+	session := NewHermesProviderSession(HermesProviderSessionConfig{
+		Transport: &fakeProviderTransport{}, SessionID: "hermes-session", ActiveTurnID: "hermes-turn",
+	})
+	emit := func(_ task.EventKind, payload task.EventPayload) { events = append(events, payload) }
+
+	// Two thought chunks arrive before any other event: batching keeps both
+	// out of the event store until the window or a barrier flushes.
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "session/update",
+		Params: json.RawMessage(`{"sessionId":"hermes-session","turn_id":"hermes-turn","update":{"sessionUpdate":"agent_thought_chunk","text":"checking "}}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "session/update",
+		Params: json.RawMessage(`{"sessionId":"hermes-session","turn_id":"hermes-turn","update":{"sessionUpdate":"agent_thought_chunk","text":"the auth flow"}}`),
+	}, emit)
+	if len(events) != 0 {
+		t.Fatalf("thought chunks must batch before a flush: %#v", events)
+	}
+
+	// The next tool call event barriers the pending reasoning batch so the
+	// durable order matches the wire order.
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "session/update",
+		Params: json.RawMessage(`{"sessionId":"hermes-session","turn_id":"hermes-turn","update":{"sessionUpdate":"tool_call","toolCallId":"call-1","title":"bash","rawInput":{"command":"ls"}}}`),
+	}, emit)
+
+	if len(events) != 2 {
+		t.Fatalf("events after barrier = %#v", events)
+	}
+	batched := events[0]
+	if batched["provider_event"] != "session/update" || batched["stream"] != "hermes_acp" {
+		t.Fatalf("batched thought payload = %#v", batched)
+	}
+	if batched["provider_item_id"] != "hermes-thought-hermes-turn-1" {
+		t.Fatalf("batched thought identity = %#v", batched)
+	}
+	text, _ := batched["text"].(string)
+	var record map[string]any
+	if err := json.Unmarshal([]byte(text), &record); err != nil {
+		t.Fatalf("batched thought text is not JSON: %q", text)
+	}
+	if record["sessionUpdate"] != "agent_thought_chunk" || record["text"] != "checking the auth flow" {
+		t.Fatalf("batched thought record = %#v", record)
+	}
+	if record["item_id"] != "hermes-thought-hermes-turn-1" {
+		t.Fatalf("batched thought item id = %#v", record)
+	}
+	if events[1]["provider_item_id"] != nil {
+		t.Fatalf("tool call event must not carry reasoning identity: %#v", events[1])
+	}
+
+	// A turn boundary flushes any trailing reasoning tail.
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "session/update",
+		Params: json.RawMessage(`{"sessionId":"hermes-session","turn_id":"hermes-turn","update":{"sessionUpdate":"agent_thought_chunk","text":" tail"}}`),
+	}, emit)
+	if len(events) != 2 {
+		t.Fatalf("trailing chunk must stay batched: %#v", events)
+	}
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "session/update",
+		Params: json.RawMessage(`{"sessionId":"hermes-session","turn_id":"hermes-turn","update":{"sessionUpdate":"turn_ended","stopReason":"end_turn"}}`),
+	}, emit)
+	if len(events) != 3 {
+		t.Fatalf("turn end must complete the trailing reasoning segment: %#v", events)
+	}
+	// The first segment was completed before the tool call. The post-tool tail
+	// is a new reasoning segment with a different stable identity.
+	if events[0]["phase"] != "completed" || events[0]["provider_item_id"] != "hermes-thought-hermes-turn-1" {
+		t.Fatalf("first completed thought segment = %#v", events[0])
+	}
+	tailText, _ := events[2]["text"].(string)
+	if events[2]["phase"] != "completed" || events[2]["provider_item_id"] != "hermes-thought-hermes-turn-2" || !strings.Contains(tailText, " tail") {
+		t.Fatalf("second completed thought segment = %#v", events[2])
+	}
+}

--- a/internal/runtime/pi_session_tail.go
+++ b/internal/runtime/pi_session_tail.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"pentest/internal/adapters"
 	"pentest/internal/runtimeoutput"
 	"pentest/internal/task"
 )
@@ -138,10 +139,10 @@ func tailPiSession(ctx context.Context, sessionDir string, observe func(string),
 					if runtimeoutput.ShouldIgnoreForStorage(trimmed) {
 						continue
 					}
-					emit(task.EventKindRuntimeOutput, task.EventPayload{
+					emit(task.EventKindRuntimeOutput, task.EventPayload(adapters.Redact(map[string]any{
 						"stream": "pi_session",
 						"text":   trimmed,
-					})
+					})))
 				}
 			}
 			if err != nil {

--- a/internal/runtime/pi_session_tail_test.go
+++ b/internal/runtime/pi_session_tail_test.go
@@ -2,14 +2,17 @@ package runtime_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"pentest/internal/runtime"
 	"pentest/internal/task"
+	"pentest/internal/transcript"
 )
 
 // fakeInnerAdapter is a no-op adapter used to isolate the tail decorator.
@@ -105,6 +108,49 @@ func TestPiSessionTailEmitsAppendedLines(t *testing.T) {
 		if stream, _ := e.payload["stream"].(string); stream != "pi_session" {
 			t.Fatalf("expected stream pi_session, got %q", stream)
 		}
+	}
+}
+
+func TestPiSessionTailProjectsReasoningBlock(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "sessions", "--task-workdir--")
+	adapter := runtime.NewPiSessionTailAdapter(fakeInnerAdapter{}, sessionDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	emitCalls, getEmits, _ := collectEmits(func(task.EventKind, task.EventPayload) {})
+	go func() { _ = adapter.Run(ctx, "goal", emitCalls) }()
+
+	sessionFile := filepath.Join(sessionDir, "2026-06-19T12-11-46-221Z_abc.jsonl")
+	writeSessionLine(t, sessionFile, `{"type":"message","message":{"role":"assistant","content":[{"type":"reasoning","id":"pi-reasoning-1","reasoning":"checking the target"}]}}`)
+	waitForCount(t, getEmits, 1, 2*time.Second)
+
+	got := getEmits()
+	text, _ := got[0].payload["text"].(string)
+	var record map[string]any
+	if err := json.Unmarshal([]byte(text), &record); err != nil {
+		t.Fatalf("tail output is not provider JSON: %v", err)
+	}
+	entries := transcript.ParseRecord(record, transcript.Entry{ID: "event-1", Seq: 1, Continuation: 1})
+	if len(entries) != 1 || entries[0].Kind != transcript.KindReasoning || entries[0].Text != "checking the target" {
+		t.Fatalf("Pi reasoning projection = %#v", entries)
+	}
+}
+
+func TestPiSessionTailShapeRedactsReasoning(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "sessions", "--task-workdir--")
+	adapter := runtime.NewPiSessionTailAdapter(fakeInnerAdapter{}, sessionDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	emitCalls, getEmits, _ := collectEmits(func(task.EventKind, task.EventPayload) {})
+	go func() { _ = adapter.Run(ctx, "goal", emitCalls) }()
+
+	sessionFile := filepath.Join(sessionDir, "2026-06-19T12-11-46-221Z_abc.jsonl")
+	writeSessionLine(t, sessionFile, `{"type":"message","message":{"role":"assistant","content":[{"type":"reasoning","reasoning":"use bearer secret-pi-token-123456"}]}}`)
+	waitForCount(t, getEmits, 1, 2*time.Second)
+	text, _ := getEmits()[0].payload["text"].(string)
+	if strings.Contains(text, "secret-pi-token-123456") || !strings.Contains(text, "bearer [REDACTED]") {
+		t.Fatalf("Pi reasoning was not shape-redacted: %q", text)
 	}
 }
 

--- a/internal/runtime/provider_adapters.go
+++ b/internal/runtime/provider_adapters.go
@@ -1026,7 +1026,8 @@ type CodexProviderSessionConfig struct {
 
 type CodexProviderSession struct {
 	*providerSessionAdapter
-	assisted *codexAssistedSession
+	assisted  *codexAssistedSession
+	reasoning *reasoningDeltaBatcher
 }
 
 func NewCodexProviderSession(config CodexProviderSessionConfig) *CodexProviderSession {
@@ -1092,6 +1093,7 @@ func NewCodexProviderSession(config CodexProviderSessionConfig) *CodexProviderSe
 	return &CodexProviderSession{
 		providerSessionAdapter: newProviderSessionAdapter("codex", config.Transport, threadID, config.ActiveTurnID, capabilities, methods),
 		assisted:               newCodexAssistedSession(),
+		reasoning:              newReasoningDeltaBatcher(reasoningBatchWindow),
 	}
 }
 
@@ -1106,7 +1108,8 @@ type ClaudeCodeProviderSessionConfig struct {
 
 type ClaudeCodeProviderSession struct {
 	*providerSessionAdapter
-	assisted *claudeAssistedSession
+	assisted  *claudeAssistedSession
+	reasoning *reasoningDeltaBatcher
 }
 
 func NewClaudeCodeProviderSession(config ClaudeCodeProviderSessionConfig) *ClaudeCodeProviderSession {
@@ -1121,6 +1124,7 @@ func NewClaudeCodeProviderSession(config ClaudeCodeProviderSessionConfig) *Claud
 	return &ClaudeCodeProviderSession{
 		providerSessionAdapter: newProviderSessionAdapter("claude_code", config.Transport, config.SessionID, config.ActiveTurnID, capabilities, methods),
 		assisted:               newClaudeAssistedSession(),
+		reasoning:              newReasoningDeltaBatcher(reasoningBatchWindow),
 	}
 }
 
@@ -1164,7 +1168,10 @@ type HermesProviderSessionConfig struct {
 	Capabilities runtimeplugin.Capabilities
 }
 
-type HermesProviderSession struct{ *providerSessionAdapter }
+type HermesProviderSession struct {
+	*providerSessionAdapter
+	reasoning *reasoningDeltaBatcher
+}
 
 func NewHermesProviderSession(config HermesProviderSessionConfig) *HermesProviderSession {
 	methods := providerWireMethods{
@@ -1177,7 +1184,10 @@ func NewHermesProviderSession(config HermesProviderSessionConfig) *HermesProvide
 		turnID:    func(record map[string]any) string { return providerJSONValue(record, "turn_id", "turnId", "id") },
 		sessionID: identitySession,
 	}
-	return &HermesProviderSession{newProviderSessionAdapter("hermes", config.Transport, config.SessionID, config.ActiveTurnID, providerCapabilities(config.Capabilities), methods)}
+	return &HermesProviderSession{
+		providerSessionAdapter: newProviderSessionAdapter("hermes", config.Transport, config.SessionID, config.ActiveTurnID, providerCapabilities(config.Capabilities), methods),
+		reasoning:              newReasoningDeltaBatcher(reasoningBatchWindow),
+	}
 }
 
 func hermesACPParams(sessionID, turnID string, request ProviderSessionRequest) map[string]any {

--- a/internal/runtime/provider_adapters_test.go
+++ b/internal/runtime/provider_adapters_test.go
@@ -1532,7 +1532,7 @@ func TestCodexProviderSessionProjectsVisibleRuntimeOutput(t *testing.T) {
 		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"userMessage","id":"item-user","content":[{"type":"text","text":"operator prompt"}]}}`),
 	}, emit)
 
-	if len(events) != 6 {
+	if len(events) != 7 {
 		t.Fatalf("runtime events = %#v", events)
 	}
 	for i, kind := range kinds {
@@ -1558,12 +1558,84 @@ func TestCodexProviderSessionProjectsVisibleRuntimeOutput(t *testing.T) {
 	if events[3]["provider_event"] != "item/started" || events[4]["provider_event"] != "item/completed" {
 		t.Fatalf("MCP lifecycle = %#v %#v", events[3], events[4])
 	}
+	// Completed reasoning retains the raw content. Third-party model summaries
+	// are not the real thinking, so raw content is durable transcript content;
+	// shape-based redaction still applies at storage time.
 	text, _ := events[5]["text"].(string)
 	if events[5]["provider_event"] != "item/completed" || !strings.Contains(text, "Checked the active challenge.") {
 		t.Fatalf("completed reasoning summary = %#v", events[5])
 	}
-	if strings.Contains(text, "SECRET_RAW_REASONING") || strings.Contains(text, `"content"`) {
-		t.Fatalf("reasoning event leaked raw content: %s", text)
+	if !strings.Contains(text, "SECRET_RAW_REASONING") {
+		t.Fatalf("completed reasoning must retain raw content: %s", text)
+	}
+	// The summary text delta batches and flushes when the next event passes,
+	// carrying the cumulative text and the stable provider item identity.
+	batched, _ := events[6]["text"].(string)
+	if events[6]["provider_event"] != "item/reasoning/summaryTextDelta" {
+		t.Fatalf("batched reasoning provider_event = %#v", events[6])
+	}
+	if events[6]["provider_item_id"] != "item-reasoning" {
+		t.Fatalf("batched reasoning identity = %#v", events[6])
+	}
+	if !strings.Contains(batched, "Checked") {
+		t.Fatalf("batched reasoning text = %q", batched)
+	}
+}
+
+func TestCodexReasoningCompletionFallsBackToStreamedRawContent(t *testing.T) {
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: &fakeProviderTransport{}, SessionID: "thread-1", ActiveTurnID: "turn-1",
+	})
+	var events []task.EventPayload
+	emit := func(_ task.EventKind, payload task.EventPayload) { events = append(events, payload) }
+
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/reasoning/summaryTextDelta",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","itemId":"reasoning-1","delta":"raw reasoning"}`),
+	}, emit)
+	// Some third-party Codex-compatible models complete the item without a
+	// summary/content body. The accumulated stream must still close the entry.
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/completed",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"reasoning","id":"reasoning-1","summary":[]}}`),
+	}, emit)
+
+	if len(events) != 2 {
+		t.Fatalf("reasoning events = %#v", events)
+	}
+	completed := events[1]
+	if completed["provider_event"] != "item/completed" {
+		t.Fatalf("completed event = %#v", completed)
+	}
+	text, _ := completed["text"].(string)
+	if !strings.Contains(text, "raw reasoning") || !strings.Contains(text, `"content"`) {
+		t.Fatalf("completed fallback lost streamed raw reasoning: %s", text)
+	}
+}
+
+func TestCodexTurnCompletionClosesDeltaOnlyReasoning(t *testing.T) {
+	session := NewCodexProviderSession(CodexProviderSessionConfig{
+		Transport: &fakeProviderTransport{}, SessionID: "thread-1", ActiveTurnID: "turn-1",
+	})
+	var events []task.EventPayload
+	emit := func(_ task.EventKind, payload task.EventPayload) { events = append(events, payload) }
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "item/reasoning/summaryTextDelta",
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","itemId":"reasoning-1","delta":"raw reasoning"}`),
+	}, emit)
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "turn/completed",
+		Params: json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+	}, emit)
+	var completed task.EventPayload
+	for _, event := range events {
+		if event["phase"] == "completed" && event["provider_item_id"] == "reasoning-1" {
+			completed = event
+			break
+		}
+	}
+	if completed == nil || completed["provider_event"] != "item/completed" {
+		t.Fatalf("turn completion did not close reasoning: %#v", events)
 	}
 }
 
@@ -1588,6 +1660,82 @@ func TestClaudeProviderSessionProjectsVisibleRuntimeOutput(t *testing.T) {
 	}
 	if _, leaked := events[0]["params"]; leaked {
 		t.Fatalf("runtime output leaked protocol params: %#v", events[0])
+	}
+}
+
+func TestClaudeProviderSessionBatchesThinkingDeltasBeforeVisibleOutput(t *testing.T) {
+	var kinds []task.EventKind
+	var events []task.EventPayload
+	session := NewClaudeCodeProviderSession(ClaudeCodeProviderSessionConfig{
+		Transport: &fakeProviderTransport{}, SessionID: "claude-1", ActiveTurnID: "turn-1",
+	})
+	emit := func(kind task.EventKind, payload task.EventPayload) {
+		kinds = append(kinds, kind)
+		events = append(events, payload)
+	}
+
+	for _, text := range []string{
+		`{"type":"content_block_delta","index":0,"item_id":"turn-1-thinking-0","delta":{"type":"thinking_delta","thinking":"checking "}}`,
+		`{"type":"content_block_delta","index":0,"item_id":"turn-1-thinking-0","delta":{"type":"thinking_delta","thinking":"the auth flow"}}`,
+	} {
+		params, err := json.Marshal(map[string]any{
+			"session_id": "claude-1", "turn_id": "turn-1", "stream": "stream_event", "text": text,
+		})
+		if err != nil {
+			t.Fatalf("marshal delta: %v", err)
+		}
+		session.HandleEvent(SandboxBridgeEvent{Method: "claude/runtime_output", Params: params}, emit)
+	}
+	if len(events) != 0 {
+		t.Fatalf("thinking deltas must batch before a flush: %#v", events)
+	}
+
+	// A normal assistant record barriers reasoning before it passes through.
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "claude/runtime_output",
+		Params: json.RawMessage(`{"session_id":"claude-1","turn_id":"turn-1","stream":"assistant","text":"{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"ready\"}]}}"}`),
+	}, emit)
+
+	if len(events) != 2 || len(kinds) != 2 {
+		t.Fatalf("events = %#v kinds = %#v", events, kinds)
+	}
+	for index, kind := range kinds {
+		if kind != task.EventKindRuntimeOutput {
+			t.Fatalf("kind[%d] = %q", index, kind)
+		}
+	}
+	batched := events[0]
+	if batched["provider_item_id"] != "turn-1-thinking-0" || batched["stream"] != "stream_event" {
+		t.Fatalf("batched thinking payload = %#v", batched)
+	}
+	batchedText, _ := batched["text"].(string)
+	var record map[string]any
+	if err := json.Unmarshal([]byte(batchedText), &record); err != nil {
+		t.Fatalf("batched thinking text is not JSON: %q", batchedText)
+	}
+	delta, _ := record["delta"].(map[string]any)
+	if record["item_id"] != "turn-1-thinking-0" || delta["thinking"] != "checking the auth flow" {
+		t.Fatalf("batched thinking record = %#v", record)
+	}
+	if events[1]["stream"] != "assistant" {
+		t.Fatalf("assistant event order = %#v", events)
+	}
+
+	// A provider terminal event closes a delta-only segment with one completed
+	// replacement, so the UI does not retain a stale streaming status.
+	session.HandleEvent(SandboxBridgeEvent{
+		Method: "claude/turn/completed",
+		Params: json.RawMessage(`{"request_id":"turn-1","session_id":"claude-1","turn_id":"turn-1","status":"completed"}`),
+	}, emit)
+	var completed task.EventPayload
+	for _, event := range events {
+		if event["phase"] == "completed" && event["provider_item_id"] == "turn-1-thinking-0" {
+			completed = event
+			break
+		}
+	}
+	if completed == nil {
+		t.Fatalf("missing completed reasoning replacement: %#v", events)
 	}
 }
 

--- a/internal/runtime/provider_bridge_adapter.go
+++ b/internal/runtime/provider_bridge_adapter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"pentest/internal/adapters"
 	"pentest/internal/task"
 )
 
@@ -71,10 +72,13 @@ func (a *ProviderSessionRunAdapter) Run(ctx context.Context, goal string, emit f
 	if a.session == nil {
 		return fmt.Errorf("provider session is required")
 	}
+	safeEmit := func(kind task.EventKind, payload task.EventPayload) {
+		emit(kind, task.EventPayload(adapters.Redact(map[string]any(payload))))
+	}
 	a.mu.Lock()
 	continuation := a.continuation
 	selection := a.initialTurn
-	a.emit = emit
+	a.emit = safeEmit
 	a.mu.Unlock()
 	if continuation == "" {
 		return fmt.Errorf("provider session continuation is required")
@@ -88,7 +92,7 @@ func (a *ProviderSessionRunAdapter) Run(ctx context.Context, goal string, emit f
 		Model:                    selection.Model,
 		RequestedReasoningEffort: selection.RequestedReasoningEffort,
 	}
-	_, err := a.session.SendTurn(ctx, request, emit)
+	_, err := a.session.SendTurn(ctx, request, safeEmit)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/reasoning_batcher.go
+++ b/internal/runtime/reasoning_batcher.go
@@ -1,0 +1,219 @@
+package runtime
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"pentest/internal/adapters"
+	"pentest/internal/task"
+)
+
+// reasoningBatchWindow coalesces streaming reasoning deltas before they become
+// durable Task Events. Live-tail polling cannot render finer granularity, so
+// tighter batches only grow the event store without changing what the
+// operator sees.
+const reasoningBatchWindow = 300 * time.Millisecond
+
+type reasoningRuntimeOutput struct {
+	ProviderEvent string
+	SessionID     string
+	TurnID        string
+	ItemID        string
+	Stream        string
+	Phase         string
+	Text          string
+}
+
+// emitReasoningRuntimeOutput is the single provider-session boundary for a
+// Runtime Reasoning Entry. It applies the normal shape-based redaction before
+// forwarding the bounded correlation payload to the Harness or daemon sink.
+func (s *providerSessionAdapter) emitReasoningRuntimeOutput(emit ProviderSessionEmit, output reasoningRuntimeOutput) {
+	if s == nil || output.Text == "" {
+		return
+	}
+	if emit == nil {
+		s.mu.Lock()
+		emit = s.eventSink
+		s.mu.Unlock()
+	}
+	if emit == nil {
+		return
+	}
+	payload := task.EventPayload{
+		"provider": s.provider, "provider_event": output.ProviderEvent,
+		"session_id": output.SessionID, "provider_turn_id": output.TurnID,
+		"provider_item_id": output.ItemID, "phase": output.Phase,
+		"stream": output.Stream, "text": output.Text,
+	}
+	emit(task.EventKindRuntimeOutput, task.EventPayload(adapters.Redact(map[string]any(payload))))
+}
+
+// reasoningDeltaBatcher accumulates reasoning deltas for one streaming segment
+// and emits the full cumulative text after the batch window. Every emission
+// carries the whole text so far, so transcript projections replace one stable
+// entry in place instead of appending fragments. A flush also fires when any
+// other event must pass (Barrier), which keeps durable event order equal to
+// wire order.
+type reasoningDeltaBatcher struct {
+	window   time.Duration
+	schedule func(delay time.Duration, fn func())
+
+	mu         sync.Mutex
+	key        string
+	base       string
+	text       strings.Builder
+	flush      func(text string)
+	timerSet   bool
+	generation uint64
+}
+
+func newReasoningDeltaBatcher(window time.Duration) *reasoningDeltaBatcher {
+	return &reasoningDeltaBatcher{
+		window: window,
+		schedule: func(delay time.Duration, fn func()) {
+			time.AfterFunc(delay, fn)
+		},
+	}
+}
+
+// Add accumulates one reasoning delta for the segment identified by key. A
+// pending segment for a different key flushes first so durable order follows
+// wire order. The flush callback receives the full cumulative segment text,
+// including text already flushed for the same key, so transcript projections
+// can replace one stable entry in place.
+func (b *reasoningDeltaBatcher) Add(key string, flush func(text string), delta string) {
+	if b == nil || key == "" || delta == "" {
+		return
+	}
+	b.mu.Lock()
+	if b.key != "" && b.key != key {
+		var text string
+		var flushFn func(string)
+		if b.text.Len() > 0 {
+			text, flushFn = b.emitTextLocked()
+		}
+		b.mu.Unlock()
+		if flushFn != nil {
+			flushFn(text)
+		}
+		b.mu.Lock()
+		// The old segment ended; the new key starts fresh. A fully flushed old
+		// base is not emitted again during the key transition.
+		b.key = ""
+		b.base = ""
+		b.flush = nil
+		b.timerSet = false
+	}
+	if b.key == "" {
+		b.key = key
+		b.text.Reset()
+	}
+	// Refresh the callback because a later Add can carry a newer direct emit
+	// target even when the segment key stays the same.
+	b.flush = flush
+	if !b.timerSet {
+		b.timerSet = true
+		b.generation++
+		generation := b.generation
+		b.schedule(b.window, func() { b.flushGeneration(generation) })
+	}
+	b.text.WriteString(delta)
+	b.mu.Unlock()
+}
+
+// Barrier flushes any pending reasoning segment immediately. Adapters call it
+// before forwarding a non-reasoning event so reasoning never lands after the
+// work it preceded. The segment stays cumulative for later deltas.
+func (b *reasoningDeltaBatcher) Barrier() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	if b.key == "" || b.text.Len() == 0 {
+		b.mu.Unlock()
+		return
+	}
+	text, flushFn := b.emitTextLocked()
+	b.mu.Unlock()
+	flushFn(text)
+}
+
+func (b *reasoningDeltaBatcher) flushGeneration(generation uint64) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	if generation != b.generation || b.key == "" || b.text.Len() == 0 {
+		b.mu.Unlock()
+		return
+	}
+	text, flushFn := b.emitTextLocked()
+	b.mu.Unlock()
+	flushFn(text)
+}
+
+// Flush emits any pending segment immediately. Tests and explicit lifecycle
+// boundaries use it; scheduled callbacks use flushGeneration so stale timers
+// cannot flush a later segment.
+func (b *reasoningDeltaBatcher) Flush() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	if b.key == "" || b.text.Len() == 0 {
+		b.mu.Unlock()
+		return
+	}
+	text, flushFn := b.emitTextLocked()
+	b.mu.Unlock()
+	flushFn(text)
+}
+
+// Complete returns the full cumulative segment and clears its lifecycle state.
+// Adapters use it when a provider turn ends without a separate completed
+// reasoning item, so the final projection replaces `streaming` with
+// `collapsed` instead of leaving a stale live entry.
+func (b *reasoningDeltaBatcher) Complete() (string, string, bool) {
+	if b == nil {
+		return "", "", false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.key == "" {
+		return "", "", false
+	}
+	key := b.key
+	text := b.base + b.text.String()
+	b.resetLocked()
+	return key, text, text != ""
+}
+
+// Reset clears one completed segment after the provider supplied its own full
+// reasoning item.
+func (b *reasoningDeltaBatcher) Reset() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.resetLocked()
+	b.mu.Unlock()
+}
+
+// emitTextLocked joins the committed base with the pending text, remembers
+// the combined text as the new base, and clears the pending state.
+func (b *reasoningDeltaBatcher) emitTextLocked() (string, func(string)) {
+	text := b.base + b.text.String()
+	b.base = text
+	b.text.Reset()
+	b.timerSet = false
+	return text, b.flush
+}
+
+func (b *reasoningDeltaBatcher) resetLocked() {
+	b.key = ""
+	b.base = ""
+	b.text.Reset()
+	b.flush = nil
+	b.timerSet = false
+}

--- a/internal/runtime/reasoning_batcher_test.go
+++ b/internal/runtime/reasoning_batcher_test.go
@@ -1,0 +1,136 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"pentest/internal/runtimeplugin"
+	"pentest/internal/task"
+)
+
+func TestReasoningDeltaBatcherAccumulatesWithinWindow(t *testing.T) {
+	var fired []func()
+	batcher := newReasoningDeltaBatcher(300 * time.Millisecond)
+	batcher.schedule = func(delay time.Duration, fn func()) {
+		if delay != 300*time.Millisecond {
+			t.Fatalf("schedule delay = %v", delay)
+		}
+		fired = append(fired, fn)
+	}
+
+	var flushed []string
+	batcher.Add("seg-1", func(text string) { flushed = append(flushed, text) }, "alpha ")
+	batcher.Add("seg-1", func(text string) { flushed = append(flushed, text) }, "beta")
+	if len(flushed) != 0 {
+		t.Fatalf("deltas must not flush inside the window: %#v", flushed)
+	}
+	if len(fired) != 1 {
+		t.Fatalf("expected one scheduled flush, got %d", len(fired))
+	}
+
+	// The window callback flushes the cumulative text once.
+	fired[0]()
+	if len(flushed) != 1 || flushed[0] != "alpha beta" {
+		t.Fatalf("window flush = %#v", flushed)
+	}
+	fired[0]() // A stale timer must not re-emit.
+	if len(flushed) != 1 {
+		t.Fatalf("stale timer re-flushed: %#v", flushed)
+	}
+
+	// Deltas arriving after an earlier flush stay cumulative for the same
+	// segment: later flushes carry the whole text, not just the new tail.
+	batcher.Add("seg-1", func(text string) { flushed = append(flushed, text) }, "gamma")
+	if len(fired) != 2 {
+		t.Fatalf("expected a second scheduled flush, got %d", len(fired))
+	}
+	fired[1]()
+	if len(flushed) != 2 || flushed[1] != "alpha betagamma" {
+		t.Fatalf("post-flush accumulation = %#v", flushed)
+	}
+}
+
+func TestReasoningDeltaBatcherIgnoresStaleTimerFromCompletedSegment(t *testing.T) {
+	var fired []func()
+	batcher := newReasoningDeltaBatcher(300 * time.Millisecond)
+	batcher.schedule = func(_ time.Duration, fn func()) { fired = append(fired, fn) }
+
+	var flushed []string
+	batcher.Add("seg-a", func(text string) { flushed = append(flushed, "a:"+text) }, "alpha")
+	batcher.Barrier()
+	if len(flushed) != 1 || flushed[0] != "a:alpha" {
+		t.Fatalf("barrier flush = %#v", flushed)
+	}
+	batcher.Add("seg-b", func(text string) { flushed = append(flushed, "b:"+text) }, "beta")
+	if len(fired) != 2 {
+		t.Fatalf("scheduled callbacks = %d", len(fired))
+	}
+
+	// The old Segment A callback must not flush Segment B before its own window.
+	fired[0]()
+	if len(flushed) != 1 {
+		t.Fatalf("stale timer flushed the new segment: %#v", flushed)
+	}
+	fired[1]()
+	if len(flushed) != 2 || flushed[1] != "b:beta" {
+		t.Fatalf("current timer flush = %#v", flushed)
+	}
+}
+
+func TestReasoningEmitterShapeRedactsRawContent(t *testing.T) {
+	adapter := newProviderSessionAdapter("claude_code", &fakeProviderTransport{}, "session-1", "turn-1", runtimeplugin.Capabilities{}, providerWireMethods{})
+	var payload task.EventPayload
+	adapter.emitReasoningRuntimeOutput(func(_ task.EventKind, got task.EventPayload) { payload = got }, reasoningRuntimeOutput{
+		ProviderEvent: "claude/runtime_output",
+		SessionID:     "session-1",
+		TurnID:        "turn-1",
+		ItemID:        "reasoning-1",
+		Stream:        "stream_event",
+		Phase:         "streaming",
+		Text:          `{"delta":{"thinking":"bearer secret-runtime-token-123456"}}`,
+	})
+	text, _ := payload["text"].(string)
+	if strings.Contains(text, "secret-runtime-token-123456") || !strings.Contains(text, "bearer [REDACTED]") {
+		t.Fatalf("reasoning emitter did not redact content: %#v", payload)
+	}
+}
+
+func TestReasoningDeltaBatcherBarrierFlushesBeforeOtherEvents(t *testing.T) {
+	batcher := newReasoningDeltaBatcher(300 * time.Millisecond)
+	batcher.schedule = func(time.Duration, func()) {}
+
+	var order []string
+	batcher.Add("seg-1", func(text string) { order = append(order, "reasoning:"+text) }, "thought one ")
+	batcher.Add("seg-1", func(text string) { order = append(order, "reasoning:"+text) }, "thought two")
+
+	// A different segment key flushes the previous segment first.
+	batcher.Add("seg-2", func(text string) { order = append(order, "reasoning:"+text) }, "next")
+	if len(order) != 1 || order[0] != "reasoning:thought one thought two" {
+		t.Fatalf("segment switch flush = %#v", order)
+	}
+
+	batcher.Barrier()
+	if len(order) != 2 || order[1] != "reasoning:next" {
+		t.Fatalf("barrier flush = %#v", order)
+	}
+	batcher.Barrier() // Empty barrier is a no-op.
+	if len(order) != 2 {
+		t.Fatalf("empty barrier emitted: %#v", order)
+	}
+	batcher.Flush() // Flush on an empty batcher is a no-op.
+	if len(order) != 2 {
+		t.Fatalf("empty flush emitted: %#v", order)
+	}
+
+	// Starting a new key after the old key was fully flushed must not re-emit
+	// the old cumulative base.
+	batcher.Add("seg-3", func(text string) { order = append(order, "reasoning:"+text) }, "fresh")
+	if len(order) != 2 {
+		t.Fatalf("new key re-emitted old base: %#v", order)
+	}
+	batcher.Barrier()
+	if strings.Join(order, "|") != "reasoning:thought one thought two|reasoning:next|reasoning:fresh" {
+		t.Fatalf("order = %#v", order)
+	}
+}

--- a/internal/runtimeoutput/coalesce.go
+++ b/internal/runtimeoutput/coalesce.go
@@ -2,7 +2,7 @@ package runtimeoutput
 
 import "strings"
 
-// CoalesceStreaming merges adjacent thinking or text turns split by flush timing.
+// CoalesceStreaming merges adjacent reasoning or text turns split by flush timing.
 func CoalesceStreaming(turns []Turn) []Turn {
 	if len(turns) == 0 {
 		return turns
@@ -20,6 +20,7 @@ func CoalesceStreaming(turns []Turn) []Turn {
 				SourceSeq:      turn.SourceSeq,
 				ProviderItemID: prev.ProviderItemID,
 				LifecyclePhase: turn.LifecyclePhase,
+				Incremental:    turn.Incremental,
 				Kind:           prev.Kind,
 				Role:           prev.Role,
 				Text:           prev.Text + turn.Text,
@@ -44,7 +45,7 @@ func ReconcileLifecycle(turns []Turn) []Turn {
 	out := make([]Turn, 0, len(turns))
 	toolUses := map[string]int{}
 	toolResults := map[string]int{}
-	thinking := map[string]int{}
+	reasoning := map[string]int{}
 	for _, turn := range turns {
 		switch turn.Kind {
 		case KindToolUse:
@@ -63,13 +64,13 @@ func ReconcileLifecycle(turns []Turn) []Turn {
 				}
 				toolResults[key] = len(out)
 			}
-		case KindThinking:
+		case KindReasoning:
 			if key := strings.TrimSpace(turn.ProviderItemID); key != "" {
-				if index, ok := thinking[key]; ok {
+				if index, ok := reasoning[key]; ok {
 					out[index] = mergeLifecycleTurn(out[index], turn)
 					continue
 				}
-				thinking[key] = len(out)
+				reasoning[key] = len(out)
 			}
 		}
 		out = append(out, turn)
@@ -78,6 +79,9 @@ func ReconcileLifecycle(turns []Turn) []Turn {
 }
 
 func mergeLifecycleTurn(previous, next Turn) Turn {
+	if next.Incremental {
+		next.Text = previous.Text + next.Text
+	}
 	if previous.SourceID != "" {
 		next.SourceID = previous.SourceID
 	}
@@ -108,5 +112,5 @@ func mergeLifecycleTurn(previous, next Turn) Turn {
 }
 
 func canMergeStreamingText(prev, next Turn) bool {
-	return (prev.Kind == KindThinking || prev.Kind == KindText) && prev.Kind == next.Kind
+	return (prev.Kind == KindReasoning || prev.Kind == KindText) && prev.Kind == next.Kind
 }

--- a/internal/runtimeoutput/ignore.go
+++ b/internal/runtimeoutput/ignore.go
@@ -44,7 +44,22 @@ func ShouldIgnoreForTimeline(text string) bool {
 }
 
 func isIgnorableStorageRecord(record map[string]any) bool {
-	return isIgnorableSystemRecord(record) || isIgnorableRecordType(record) || isThinkingOnlyAssistantRecord(record)
+	return isIgnorableSystemRecord(record) || isIgnorableRecordType(record) || isNonReasoningStreamEvent(record)
+}
+
+func isNonReasoningStreamEvent(record map[string]any) bool {
+	if !strings.EqualFold(stringValue(record, "type"), "stream_event") {
+		return false
+	}
+	event, ok := mapValue(record, "event")
+	if !ok || !strings.EqualFold(stringValue(event, "type"), "content_block_delta") {
+		return true
+	}
+	delta, ok := mapValue(event, "delta")
+	if !ok {
+		return true
+	}
+	return !strings.EqualFold(stringValue(delta, "type"), "thinking_delta")
 }
 
 func isIgnorableRecordType(record map[string]any) bool {

--- a/internal/runtimeoutput/parity_test.go
+++ b/internal/runtimeoutput/parity_test.go
@@ -37,7 +37,7 @@ func timelineSteps(items []timeline.Item) []semanticStep {
 	out := make([]semanticStep, 0, len(items))
 	for _, item := range items {
 		switch item.Type {
-		case "thinking":
+		case "reasoning":
 			continue
 		case "text":
 			out = append(out, semanticStep{kind: "text", text: item.Content})

--- a/internal/runtimeoutput/parse.go
+++ b/internal/runtimeoutput/parse.go
@@ -2,6 +2,7 @@ package runtimeoutput
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -40,6 +41,23 @@ func ParseRecord(record map[string]any, opts ParseOptions, createdAt time.Time) 
 // ParseRecordWithMeta projects one provider JSON object with its durable
 // lifecycle metadata into normalized turns.
 func ParseRecordWithMeta(record map[string]any, meta RecordMeta, opts ParseOptions, createdAt time.Time) []Turn {
+	if strings.EqualFold(stringValue(record, "type"), "stream_event") {
+		if event, ok := mapValue(record, "event"); ok {
+			nested := make(map[string]any, len(event)+1)
+			for key, value := range event {
+				nested[key] = value
+			}
+			if delta, ok := mapValue(event, "delta"); ok && firstText(delta, "thinking", "reasoning", "reasoning_content") != "" {
+				nested["incremental"] = true
+				if messageID := firstText(record, "uuid", "message_id", "messageId", "id"); messageID != "" {
+					if index, ok := numberValue(event, "index"); ok {
+						nested["item_id"] = messageID + "-reasoning-" + strconv.Itoa(index)
+					}
+				}
+			}
+			return ParseRecordWithMeta(nested, meta, opts, createdAt)
+		}
+	}
 	if turns := parseHermesACPRecord(record, opts, createdAt); len(turns) > 0 || isHermesACPRecord(record) {
 		return turns
 	}
@@ -51,6 +69,17 @@ func ParseRecordWithMeta(record map[string]any, meta RecordMeta, opts ParseOptio
 	if delta, ok := mapValue(record, "delta"); ok {
 		if text := firstText(delta, "text", "content"); text != "" {
 			return []Turn{{Kind: KindText, Role: roleAssistant, Text: text, ContentIndex: -1, CreatedAt: createdAt}}
+		}
+		// Streaming reasoning deltas carry a synthesized provider item id so
+		// every batched projection replaces one stable transcript row.
+		if opts.IncludeThinking {
+			if text := firstText(delta, "thinking", "reasoning", "reasoning_content"); text != "" {
+				phase := firstText(record, "phase")
+				if phase == "" {
+					phase = ReasoningPhaseStreaming
+				}
+				return []Turn{{Kind: KindReasoning, Role: roleAssistant, Text: text, ProviderItemID: firstText(record, "item_id", "itemId", "provider_item_id"), LifecyclePhase: phase, Incremental: isTruthy(record["incremental"]), ContentIndex: -1, CreatedAt: createdAt}}
+			}
 		}
 	}
 
@@ -109,19 +138,37 @@ func parseMessageRecord(record map[string]any, opts ParseOptions, role string, c
 			}
 		}
 		if content, ok := sliceValue(message, "content"); ok {
-			return parseContentBlocks(content, opts, role, createdAt)
+			turns := parseContentBlocks(content, opts, role, createdAt)
+			messageID := firstText(record, "uuid", "message_id", "messageId", "id")
+			if messageID == "" {
+				messageID = firstText(message, "uuid", "message_id", "messageId", "id")
+			}
+			return assignReasoningBlockIDs(turns, messageID)
 		}
 		if text := firstText(message, "text", "content", "message"); text != "" {
 			return []Turn{{Kind: KindText, Role: role, Text: text, ContentIndex: -1, CreatedAt: createdAt}}
 		}
 	}
 	if content, ok := sliceValue(record, "content"); ok {
-		return parseContentBlocks(content, opts, role, createdAt)
+		return assignReasoningBlockIDs(parseContentBlocks(content, opts, role, createdAt), firstText(record, "uuid", "message_id", "messageId", "id"))
 	}
 	if text := firstText(record, "text", "content", "message"); text != "" {
 		return []Turn{{Kind: KindText, Role: role, Text: text, ContentIndex: -1, CreatedAt: createdAt}}
 	}
 	return nil
+}
+
+func assignReasoningBlockIDs(turns []Turn, messageID string) []Turn {
+	if messageID == "" {
+		return turns
+	}
+	for index := range turns {
+		if turns[index].Kind == KindReasoning && turns[index].ProviderItemID == "" {
+			turns[index].ProviderItemID = messageID + "-reasoning-" + strconv.Itoa(turns[index].ContentIndex)
+			turns[index].LifecyclePhase = ReasoningPhaseCompleted
+		}
+	}
+	return turns
 }
 
 func parseContentBlocks(content []any, opts ParseOptions, role string, createdAt time.Time) []Turn {
@@ -135,12 +182,12 @@ func parseContentBlocks(content []any, opts ParseOptions, role string, createdAt
 		case map[string]any:
 			blockType := strings.ToLower(stringValue(value, "type"))
 			switch blockType {
-			case "thinking":
+			case "thinking", "reasoning":
 				if !opts.IncludeThinking {
 					continue
 				}
 				if text := thinkingText(value); text != "" {
-					turns = append(turns, Turn{Kind: KindThinking, Role: role, Text: text, ContentIndex: index, CreatedAt: createdAt})
+					turns = append(turns, Turn{Kind: KindReasoning, Role: role, Text: text, ProviderItemID: firstText(value, "id", "item_id", "itemId"), ContentIndex: index, CreatedAt: createdAt})
 				}
 			case "text":
 				if text := firstText(value, "text", "content"); text != "" {
@@ -247,14 +294,14 @@ func parseCodexReasoning(record map[string]any, meta RecordMeta, opts ParseOptio
 	if phase == "started" {
 		return nil
 	}
-	text := firstText(record, "summary")
+	text := firstText(record, "content", "summary")
 	if text == "" {
 		return nil
 	}
 	return []Turn{{
 		ProviderItemID: id,
 		LifecyclePhase: phase,
-		Kind:           KindThinking,
+		Kind:           KindReasoning,
 		Role:           roleAssistant,
 		Text:           text,
 		ContentIndex:   -1,
@@ -267,7 +314,9 @@ func codexLifecyclePhase(providerEvent string) string {
 	case "item/started":
 		return "started"
 	case "item/completed":
-		return "completed"
+		return ReasoningPhaseCompleted
+	case "item/reasoning/summarytextdelta":
+		return ReasoningPhaseStreaming
 	default:
 		return ""
 	}
@@ -318,7 +367,7 @@ func toolResultTurn(record map[string]any, createdAt time.Time) Turn {
 }
 
 func thinkingText(record map[string]any) string {
-	return firstText(record, "thinking", "text", "content")
+	return firstText(record, "thinking", "reasoning", "text", "content")
 }
 
 const (
@@ -404,6 +453,23 @@ func mapValue(record map[string]any, key string) (map[string]any, bool) {
 	return typed, ok
 }
 
+func numberValue(record map[string]any, key string) (int, bool) {
+	value, ok := record[key]
+	if !ok {
+		return 0, false
+	}
+	switch typed := value.(type) {
+	case float64:
+		return int(typed), true
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
 func sliceValue(record map[string]any, key string) ([]any, bool) {
 	value, ok := record[key]
 	if !ok {
@@ -462,9 +528,16 @@ func parseHermesACPRecord(record map[string]any, opts ParseOptions, createdAt ti
 		}
 		turnKind := KindText
 		if kind == "agent_thought_chunk" {
-			turnKind = KindThinking
+			turnKind = KindReasoning
 		}
-		return []Turn{{Kind: turnKind, Role: roleAssistant, Text: text, ContentIndex: -1, CreatedAt: createdAt}}
+		phase := ""
+		if kind == "agent_thought_chunk" {
+			phase = firstText(update, "phase")
+			if phase == "" {
+				phase = ReasoningPhaseStreaming
+			}
+		}
+		return []Turn{{Kind: turnKind, Role: roleAssistant, Text: text, ProviderItemID: firstText(update, "item_id", "itemId", "provider_item_id"), LifecyclePhase: phase, ContentIndex: -1, CreatedAt: createdAt}}
 	case "tool_call":
 		turn := toolUseTurn(update, createdAt)
 		if turn.Tool == "" {

--- a/internal/runtimeoutput/parse_test.go
+++ b/internal/runtimeoutput/parse_test.go
@@ -1,7 +1,6 @@
 package runtimeoutput_test
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +15,9 @@ func TestShouldIgnoreForStorageDropsThinkingTokensAndTaskProgress(t *testing.T) 
 		{`{"type":"system","subtype":"thinking_tokens","estimated_tokens":13}`, true},
 		{`{"type":"system","subtype":"task_progress","description":"Exploit"}`, true},
 		{`{"type":"assistant","message":{"content":[{"type":"text","text":"Visible."}]}}`, false},
-		{`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan"}]}}`, true},
+		// Reasoning is durable transcript content: thinking-only assistant
+		// frames are stored and projected, never dropped.
+		{`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan"}]}}`, false},
 	}
 	for _, tc := range cases {
 		if got := runtimeoutput.ShouldIgnoreForStorage(tc.line); got != tc.ignore {
@@ -27,11 +28,172 @@ func TestShouldIgnoreForStorageDropsThinkingTokensAndTaskProgress(t *testing.T) 
 
 func TestShouldIgnoreForTimelineAllowsThinkingOnlyAssistant(t *testing.T) {
 	line := `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan recon"}]}}`
-	if !runtimeoutput.ShouldIgnoreForStorage(line) {
-		t.Fatal("storage should ignore thinking-only assistant")
+	if runtimeoutput.ShouldIgnoreForStorage(line) {
+		t.Fatal("storage must keep thinking-only assistant frames")
 	}
 	if runtimeoutput.ShouldIgnoreForTimeline(line) {
 		t.Fatal("timeline projection should keep thinking-only assistant")
+	}
+}
+
+func TestParseRecordProjectsReasoningKindForThinkingBlocks(t *testing.T) {
+	record := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{map[string]any{"type": "thinking", "thinking": "plan the recon"}},
+		},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	if len(turns) != 1 {
+		t.Fatalf("expected 1 turn, got %#v", turns)
+	}
+	if turns[0].Kind != runtimeoutput.KindReasoning {
+		t.Fatalf("kind = %q, want %q", turns[0].Kind, runtimeoutput.KindReasoning)
+	}
+	if string(turns[0].Kind) != "reasoning" {
+		t.Fatalf("wire kind = %q, want reasoning", turns[0].Kind)
+	}
+	if turns[0].Text != "plan the recon" {
+		t.Fatalf("text = %q", turns[0].Text)
+	}
+}
+
+func TestParseRecordPiReasoningBlock(t *testing.T) {
+	record := map[string]any{
+		"type": "message",
+		"message": map[string]any{
+			"role": "assistant",
+			"content": []any{
+				map[string]any{"type": "reasoning", "id": "msg-1-think-0", "reasoning": "enumerate endpoints first"},
+				map[string]any{"type": "text", "text": "Starting scan."},
+			},
+		},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	if len(turns) != 2 {
+		t.Fatalf("expected 2 turns, got %#v", turns)
+	}
+	if turns[0].Kind != runtimeoutput.KindReasoning || turns[0].Text != "enumerate endpoints first" {
+		t.Fatalf("reasoning turn = %#v", turns[0])
+	}
+	if turns[0].ProviderItemID != "msg-1-think-0" {
+		t.Fatalf("provider item id = %q, want msg-1-think-0", turns[0].ProviderItemID)
+	}
+	if turns[1].Kind != runtimeoutput.KindText || turns[1].Text != "Starting scan." {
+		t.Fatalf("text turn = %#v", turns[1])
+	}
+	if disabled := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{}, time.Time{}); len(disabled) != 1 || disabled[0].Kind != runtimeoutput.KindText {
+		t.Fatalf("IncludeThinking=false must hide reasoning, got %#v", disabled)
+	}
+}
+
+func TestParseRecordThinkingDeltaCarriesProviderItemID(t *testing.T) {
+	record := map[string]any{
+		"type":    "content_block_delta",
+		"index":   float64(0),
+		"item_id": "t1-thinking-0",
+		"delta":   map[string]any{"type": "thinking_delta", "thinking": "partial thought"},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	if len(turns) != 1 {
+		t.Fatalf("expected 1 turn, got %#v", turns)
+	}
+	if turns[0].Kind != runtimeoutput.KindReasoning || turns[0].Text != "partial thought" {
+		t.Fatalf("delta turn = %#v", turns[0])
+	}
+	if turns[0].ProviderItemID != "t1-thinking-0" || turns[0].LifecyclePhase != "streaming" {
+		t.Fatalf("delta identity/lifecycle = %#v", turns[0])
+	}
+	if disabled := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{}, time.Time{}); len(disabled) != 0 {
+		t.Fatalf("IncludeThinking=false must hide thinking deltas, got %#v", disabled)
+	}
+}
+
+func TestStorageKeepsOnlyReasoningClaudeCLIStreamEvents(t *testing.T) {
+	thinking := `{"type":"stream_event","uuid":"message-1","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"checking"}}}`
+	text := `{"type":"stream_event","uuid":"message-1","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"visible later"}}}`
+	start := `{"type":"stream_event","uuid":"message-1","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}}`
+	if runtimeoutput.ShouldIgnoreForStorage(thinking) {
+		t.Fatal("thinking delta must remain durable")
+	}
+	if !runtimeoutput.ShouldIgnoreForStorage(text) || !runtimeoutput.ShouldIgnoreForStorage(start) {
+		t.Fatal("non-reasoning partial events must not become raw transcript fallback")
+	}
+}
+
+func TestParseRecordClaudeCLIStreamEventReasoningDelta(t *testing.T) {
+	record := map[string]any{
+		"type": "stream_event",
+		"uuid": "claude-message-1",
+		"event": map[string]any{
+			"type":  "content_block_delta",
+			"index": float64(0),
+			"delta": map[string]any{"type": "thinking_delta", "thinking": "checking auth"},
+		},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	if len(turns) != 1 || turns[0].Kind != runtimeoutput.KindReasoning || turns[0].Text != "checking auth" {
+		t.Fatalf("Claude CLI stream event = %#v", turns)
+	}
+	if turns[0].ProviderItemID != "claude-message-1-reasoning-0" || turns[0].LifecyclePhase != "streaming" {
+		t.Fatalf("Claude CLI stream identity/lifecycle = %#v", turns[0])
+	}
+}
+
+func TestReconcileClaudeCLIIncrementalReasoningDeltas(t *testing.T) {
+	parse := func(text string) []runtimeoutput.Turn {
+		return runtimeoutput.ParseRecord(map[string]any{
+			"type": "stream_event",
+			"uuid": "claude-message-1",
+			"event": map[string]any{
+				"type":  "content_block_delta",
+				"index": float64(0),
+				"delta": map[string]any{"type": "thinking_delta", "thinking": text},
+			},
+		}, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	}
+	turns := runtimeoutput.ReconcileLifecycle(append(parse("checking "), parse("auth")...))
+	if len(turns) != 1 || turns[0].Text != "checking auth" {
+		t.Fatalf("incremental reasoning reconciliation = %#v", turns)
+	}
+}
+
+func TestParseRecordClaudeCLICompletedReasoningUsesSameStableItem(t *testing.T) {
+	record := map[string]any{
+		"type": "assistant",
+		"uuid": "claude-message-1",
+		"message": map[string]any{
+			"role":    "assistant",
+			"content": []any{map[string]any{"type": "thinking", "thinking": "checking auth"}},
+		},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	if len(turns) != 1 || turns[0].ProviderItemID != "claude-message-1-reasoning-0" {
+		t.Fatalf("completed reasoning identity = %#v", turns)
+	}
+}
+
+func TestParseRecordHermesThoughtChunkProjectsReasoning(t *testing.T) {
+	record := map[string]any{
+		"method": "session/update",
+		"params": map[string]any{
+			"sessionId": "hermes-session",
+			"update": map[string]any{
+				"sessionUpdate": "agent_thought_chunk",
+				"text":          "considering the auth flow",
+				"item_id":       "hermes-thought-turn-1",
+			},
+		},
+	}
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeThinking: true}, time.Time{})
+	if len(turns) != 1 {
+		t.Fatalf("expected 1 turn, got %#v", turns)
+	}
+	if turns[0].Kind != runtimeoutput.KindReasoning || turns[0].Text != "considering the auth flow" {
+		t.Fatalf("thought turn = %#v", turns[0])
+	}
+	if turns[0].ProviderItemID != "hermes-thought-turn-1" {
+		t.Fatalf("provider item id = %q", turns[0].ProviderItemID)
 	}
 }
 
@@ -144,7 +306,7 @@ func TestParseRecordCodexAppServerItems(t *testing.T) {
 			"type":    "reasoning",
 			"id":      "item-reasoning",
 			"summary": []any{},
-			"content": []any{"SECRET_RAW_REASONING"},
+			"content": []any{"raw chain of thought"},
 		},
 	}, runtimeoutput.RecordMeta{ProviderEvent: "item/started"}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, at)
 	reasoningCompleted := runtimeoutput.ParseRecordWithMeta(map[string]any{
@@ -152,18 +314,31 @@ func TestParseRecordCodexAppServerItems(t *testing.T) {
 			"type":    "reasoning",
 			"id":      "item-reasoning",
 			"summary": []any{"Checked the target.", "Prepared the command."},
-			"content": []any{"SECRET_RAW_REASONING"},
+			"content": []any{"raw chain of thought"},
 		},
 	}, runtimeoutput.RecordMeta{ProviderEvent: "item/completed"}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, at.Add(time.Second))
 	if len(reasoningStarted) != 0 {
-		t.Fatalf("started reasoning should stay hidden without a summary: %#v", reasoningStarted)
+		t.Fatalf("started reasoning should stay hidden until completion: %#v", reasoningStarted)
 	}
+	// Raw reasoning content is durable transcript content. It is preferred over
+	// the provider summary because third-party model summaries are not the real
+	// thinking; the summary remains the fallback when no content exists.
 	reasoning := runtimeoutput.ReconcileLifecycle(reasoningCompleted)
-	if len(reasoning) != 1 || reasoning[0].Kind != runtimeoutput.KindThinking || reasoning[0].Text != "Checked the target.\nPrepared the command." {
+	if len(reasoning) != 1 || reasoning[0].Kind != runtimeoutput.KindReasoning || reasoning[0].Text != "raw chain of thought" {
 		t.Fatalf("reasoning lifecycle = %#v", reasoning)
 	}
-	if strings.Contains(reasoning[0].Text, "SECRET_RAW_REASONING") {
-		t.Fatalf("reasoning leaked raw content: %#v", reasoning[0])
+	if reasoning[0].ProviderItemID != "item-reasoning" {
+		t.Fatalf("provider item id = %q", reasoning[0].ProviderItemID)
+	}
+	summaryOnly := runtimeoutput.ParseRecordWithMeta(map[string]any{
+		"item": map[string]any{
+			"type":    "reasoning",
+			"id":      "item-reasoning-2",
+			"summary": []any{"Checked the target.", "Prepared the command."},
+		},
+	}, runtimeoutput.RecordMeta{ProviderEvent: "item/completed"}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, at.Add(time.Second))
+	if len(summaryOnly) != 1 || summaryOnly[0].Kind != runtimeoutput.KindReasoning || summaryOnly[0].Text != "Checked the target.\nPrepared the command." {
+		t.Fatalf("summary-fallback reasoning = %#v", summaryOnly)
 	}
 	if empty := runtimeoutput.ParseRecordWithMeta(map[string]any{
 		"item": map[string]any{"type": "reasoning", "id": "empty", "summary": []any{}},
@@ -185,10 +360,10 @@ func TestParseLinePlainTextFallback(t *testing.T) {
 	}
 }
 
-func TestCoalesceMergesAdjacentThinking(t *testing.T) {
+func TestCoalesceMergesAdjacentReasoning(t *testing.T) {
 	turns := []runtimeoutput.Turn{
-		{Kind: runtimeoutput.KindThinking, Text: "part one"},
-		{Kind: runtimeoutput.KindThinking, Text: " part two"},
+		{Kind: runtimeoutput.KindReasoning, Text: "part one"},
+		{Kind: runtimeoutput.KindReasoning, Text: " part two"},
 		{Kind: runtimeoutput.KindToolUse, Tool: "Bash"},
 	}
 	got := runtimeoutput.CoalesceStreaming(turns)

--- a/internal/runtimeoutput/turn.go
+++ b/internal/runtimeoutput/turn.go
@@ -6,11 +6,16 @@ import "time"
 type Kind string
 
 const (
-	KindThinking   Kind = "thinking"
+	KindReasoning  Kind = "reasoning"
 	KindText       Kind = "text"
 	KindToolUse    Kind = "tool_use"
 	KindToolResult Kind = "tool_result"
 	KindError      Kind = "error"
+)
+
+const (
+	ReasoningPhaseStreaming = "streaming"
+	ReasoningPhaseCompleted = "completed"
 )
 
 // Turn is one normalized fragment from a provider stdout/stderr JSON line.
@@ -19,6 +24,7 @@ type Turn struct {
 	SourceSeq      int
 	ProviderItemID string
 	LifecyclePhase string
+	Incremental    bool
 	Kind           Kind
 	Role           string
 	Text           string

--- a/internal/runtimeplugin/builtin.go
+++ b/internal/runtimeplugin/builtin.go
@@ -139,6 +139,7 @@ func BuiltinPlugins() []Plugin {
 					"{{mcp_args}}",
 					"-p",
 					"--output-format", "stream-json",
+					"--include-partial-messages",
 					"--verbose",
 					"{{custom_args}}",
 					"{{claude_goal_prefix}}",
@@ -147,6 +148,7 @@ func BuiltinPlugins() []Plugin {
 				SingletonOptions: []SingletonOption{
 					{Options: []string{"-p", "--print"}, Arity: 0},
 					{Options: []string{"--output-format"}, Arity: 1},
+					{Options: []string{"--include-partial-messages"}, Arity: 0},
 					{Options: []string{"--verbose"}, Arity: 0},
 				},
 			},
@@ -161,6 +163,7 @@ func BuiltinPlugins() []Plugin {
 					"{{mcp_args}}",
 					"-p",
 					"--output-format", "stream-json",
+					"--include-partial-messages",
 					"--verbose",
 					"{{custom_args}}",
 					"{{claude_goal_prefix}}",

--- a/internal/runtimeplugin/plugin_test.go
+++ b/internal/runtimeplugin/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"slices"
 	"testing"
 
 	"pentest/internal/runtimeplugin"
@@ -234,6 +235,9 @@ func TestClaudeCodeBuiltinDeclaresNativeResume(t *testing.T) {
 	if !plugin.NativeResume.Supported {
 		t.Fatal("expected claude_code native resume support")
 	}
+	if !slices.Contains(plugin.Launch.Args, "--include-partial-messages") {
+		t.Fatalf("claude launch args must request partial messages: %#v", plugin.Launch.Args)
+	}
 	if plugin.NativeResume.SessionSource != "claude_stream_json" {
 		t.Fatalf("session source = %q, want claude_stream_json", plugin.NativeResume.SessionSource)
 	}
@@ -245,6 +249,7 @@ func TestClaudeCodeBuiltinDeclaresNativeResume(t *testing.T) {
 		"{{mcp_args}}",
 		"-p",
 		"--output-format", "stream-json",
+		"--include-partial-messages",
 		"--verbose",
 		"{{custom_args}}",
 		"{{claude_goal_prefix}}",

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -1,5 +1,5 @@
 // Package timeline projects retained task or session events into a
-// multica-style agent transcript timeline: thinking, tool calls, tool results,
+// multica-style agent transcript timeline: reasoning, tool calls, tool results,
 // agent text, and errors. Both owner kinds feed the same normalization chain
 // (runtimeoutput parse + streaming coalesce) so task and session timelines
 // render identically.
@@ -18,16 +18,18 @@ import (
 // window byte budget; Detail references the owner-authorized endpoint that
 // returns the complete retained item.
 type Item struct {
-	ID        string         `json:"id,omitempty"`
-	Seq       int            `json:"seq"`
-	Type      string         `json:"type"`
-	Tool      string         `json:"tool,omitempty"`
-	Content   string         `json:"content,omitempty"`
-	Input     map[string]any `json:"input,omitempty"`
-	Output    string         `json:"output,omitempty"`
-	CreatedAt time.Time      `json:"created_at"`
-	Truncated bool           `json:"truncated,omitempty"`
-	Detail    string         `json:"detail,omitempty"`
+	ID          string         `json:"id,omitempty"`
+	Seq         int            `json:"seq"`
+	Type        string         `json:"type"`
+	Tool        string         `json:"tool,omitempty"`
+	Content     string         `json:"content,omitempty"`
+	Input       map[string]any `json:"input,omitempty"`
+	Output      string         `json:"output,omitempty"`
+	Status      string         `json:"status,omitempty"`
+	Incremental bool           `json:"incremental,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	Truncated   bool           `json:"truncated,omitempty"`
+	Detail      string         `json:"detail,omitempty"`
 }
 
 // Event is the minimal owner-event surface Build consumes. Task and Session
@@ -77,6 +79,10 @@ func Build(events []Event) []Item {
 			continue
 		case "lifecycle":
 			flushTurns()
+			phase := stringValue(event.Payload, "phase")
+			if phase == "completed" || phase == "failed" || phase == "stopped" {
+				completeStreamingReasoning(items)
+			}
 			if item, ok := lifecycleItem(event); ok {
 				item.ID = event.ID
 				item.Seq = event.Seq
@@ -131,6 +137,14 @@ func Build(events []Event) []Item {
 	}
 	flushTurns()
 	return items
+}
+
+func completeStreamingReasoning(items []Item) {
+	for index := range items {
+		if items[index].Type == "reasoning" && items[index].Status == runtimeoutput.ReasoningPhaseStreaming {
+			items[index].Status = runtimeoutput.ReasoningPhaseCompleted
+		}
+	}
 }
 
 func blackboardConclusionItem(event Event) (Item, bool) {
@@ -253,8 +267,8 @@ func turnToItem(turn runtimeoutput.Turn) (Item, bool) {
 		id = fmt.Sprintf("%s-%s-%d", id, turn.Kind, turn.ContentIndex)
 	}
 	switch turn.Kind {
-	case runtimeoutput.KindThinking:
-		return Item{ID: id, Seq: turn.SourceSeq, Type: "thinking", Content: turn.Text, CreatedAt: turn.CreatedAt}, true
+	case runtimeoutput.KindReasoning:
+		return Item{ID: id, Seq: turn.SourceSeq, Type: "reasoning", Content: turn.Text, Status: turn.LifecyclePhase, Incremental: turn.Incremental, CreatedAt: turn.CreatedAt}, true
 	case runtimeoutput.KindText:
 		return Item{ID: id, Seq: turn.SourceSeq, Type: "text", Content: turn.Text, CreatedAt: turn.CreatedAt}, true
 	case runtimeoutput.KindToolUse:

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/timeline"
 )
 
@@ -27,7 +28,7 @@ func TestBuildParsesThinkingToolUseTextAndResult(t *testing.T) {
 	got := timeline.Build(events)
 
 	requireItem(t, got, 0, "lifecycle", "", "Lifecycle: started")
-	requireItem(t, got, 1, "thinking", "", "plan recon")
+	requireItem(t, got, 1, "reasoning", "", "plan recon")
 	requireItem(t, got, 2, "tool_use", "Bash", "")
 	if got[2].Input["command"] != "curl example.com" {
 		t.Fatalf("unexpected tool input: %#v", got[2].Input)
@@ -65,7 +66,7 @@ func TestBuildReconcilesCodexItemLifecycle(t *testing.T) {
 			toolUses++
 		case "tool_result":
 			toolResults++
-		case "thinking":
+		case "reasoning":
 			thinking++
 			if item.Content != "Checked the target." {
 				t.Fatalf("thinking = %#v", item)
@@ -74,6 +75,34 @@ func TestBuildReconcilesCodexItemLifecycle(t *testing.T) {
 	}
 	if toolUses != 1 || toolResults != 1 || thinking != 1 {
 		t.Fatalf("Timeline lifecycle counts: tool_use=%d tool_result=%d thinking=%d items=%#v", toolUses, toolResults, thinking, got)
+	}
+}
+
+func TestBuildProjectsReasoningLifecycleStatus(t *testing.T) {
+	createdAt := time.Now().UTC()
+	got := timeline.Build([]timeline.Event{
+		{ID: "ev-1", Seq: 1, Kind: "runtime_output", Payload: map[string]any{
+			"provider_event": "item/reasoning/summaryTextDelta",
+			"text":           `{"item":{"type":"reasoning","id":"reasoning-1","summary":["checking"]}}`,
+		}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{
+			"provider_event": "item/completed",
+			"text":           `{"item":{"type":"reasoning","id":"reasoning-1","content":["checking auth"]}}`,
+		}, CreatedAt: createdAt.Add(time.Second)},
+	})
+	if len(got) != 1 || got[0].Type != "reasoning" || got[0].Status != "completed" {
+		t.Fatalf("reasoning lifecycle item = %#v", got)
+	}
+}
+
+func TestBuildCompletesStreamingReasoningAtLifecycleSettlement(t *testing.T) {
+	createdAt := time.Now().UTC()
+	got := timeline.Build([]timeline.Event{
+		{ID: "ev-1", Seq: 1, Kind: "runtime_output", Payload: map[string]any{"text": `{"type":"stream_event","uuid":"claude-message-1","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"checking"}}}`}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "lifecycle", Payload: map[string]any{"phase": "completed"}, CreatedAt: createdAt.Add(time.Second)},
+	})
+	if len(got) < 1 || got[0].Type != "reasoning" || got[0].Status != runtimeoutput.ReasoningPhaseCompleted {
+		t.Fatalf("settled Timeline reasoning = %#v", got)
 	}
 }
 
@@ -109,7 +138,7 @@ func TestBuildCoalescesAdjacentThinkingFragments(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 coalesced thinking item, got %d: %#v", len(got), got)
 	}
-	if got[0].Type != "thinking" || got[0].Content != "part one part two" {
+	if got[0].Type != "reasoning" || got[0].Content != "part one part two" {
 		t.Fatalf("unexpected coalesced thinking: %#v", got[0])
 	}
 }

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	KindMessage       = "message"
-	KindThinking      = "thinking"
+	KindReasoning     = "reasoning"
 	KindToolCall      = "tool_call"
 	KindToolResult    = "tool_result"
 	KindRuntimeOutput = "runtime_output"
@@ -59,6 +59,7 @@ type Entry struct {
 	Details      map[string]any `json:"details,omitempty"`
 	Stream       string         `json:"stream,omitempty"`
 	Status       string         `json:"status,omitempty"`
+	Incremental  bool           `json:"incremental,omitempty"`
 	CreatedAt    time.Time      `json:"created_at"`
 	Truncated    bool           `json:"truncated,omitempty"`
 	Detail       string         `json:"detail,omitempty"`
@@ -113,6 +114,10 @@ func BuildWindow(subject Subject, events []Event, context WindowContext) []Entry
 	adapter := context.Adapter
 	for _, event := range events {
 		if event.Kind == "lifecycle" {
+			phase := stringValue(event.Payload, "phase")
+			if phase == "completed" || phase == "failed" || phase == "stopped" {
+				collapseStreamingReasoning(entries, continuation)
+			}
 			next, ok := lifecycleEntry(event, continuation)
 			if ok {
 				if stringValue(event.Payload, "phase") == "started" {
@@ -131,6 +136,14 @@ func BuildWindow(subject Subject, events []Event, context WindowContext) []Entry
 
 // appendOrCoalesceTranscript joins adjacent assistant message chunks from one
 // Continuation so a streamed sentence is one row, not one row per token.
+func collapseStreamingReasoning(entries []Entry, continuation int) {
+	for index := range entries {
+		if entries[index].Continuation == continuation && entries[index].Kind == KindReasoning && entries[index].Status == runtimeoutput.ReasoningPhaseStreaming {
+			entries[index].Status = StatusCollapsed
+		}
+	}
+}
+
 func appendOrCoalesceTranscript(entries, next []Entry) []Entry {
 	for _, entry := range next {
 		if entry.ID != "" {
@@ -143,6 +156,9 @@ func appendOrCoalesceTranscript(entries, next []Entry) []Entry {
 					entry.Seq = entries[index].Seq
 					entry.Continuation = entries[index].Continuation
 					entry.CreatedAt = entries[index].CreatedAt
+					if entry.Incremental {
+						entry.Text = entries[index].Text + entry.Text
+					}
 					entries[index] = entry
 					replaced = true
 					break
@@ -370,7 +386,7 @@ func parseRuntimeOutput(event Event, continuation int, adapter, text string) ([]
 	}
 	turns := runtimeoutput.ParseRecordWithMeta(record, runtimeoutput.RecordMeta{
 		ProviderEvent: stringValue(event.Payload, "provider_event"),
-	}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, base.CreatedAt)
+	}, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true, IncludeThinking: true}, base.CreatedAt)
 	if len(turns) == 0 {
 		return nil, false
 	}
@@ -396,7 +412,7 @@ func ParserForAdapter(adapter string, registry *runtimeplugin.Registry) string {
 // derived entries inherit. It is exported so runtime tails can reuse the same
 // parsing as the post-hoc transcript builder.
 func ParseRecord(record map[string]any, base Entry) []Entry {
-	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true}, base.CreatedAt)
+	turns := runtimeoutput.ParseRecord(record, runtimeoutput.ParseOptions{IncludeReasoningSummaries: true, IncludeThinking: true}, base.CreatedAt)
 	return turnsToEntries(turns, base)
 }
 
@@ -404,8 +420,8 @@ func turnsToEntries(turns []runtimeoutput.Turn, base Entry) []Entry {
 	entries := make([]Entry, 0, len(turns))
 	for _, turn := range runtimeoutput.ReconcileLifecycle(turns) {
 		switch turn.Kind {
-		case runtimeoutput.KindThinking:
-			entries = append(entries, thinkingEntryFromTurn(turn, base, stableTurnEntryID(turn, base, "thinking")))
+		case runtimeoutput.KindReasoning:
+			entries = append(entries, reasoningEntryFromTurn(turn, base, stableTurnEntryID(turn, base, "reasoning")))
 		case runtimeoutput.KindText:
 			// Provider user records are internal prompt/session frames. Operator
 			// text is projected only from durable conversation or steering Events.
@@ -462,17 +478,25 @@ func messageEntry(base Entry, id, role, text string) Entry {
 	}
 }
 
-func thinkingEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry {
+func reasoningEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry {
 	return Entry{
 		ID:           id,
 		Seq:          base.Seq,
 		Continuation: base.Continuation,
-		Kind:         KindThinking,
+		Kind:         KindReasoning,
 		Role:         RoleAssistant,
 		Text:         turn.Text,
-		Status:       StatusCollapsed,
+		Status:       reasoningEntryStatus(turn),
+		Incremental:  turn.Incremental,
 		CreatedAt:    base.CreatedAt,
 	}
+}
+
+func reasoningEntryStatus(turn runtimeoutput.Turn) string {
+	if turn.LifecyclePhase == runtimeoutput.ReasoningPhaseStreaming {
+		return runtimeoutput.ReasoningPhaseStreaming
+	}
+	return StatusCollapsed
 }
 
 func toolCallEntryFromTurn(turn runtimeoutput.Turn, base Entry, id string) Entry {

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"pentest/internal/runtimeoutput"
 	"pentest/internal/transcript"
 )
 
@@ -137,7 +138,7 @@ func TestBuildReconcilesCodexStartedCompletedAndReasoningItems(t *testing.T) {
 			calls = append(calls, entry)
 		case transcript.KindToolResult:
 			results = append(results, entry)
-		case transcript.KindThinking:
+		case transcript.KindReasoning:
 			thinking = append(thinking, entry)
 		}
 	}
@@ -399,14 +400,14 @@ func TestIsIgnorableRuntimeLineDetectsClaudeInitAndResult(t *testing.T) {
 	}
 }
 
-func TestIsIgnorableRuntimeLineDetectsThinkingOnlyAssistant(t *testing.T) {
+func TestIsIgnorableRuntimeLineKeepsThinkingOnlyAssistant(t *testing.T) {
 	line := `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"planning next step"}]}}`
-	if !transcript.IsIgnorableRuntimeLine(line) {
-		t.Fatal("expected thinking-only assistant line to be ignorable")
+	if transcript.IsIgnorableRuntimeLine(line) {
+		t.Fatal("thinking-only assistant lines are durable transcript content and must not be ignored")
 	}
 }
 
-func TestBuildDropsClaudeInitResultAndThinkingOnlyChunks(t *testing.T) {
+func TestBuildProjectsReasoningEntriesAndDropsClaudeInitResult(t *testing.T) {
 	subject := transcript.Subject{ID: "task-1", Title: "Do work", CreatedAt: time.Now().UTC()}
 	events := []transcript.Event{
 		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "claude_code"}},
@@ -429,6 +430,131 @@ func TestBuildDropsClaudeInitResultAndThinkingOnlyChunks(t *testing.T) {
 		t.Fatalf("unexpected tool call: %#v", call)
 	}
 	requireEntry(t, got, "ev-6-message-0", "message", "assistant", "Done.")
+	thinking := requireEntry(t, got, "ev-3-reasoning-0", "reasoning", "assistant", "only thoughts")
+	if thinking.Status != transcript.StatusCollapsed {
+		t.Fatalf("reasoning entry should be collapsed: %#v", thinking)
+	}
+}
+
+func TestBuildStreamsCodexReasoningDeltasIntoOneGrowingEntry(t *testing.T) {
+	createdAt := time.Date(2026, 8, 26, 9, 0, 0, 0, time.UTC)
+	subject := transcript.Subject{ID: "session-1", Title: "Inspect", CreatedAt: createdAt}
+	events := []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "provider-session:thread-1"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/reasoning/summaryTextDelta", "stream": "codex_app_server",
+			"text": `{"item":{"type":"reasoning","id":"item-reasoning","summary":["Checked"]}}`,
+		}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/reasoning/summaryTextDelta", "stream": "codex_app_server",
+			"text": `{"item":{"type":"reasoning","id":"item-reasoning","summary":["Checked the target."]}}`,
+		}, CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "ev-4", Seq: 4, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/started", "stream": "codex_app_server",
+			"text": `{"item":{"type":"commandExecution","id":"item-cmd","command":"curl example.com","status":"inProgress"}}`,
+		}, CreatedAt: createdAt.Add(3 * time.Second)},
+		{ID: "ev-5", Seq: 5, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "codex", "provider_event": "item/completed", "stream": "codex_app_server",
+			"text": `{"item":{"type":"reasoning","id":"item-reasoning","summary":["Checked the target.","Prepared the command."]}}`,
+		}, CreatedAt: createdAt.Add(4 * time.Second)},
+	}
+
+	got := transcript.Build(subject, events)
+
+	stableID := "continuation-1-" + runtimeoutput.StableProviderItemID("item-reasoning", "reasoning")
+	var reasoningEntries []transcript.Entry
+	reasoningIndex := -1
+	toolIndex := -1
+	for index, entry := range got {
+		if entry.Kind == transcript.KindReasoning {
+			reasoningEntries = append(reasoningEntries, entry)
+			reasoningIndex = index
+		}
+		if entry.Kind == transcript.KindToolCall && entry.ToolName == "command_execution" {
+			toolIndex = index
+		}
+	}
+	if len(reasoningEntries) != 1 {
+		t.Fatalf("streamed reasoning must be one growing entry, got %d: %#v", len(reasoningEntries), reasoningEntries)
+	}
+	entry := reasoningEntries[0]
+	if entry.ID != stableID {
+		t.Fatalf("reasoning id = %q, want %q", entry.ID, stableID)
+	}
+	if entry.Seq != 2 {
+		t.Fatalf("reasoning seq = %d, want 2 (first projection position)", entry.Seq)
+	}
+	if entry.Text != "Checked the target.\nPrepared the command." || entry.Status != transcript.StatusCollapsed {
+		t.Fatalf("completed reasoning = text=%q status=%q", entry.Text, entry.Status)
+	}
+	if reasoningIndex == -1 || toolIndex == -1 || reasoningIndex > toolIndex {
+		t.Fatalf("reasoning must interleave before its tool call: reasoning=%d tool=%d", reasoningIndex, toolIndex)
+	}
+}
+
+func TestBuildJoinsClaudeCLIIncrementalThinkingDeltas(t *testing.T) {
+	createdAt := time.Now().UTC()
+	got := transcript.Build(transcript.Subject{ID: "task-1", Title: "Do work", CreatedAt: createdAt}, []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "claude_code"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{"text": `{"type":"stream_event","uuid":"claude-message-1","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"checking "}}}`}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: "runtime_output", Payload: map[string]any{"text": `{"type":"stream_event","uuid":"claude-message-1","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"auth"}}}`}, CreatedAt: createdAt.Add(2 * time.Second)},
+	})
+	var reasoning []transcript.Entry
+	for _, entry := range got {
+		if entry.Kind == transcript.KindReasoning {
+			reasoning = append(reasoning, entry)
+		}
+	}
+	if len(reasoning) != 1 || reasoning[0].Text != "checking auth" || !reasoning[0].Incremental {
+		t.Fatalf("incremental Claude CLI reasoning = %#v", reasoning)
+	}
+}
+
+func TestBuildStreamsClaudeThinkingDeltasIntoOneGrowingEntry(t *testing.T) {
+	createdAt := time.Now().UTC()
+	subject := transcript.Subject{ID: "task-1", Title: "Do work", CreatedAt: createdAt}
+	events := []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "claude_code"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "claude", "provider_event": "claude/runtime_output", "stream": "stream_event",
+			"text": `{"type":"content_block_delta","index":0,"item_id":"t1-thinking-0","delta":{"type":"thinking_delta","thinking":"partial"}}`,
+		}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: "runtime_output", Payload: map[string]any{
+			"provider": "claude", "provider_event": "claude/runtime_output", "stream": "stream_event",
+			"text": `{"type":"content_block_delta","index":0,"item_id":"t1-thinking-0","delta":{"type":"thinking_delta","thinking":"partial thought"}}`,
+		}, CreatedAt: createdAt.Add(2 * time.Second)},
+	}
+
+	got := transcript.Build(subject, events)
+
+	stableID := "continuation-1-" + runtimeoutput.StableProviderItemID("t1-thinking-0", "reasoning")
+	var reasoningEntries []transcript.Entry
+	for _, entry := range got {
+		if entry.Kind == transcript.KindReasoning {
+			reasoningEntries = append(reasoningEntries, entry)
+		}
+	}
+	if len(reasoningEntries) != 1 {
+		t.Fatalf("streamed thinking must be one growing entry, got %d: %#v", len(reasoningEntries), reasoningEntries)
+	}
+	entry := reasoningEntries[0]
+	if entry.ID != stableID || entry.Seq != 2 || entry.Text != "partial thought" || entry.Status != "streaming" {
+		t.Fatalf("growing entry = id=%q seq=%d text=%q status=%q", entry.ID, entry.Seq, entry.Text, entry.Status)
+	}
+}
+
+func TestBuildCollapsesStreamingReasoningAtContinuationSettlement(t *testing.T) {
+	createdAt := time.Now().UTC()
+	got := transcript.Build(transcript.Subject{ID: "task-1", Title: "Do work", CreatedAt: createdAt}, []transcript.Event{
+		{ID: "ev-1", Seq: 1, Kind: "lifecycle", Payload: map[string]any{"phase": "started", "adapter": "claude_code"}, CreatedAt: createdAt},
+		{ID: "ev-2", Seq: 2, Kind: "runtime_output", Payload: map[string]any{"text": `{"type":"stream_event","uuid":"claude-message-1","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"checking auth"}}}`}, CreatedAt: createdAt.Add(time.Second)},
+		{ID: "ev-3", Seq: 3, Kind: "lifecycle", Payload: map[string]any{"phase": "completed"}, CreatedAt: createdAt.Add(2 * time.Second)},
+	})
+	for _, entry := range got {
+		if entry.Kind == transcript.KindReasoning && entry.Status != transcript.StatusCollapsed {
+			t.Fatalf("settled reasoning remained live: %#v", entry)
+		}
+	}
 }
 
 func TestBuildFallsBackForUnknownJSONRuntimeOutput(t *testing.T) {

--- a/web/src/components/task-transcript/AgentTranscriptView.test.tsx
+++ b/web/src/components/task-transcript/AgentTranscriptView.test.tsx
@@ -64,6 +64,24 @@ describe("AgentTranscriptView", () => {
     expect(eventRows.map((row) => row.textContent)).toEqual(["Newer timeline event", "Older timeline event"]);
   });
 
+  it("auto-expands live reasoning and collapses it at settlement", () => {
+    const { rerender } = render(
+      <AgentTranscriptView
+        owner={{ ...owner, status: "running" }}
+        items={[{ id: "reasoning-1", seq: 1, type: "reasoning", status: "streaming", content: "checking auth" }]}
+      />,
+    );
+    expect(screen.getByTestId("timeline-event-detail")).toHaveTextContent("checking auth");
+
+    rerender(
+      <AgentTranscriptView
+        owner={{ ...owner, status: "running" }}
+        items={[{ id: "reasoning-1", seq: 2, type: "reasoning", status: "completed", content: "checked auth" }]}
+      />,
+    );
+    expect(screen.queryByTestId("timeline-event-detail")).not.toBeInTheDocument();
+  });
+
   it("labels timeline segment buttons and gives rows a content-visibility boundary", () => {
     render(
       <AgentTranscriptView

--- a/web/src/components/task-transcript/AgentTranscriptView.tsx
+++ b/web/src/components/task-transcript/AgentTranscriptView.tsx
@@ -381,7 +381,7 @@ export function AgentTranscriptView({ owner, items, profileName, isLive = false,
             )}
             {visibleItems.map((item, visibleIndex) => (
               <TranscriptEventRow
-                key={item.id ?? `${item.seq}-${visibleIndex}`}
+                key={`${item.id ?? `${item.seq}-${visibleIndex}`}-${item.type === "reasoning" ? item.status ?? "" : ""}`}
                 ref={(el) => {
                   if (el) eventRefs.current.set(item.seq, el);
                   else eventRefs.current.delete(item.seq);
@@ -558,7 +558,7 @@ function TranscriptEventRow({
   item: TimelineItem;
   isSelected: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(item.type === "reasoning" && item.status === "streaming");
   const color = getEventColor(item);
   const label = getEventLabel(item);
   const summary = getEventSummary(item);
@@ -567,7 +567,7 @@ function TranscriptEventRow({
   const hasDetail =
     (item.type === "tool_use" && item.input && Object.keys(item.input).length > 0) ||
     (item.type === "tool_result" && item.output && item.output.length > 0) ||
-    (item.type === "thinking" && item.content && item.content.length > 0) ||
+    (item.type === "reasoning" && item.content && item.content.length > 0) ||
     (item.type === "text" && item.content && item.content.length > 0) ||
     (item.type === "harness" && item.content && item.content.length > 0) ||
     (item.type === "error" && item.content && item.content.length > 0);
@@ -588,7 +588,7 @@ function TranscriptEventRow({
             colorClasses[color].label,
           )}
         >
-          {item.type === "thinking" && <Brain className="mr-1 h-3 w-3 shrink-0" />}
+          {item.type === "reasoning" && <Brain className="mr-1 h-3 w-3 shrink-0" />}
           {item.type === "error" && <AlertCircle className="mr-1 h-3 w-3 shrink-0" />}
           {label}
         </span>
@@ -629,7 +629,7 @@ function TranscriptEventRow({
       </div>
 
       {hasDetail && expanded && (
-        <div className="px-4 pb-3">
+        <div data-testid="timeline-event-detail" className="px-4 pb-3">
           <div className="ml-[72px] border-l-2 border-border/60">
             <EventDetailContent item={item} />
           </div>
@@ -659,7 +659,7 @@ function EventDetailContent({ item }: { item: TimelineItem }) {
         </pre>
       );
     }
-    case "thinking":
+    case "reasoning":
     case "text":
     case "harness":
       return (

--- a/web/src/components/task-transcript/timeline-utils.test.ts
+++ b/web/src/components/task-transcript/timeline-utils.test.ts
@@ -4,7 +4,7 @@ import type { TimelineItem } from "./types";
 
 describe("timeline-utils", () => {
   it("maps item types to timeline color roles", () => {
-    expect(getEventColor({ seq: 1, type: "thinking" })).toBe("thinking");
+    expect(getEventColor({ seq: 1, type: "reasoning" })).toBe("reasoning");
     expect(getEventColor({ seq: 2, type: "tool_use", tool: "Bash" })).toBe("tool");
     expect(getEventColor({ seq: 3, type: "text", content: "hi" })).toBe("agent");
   });

--- a/web/src/components/task-transcript/timeline-utils.ts
+++ b/web/src/components/task-transcript/timeline-utils.ts
@@ -4,8 +4,8 @@ export function getEventColor(item: TimelineItem): EventColor {
   switch (item.type) {
     case "text":
       return "agent";
-    case "thinking":
-      return "thinking";
+    case "reasoning":
+      return "reasoning";
     case "tool_use":
       return "tool";
     case "tool_result":
@@ -23,7 +23,7 @@ export function getEventColor(item: TimelineItem): EventColor {
 
 export const colorClasses: Record<EventColor, { bg: string; bgActive: string; label: string }> = {
   agent: { bg: "bg-emerald-400/60", bgActive: "bg-emerald-500", label: "bg-emerald-500/20 text-emerald-700 dark:text-emerald-300" },
-  thinking: { bg: "bg-violet-400/60", bgActive: "bg-violet-500", label: "bg-violet-500/20 text-violet-700 dark:text-violet-300" },
+  reasoning: { bg: "bg-violet-400/60", bgActive: "bg-violet-500", label: "bg-violet-500/20 text-violet-700 dark:text-violet-300" },
   tool: { bg: "bg-blue-400/60", bgActive: "bg-blue-500", label: "bg-blue-500/20 text-blue-700 dark:text-blue-300" },
   result: { bg: "bg-slate-300/60 dark:bg-slate-600/60", bgActive: "bg-slate-400 dark:bg-slate-500", label: "bg-muted text-muted-foreground" },
   error: { bg: "bg-red-400/60", bgActive: "bg-red-500", label: "bg-red-500/20 text-red-700 dark:text-red-300" },
@@ -33,8 +33,8 @@ export function getEventLabel(item: TimelineItem): string {
   switch (item.type) {
     case "text":
       return "Agent";
-    case "thinking":
-      return "Thinking";
+    case "reasoning":
+      return "Reasoning";
     case "tool_use":
       return item.tool ?? "Tool";
     case "tool_result":
@@ -71,7 +71,7 @@ export function getEventSummary(item: TimelineItem): string {
   switch (item.type) {
     case "text":
       return item.content?.split("\n").find((line) => line.trim().length > 0) ?? "";
-    case "thinking":
+    case "reasoning":
       return item.content?.slice(0, 200) ?? "";
     case "tool_use": {
       if (!item.input) return "";

--- a/web/src/components/task-transcript/types.ts
+++ b/web/src/components/task-transcript/types.ts
@@ -1,4 +1,4 @@
-export type TimelineItemType = "tool_use" | "tool_result" | "thinking" | "text" | "error" | "lifecycle" | "steering" | "harness";
+export type TimelineItemType = "tool_use" | "tool_result" | "reasoning" | "text" | "error" | "lifecycle" | "steering" | "harness";
 
 export interface TimelineItem {
   id?: string;
@@ -8,9 +8,11 @@ export interface TimelineItem {
   content?: string;
   input?: Record<string, unknown>;
   output?: string;
+  status?: string;
+  incremental?: boolean;
   created_at?: string;
 }
 
 export type TranscriptSortDirection = "chronological" | "newest_first";
 
-export type EventColor = "agent" | "thinking" | "tool" | "result" | "error";
+export type EventColor = "agent" | "reasoning" | "tool" | "result" | "error";

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -738,7 +738,7 @@ export interface TaskTranscriptEntry {
   id: string;
   seq: number;
   continuation: number;
-  kind: "message" | "tool_call" | "tool_result" | "runtime_output" | "continuation" | string;
+  kind: "message" | "reasoning" | "tool_call" | "tool_result" | "runtime_output" | "continuation" | string;
   role: "user" | "assistant" | "system" | "runtime" | "tool" | string;
   text?: string;
   tool_call_id?: string;
@@ -746,6 +746,7 @@ export interface TaskTranscriptEntry {
   details?: Record<string, unknown>;
   stream?: string;
   status?: string;
+  incremental?: boolean;
   created_at: string;
   /** True when this row is a bounded preview of an oversized entry. */
   truncated?: boolean;
@@ -766,11 +767,13 @@ export interface TaskTimelineItem {
   /** Stable item identity. Several items can share one source Event Seq. */
   id?: string;
   seq: number;
-  type: "tool_use" | "tool_result" | "thinking" | "text" | "error" | "lifecycle" | "steering" | "harness";
+  type: "tool_use" | "tool_result" | "reasoning" | "text" | "error" | "lifecycle" | "steering" | "harness";
   tool?: string;
   content?: string;
   input?: Record<string, unknown>;
   output?: string;
+  status?: string;
+  incremental?: boolean;
   created_at?: string;
   /** True when this item is a bounded preview of an oversized item. */
   truncated?: boolean;

--- a/web/src/lib/ownerEvents.test.ts
+++ b/web/src/lib/ownerEvents.test.ts
@@ -39,6 +39,20 @@ describe("mergeTimelineItems", () => {
     expect(merged.map((item) => item.seq)).toEqual([2, 3]);
   });
 
+  it("updates a growing reasoning item with the same stable id in place", () => {
+    const existing: TaskTimelineItem[] = [
+      { id: "reasoning-1", seq: 2, type: "reasoning", content: "checking", created_at: "2026-01-01T00:00:00Z" },
+      identifiedTimelineItem("tool-1", 3),
+    ];
+    const delta: TaskTimelineItem[] = [
+      { id: "reasoning-1", seq: 4, type: "reasoning", content: "checking the auth flow", created_at: "2026-01-01T00:00:01Z" },
+    ];
+    const merged = mergeTimelineItems(existing, delta);
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({ id: "reasoning-1", seq: 4, content: "checking the auth flow", created_at: "2026-01-01T00:00:00Z" });
+    expect(merged[1]?.id).toBe("tool-1");
+  });
+
   it("keeps distinct Timeline items that share one source Event seq", () => {
     const existing = [identifiedTimelineItem("event-1-text", 1)];
     const delta = [identifiedTimelineItem("event-2-thinking", 2), identifiedTimelineItem("event-2-tool", 2)];
@@ -71,6 +85,30 @@ describe("mergeTranscriptEntries", () => {
     expect(merged.map((entry) => entry.id)).toEqual(["a", "b"]);
   });
 
+  it("appends incremental reasoning text for the same stable id", () => {
+    const existing: TaskTranscriptEntry[] = [
+      { id: "reasoning-cli", seq: 2, continuation: 1, kind: "reasoning", role: "assistant", text: "checking ", status: "streaming", incremental: true, created_at: "2026-01-01T00:00:00Z" },
+    ];
+    const delta: TaskTranscriptEntry[] = [
+      { id: "reasoning-cli", seq: 3, continuation: 1, kind: "reasoning", role: "assistant", text: "auth", status: "streaming", incremental: true, created_at: "2026-01-01T00:00:01Z" },
+    ];
+    expect(mergeTranscriptEntries(existing, delta)[0]).toMatchObject({ text: "checking auth", seq: 3 });
+  });
+
+  it("updates a growing reasoning entry with the same stable id in place", () => {
+    const existing: TaskTranscriptEntry[] = [
+      { id: "reasoning-1", seq: 2, continuation: 1, kind: "reasoning", role: "assistant", text: "checking", created_at: "2026-01-01T00:00:00Z" },
+      transcriptEntry("tool-1", 3),
+    ];
+    const delta: TaskTranscriptEntry[] = [
+      { id: "reasoning-1", seq: 4, continuation: 1, kind: "reasoning", role: "assistant", text: "checking the auth flow", created_at: "2026-01-01T00:00:01Z" },
+    ];
+    const merged = mergeTranscriptEntries(existing, delta);
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({ id: "reasoning-1", seq: 4, text: "checking the auth flow", created_at: "2026-01-01T00:00:00Z" });
+    expect(merged[1]?.id).toBe("tool-1");
+  });
+
   it("joins later Hermes ACP assistant chunks onto the previous sentence", () => {
     const existing = [{ ...transcriptEntry("ev-5-message", 5), text: "Hi", stream: "hermes_acp" }];
     const delta = [
@@ -81,6 +119,16 @@ describe("mergeTranscriptEntries", () => {
     const merged = mergeTranscriptEntries(existing, delta);
     expect(merged).toHaveLength(1);
     expect(merged[0]).toMatchObject({ id: "ev-5-message", seq: 8, text: "Hi! 👋" });
+  });
+
+  it("appends incremental reasoning content for the same Timeline id", () => {
+    const existing: TaskTimelineItem[] = [
+      { id: "reasoning-cli", seq: 2, type: "reasoning", content: "checking ", status: "streaming", incremental: true },
+    ];
+    const delta: TaskTimelineItem[] = [
+      { id: "reasoning-cli", seq: 3, type: "reasoning", content: "auth", status: "streaming", incremental: true },
+    ];
+    expect(mergeTimelineItems(existing, delta)[0]).toMatchObject({ content: "checking auth", seq: 3 });
   });
 
   it("keeps complete adjacent assistant messages as separate rows", () => {

--- a/web/src/lib/ownerEvents.ts
+++ b/web/src/lib/ownerEvents.ts
@@ -13,39 +13,86 @@ export interface ProjectionDelta<T> {
   cursor: number;
 }
 
-/** mergeTimelineItems appends an ordered timeline delta without duplicates. */
+/** mergeTimelineItems appends new items and updates growing stable items in place. */
 export function mergeTimelineItems(existing: TaskTimelineItem[], delta: TaskTimelineItem[]): TaskTimelineItem[] {
   if (existing.length === 0) return delta;
   if (delta.length === 0) return existing;
-  // A refresh only ever returns items strictly after the committed cursor.
-  // Drop stale overlap (Seq <= existing max) and in-delta duplicates alike.
   const maxSeq = Math.max(...existing.map((item) => item.seq));
+  const updated = [...existing];
+  const existingByIdentity = new Map(updated.map((item, index) => [timelineItemIdentity(item), index]));
   const appended: TaskTimelineItem[] = [];
-  const seen = new Set(existing.map(timelineItemIdentity));
+  const appendedByIdentity = new Map<string, number>();
+  let changed = false;
+
   for (const item of delta) {
     const identity = timelineItemIdentity(item);
-    if (item.seq <= maxSeq || seen.has(identity)) continue;
-    seen.add(identity);
+    const existingIndex = existingByIdentity.get(identity);
+    if (existingIndex !== undefined) {
+      if (item.seq > updated[existingIndex]!.seq) {
+        // Keep the item at its first visible position while replacing its
+        // cumulative reasoning text and latest Seq.
+        const previous = updated[existingIndex]!;
+        updated[existingIndex] = {
+          ...item,
+          content: item.incremental ? `${previous.content ?? ""}${item.content ?? ""}` : item.content,
+          created_at: previous.created_at ?? item.created_at,
+        };
+        changed = true;
+      }
+      continue;
+    }
+    const appendedIndex = appendedByIdentity.get(identity);
+    if (appendedIndex !== undefined) {
+      if (item.seq > appended[appendedIndex]!.seq) appended[appendedIndex] = item;
+      continue;
+    }
+    if (item.seq <= maxSeq) continue;
+    appendedByIdentity.set(identity, appended.length);
     appended.push(item);
   }
-  if (appended.length === 0) return existing;
-  return [...existing, ...appended];
+  if (!changed && appended.length === 0) return existing;
+  return [...updated, ...appended];
 }
 
-/** mergeTranscriptEntries appends an ordered transcript delta without duplicates. */
+/** mergeTranscriptEntries appends new rows and updates growing stable rows in place. */
 export function mergeTranscriptEntries(existing: TaskTranscriptEntry[], delta: TaskTranscriptEntry[]): TaskTranscriptEntry[] {
   if (existing.length === 0) return coalesceAssistantChunks(delta);
   if (delta.length === 0) return existing;
   const maxSeq = Math.max(...existing.map((entry) => entry.seq));
+  const updated = [...existing];
+  const existingByID = new Map(updated.map((entry, index) => [entry.id, index]));
   const appended: TaskTranscriptEntry[] = [];
-  const seen = new Set<string>();
+  const appendedByID = new Map<string, number>();
+  let changed = false;
+
   for (const entry of delta) {
-    if (entry.seq <= maxSeq || seen.has(entry.id)) continue;
-    seen.add(entry.id);
+    const existingIndex = existingByID.get(entry.id);
+    if (existingIndex !== undefined) {
+      if (entry.seq > updated[existingIndex]!.seq) {
+        // A cumulative reasoning batch or completed provider item replaces the
+        // same stable row without changing its visible list position.
+        const previous = updated[existingIndex]!;
+        updated[existingIndex] = {
+          ...entry,
+          continuation: previous.continuation,
+          text: entry.incremental ? `${previous.text ?? ""}${entry.text ?? ""}` : entry.text,
+          created_at: previous.created_at ?? entry.created_at,
+        };
+        changed = true;
+      }
+      continue;
+    }
+    const appendedIndex = appendedByID.get(entry.id);
+    if (appendedIndex !== undefined) {
+      if (entry.seq > appended[appendedIndex]!.seq) appended[appendedIndex] = entry;
+      continue;
+    }
+    if (entry.seq <= maxSeq) continue;
+    appendedByID.set(entry.id, appended.length);
     appended.push(entry);
   }
-  if (appended.length === 0) return existing;
-  return appendCoalescedTranscript(existing, appended);
+  if (!changed && appended.length === 0) return existing;
+  return appendCoalescedTranscript(updated, appended);
 }
 
 function appendCoalescedTranscript(existing: TaskTranscriptEntry[], delta: TaskTranscriptEntry[]): TaskTranscriptEntry[] {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -497,13 +497,13 @@ describe("TaskDetailPage", () => {
     expect(resultBody?.textContent).not.toContain("tool_call_id: call-1");
   });
 
-  it("renders reasoning as collapsed activity instead of an agent message", async () => {
+  it("renders completed reasoning as collapsed activity instead of an agent message", async () => {
     stubTaskDetailApi({}, [
       {
-        id: "thinking-1",
+        id: "reasoning-1",
         seq: 6,
         continuation: 1,
-        kind: "thinking",
+        kind: "reasoning",
         role: "assistant",
         text: "Checked the active challenge and prepared the next command.",
         created_at: "2026-08-26T09:00:01Z",
@@ -513,12 +513,46 @@ describe("TaskDetailPage", () => {
     renderPage();
 
     expect(await screen.findByText("Reasoning")).toBeInTheDocument();
-    const row = screen.getByTestId("transcript-thinking-row");
+    const row = screen.getByTestId("transcript-reasoning-row");
     expect(row).not.toHaveAttribute("open");
     expect(screen.getByText("Checked the active challenge and prepared the next command.")).toBeInTheDocument();
     expect(screen.queryByTestId("transcript-message-bubble")).not.toBeInTheDocument();
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("You")).not.toBeInTheDocument();
+  });
+
+  it("auto-expands the latest reasoning entry while the Runtime Turn is busy", async () => {
+    stubTaskDetailApi({
+      status: "running",
+      runtime_activity: { liveness: "live", turn_activity: "busy" },
+    }, [
+      {
+        id: "reasoning-old",
+        seq: 4,
+        continuation: 1,
+        kind: "reasoning",
+        role: "assistant",
+        text: "Older reasoning.",
+        created_at: "2026-08-26T09:00:00Z",
+      },
+      {
+        id: "reasoning-live",
+        seq: 6,
+        continuation: 1,
+        kind: "reasoning",
+        role: "assistant",
+        text: "Checking the auth flow.",
+        status: "streaming",
+        created_at: "2026-08-26T09:00:01Z",
+      },
+    ]);
+
+    renderPage();
+
+    const rows = await screen.findAllByTestId("transcript-reasoning-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).not.toHaveAttribute("open");
+    expect(rows[1]).toHaveAttribute("open");
   });
 
   it("keeps agent messages and tool rows tight, only spacing out new user turns", async () => {

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -1037,6 +1037,10 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
               <TranscriptList
                 entries={history.transcript.slice(transcriptWindow.startIndex, transcriptWindow.endIndex)}
                 endRef={conversationEnd}
+                liveReasoningID={liveReasoningEntryID(
+                  history.transcript,
+                  owner.runtimeActivity?.liveness === "live" && owner.runtimeActivity.turn_activity === "busy",
+                )}
               />
               {transcriptWindow.spacerAfter > 0 && (
                 <div aria-hidden="true" data-testid="transcript-spacer-after" style={{ height: transcriptWindow.spacerAfter }} />
@@ -1629,7 +1633,25 @@ function BlackboardConclusionRecovery({
   );
 }
 
-function TranscriptList({ entries, endRef }: { entries: TaskTranscriptEntry[]; endRef: RefObject<HTMLDivElement | null> }) {
+function liveReasoningEntryID(entries: TaskTranscriptEntry[], runtimeBusy: boolean): string | undefined {
+  if (!runtimeBusy || entries.length === 0) return undefined;
+  const maxSeq = Math.max(...entries.map((entry) => entry.seq));
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.kind === "reasoning" && entry.status === "streaming" && entry.seq === maxSeq) return entry.id;
+  }
+  return undefined;
+}
+
+function TranscriptList({
+  entries,
+  endRef,
+  liveReasoningID,
+}: {
+  entries: TaskTranscriptEntry[];
+  endRef: RefObject<HTMLDivElement | null>;
+  liveReasoningID?: string;
+}) {
   return (
     <div>
       {entries.map((entry, index) => {
@@ -1643,7 +1665,7 @@ function TranscriptList({ entries, endRef }: { entries: TaskTranscriptEntry[]; e
             data-testid="transcript-row"
             className={`[contain-intrinsic-size:72px] [content-visibility:auto] ${spacing}`}
           >
-            <TranscriptRow entry={entry} />
+            <TranscriptRow entry={entry} autoExpandReasoning={entry.id === liveReasoningID} />
           </div>
         );
       })}
@@ -1668,7 +1690,7 @@ function isUserTurnStart(entry: TaskTranscriptEntry): boolean {
   return entry.role === "user";
 }
 
-function TranscriptRow({ entry }: { entry: TaskTranscriptEntry }) {
+function TranscriptRow({ entry, autoExpandReasoning = false }: { entry: TaskTranscriptEntry; autoExpandReasoning?: boolean }) {
   if (entry.kind === "continuation") {
     return (
       <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground">
@@ -1687,7 +1709,7 @@ function TranscriptRow({ entry }: { entry: TaskTranscriptEntry }) {
   }
 
   if (isCollapsedTranscriptEntry(entry)) {
-    return <CollapsedTranscriptRow entry={entry} />;
+    return <CollapsedTranscriptRow entry={entry} autoExpand={autoExpandReasoning && entry.kind === "reasoning"} />;
   }
 
   const isUser = entry.role === "user";
@@ -1724,10 +1746,18 @@ function TranscriptRow({ entry }: { entry: TaskTranscriptEntry }) {
   );
 }
 
-function CollapsedTranscriptRow({ entry }: { entry: TaskTranscriptEntry }) {
+function CollapsedTranscriptRow({ entry, autoExpand = false }: { entry: TaskTranscriptEntry; autoExpand?: boolean }) {
+  const [manuallyOpen, setManuallyOpen] = useState(false);
+  const wasAutoExpanded = useRef(false);
+  useEffect(() => {
+    // A live reasoning row opens automatically. When streaming stops, close
+    // it once; completed rows remain manually expandable across later polls.
+    if (wasAutoExpanded.current && !autoExpand) setManuallyOpen(false);
+    wasAutoExpanded.current = autoExpand;
+  }, [autoExpand]);
   const isError = entry.kind === "tool_result" && (entry.details as { is_error?: boolean } | undefined)?.is_error === true;
   const Icon =
-    entry.kind === "thinking"
+    entry.kind === "reasoning"
       ? Brain
       : entry.kind === "runtime_output"
         ? Terminal
@@ -1737,7 +1767,14 @@ function CollapsedTranscriptRow({ entry }: { entry: TaskTranscriptEntry }) {
           : CheckCircle2
         : Wrench;
   return (
-    <details data-testid={entry.kind === "thinking" ? "transcript-thinking-row" : "transcript-tool-row"} className="group border-b border-border/50 last:border-b-0">
+    <details
+      data-testid={entry.kind === "reasoning" ? "transcript-reasoning-row" : "transcript-tool-row"}
+      open={autoExpand || manuallyOpen}
+      onToggle={(event) => {
+        if (!autoExpand) setManuallyOpen(event.currentTarget.open);
+      }}
+      className="group border-b border-border/50 last:border-b-0"
+    >
       <summary className="-mx-1 flex min-h-9 cursor-pointer list-none items-center gap-2 rounded-sm px-1 py-1.5 text-sm transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
         <Icon className={`h-4 w-4 shrink-0 ${isError ? "text-destructive" : "text-muted-foreground"}`} />
@@ -1782,7 +1819,7 @@ function ToolCallDetails({ entry }: { entry: TaskTranscriptEntry }) {
 }
 
 function isCollapsedTranscriptEntry(entry: TaskTranscriptEntry) {
-  return entry.kind === "thinking" || entry.kind === "tool_call" || entry.kind === "tool_result" || entry.kind === "runtime_output";
+  return entry.kind === "reasoning" || entry.kind === "tool_call" || entry.kind === "tool_result" || entry.kind === "runtime_output";
 }
 
 function collapsedBody(entry: TaskTranscriptEntry) {

--- a/web/src/pages/taskDetailView.test.ts
+++ b/web/src/pages/taskDetailView.test.ts
@@ -50,7 +50,7 @@ describe("collapsedTranscriptTitle", () => {
       id: "thinking-1",
       seq: 3,
       continuation: 1,
-      kind: "thinking",
+      kind: "reasoning",
       role: "assistant",
       text: "Checked the target and prepared the command.",
       created_at: "",

--- a/web/src/pages/taskDetailView.ts
+++ b/web/src/pages/taskDetailView.ts
@@ -5,7 +5,7 @@ import type { TaskTranscriptEntry } from "@/lib/api";
 // the client only renders what the server already parsed.
 
 export function collapsedTranscriptTitle(entry: TaskTranscriptEntry): string {
-  if (entry.kind === "thinking") return "Reasoning";
+  if (entry.kind === "reasoning") return "Reasoning";
   if (entry.kind === "tool_call") {
     const toolName = entry.tool_name || "Tool";
     const preview = toolInputPreview(entry);


### PR DESCRIPTION
## Summary

- persist streamed Runtime Reasoning Entries for Claude Code, Codex, Hermes, and Pi
- coalesce reasoning deltas by stable provider item identity while preserving message and Tool ordering
- redact reasoning at provider-session and Pi session-tail persistence boundaries
- project reasoning lifecycle through Transcript, Timeline, owner event updates, and the Runtime Owner Workspace
- auto-expand live reasoning and auto-collapse it when the Runtime Turn settles
- add a workspace file-safety rule for coding agents

## Runtime details

- Claude SDK bridge forwards token-level thinking deltas
- Claude one-shot launch and resume request partial stream messages
- Codex retains raw reasoning content and uses summaries only as fallback
- Hermes assigns stable identity to each thought segment
- Pi projects reasoning from the persistent session JSONL tail
- reasoning batching uses a generation fence so stale timers cannot flush a later segment

## Verification

- `go test -timeout 20m ./cmd/... ./internal/... ./scripts` — 3078 passed
- `go test -race ./internal/runtime ./internal/runtimeoutput ./internal/transcript ./internal/timeline` — 290 passed
- `node --test cmd/pentest-claude-sdk-bridge/bridge.test.mjs` — 24 passed
- `cd web && npm test` — 552 passed
- `cd web && npm run build`
- `cd web && npm run lint`
- `git diff --check`

Closes #241
