### PR TITLE
refactor(ui): apply new design and unify page shells

### DIFF
--- a/web/src/components/AttachmentPicker.tsx
+++ b/web/src/components/AttachmentPicker.tsx
@@ -147,10 +147,10 @@ export function AttachmentPicker({
           <div className="flex min-w-0 items-center gap-2.5 text-xs text-muted-foreground">
             <Paperclip className="h-4 w-4 shrink-0" aria-hidden="true" />
             <span>
-              拖拽文件到这里，或 <span className="font-medium text-foreground underline underline-offset-2">浏览</span> · 最多 {MAX_ATTACHMENT_COUNT} 个文件，每个 {MAX_ATTACHMENT_MB} MB
+              Drag files here, or <span className="font-medium text-foreground underline underline-offset-2">browse</span> · up to {MAX_ATTACHMENT_COUNT} files, {MAX_ATTACHMENT_MB} MB each
             </span>
           </div>
-          <span className="shrink-0 text-[11px] text-muted-foreground">投影到 {ownerLabel} workdir</span>
+          <span className="shrink-0 text-[11px] text-muted-foreground">Projected into the {ownerLabel} workdir</span>
           {fileInput}
         </div>
         {fileList}

--- a/web/src/components/AttachmentPicker.tsx
+++ b/web/src/components/AttachmentPicker.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { Paperclip, UploadCloud, X } from "lucide-react";
 import { Label } from "@/components/ui";
+import { cn } from "@/lib/utils";
 
 const MAX_ATTACHMENT_COUNT = 25;
 const MAX_ATTACHMENT_MB = 100;
@@ -52,12 +53,14 @@ export function AttachmentPicker({
   onFilesChange,
   onError,
   ownerLabel,
+  variant = "default",
 }: {
   id: string;
   files: File[];
   onFilesChange: (files: File[]) => void;
   onError?: (message: string | null) => void;
   ownerLabel: string;
+  variant?: "default" | "compact";
 }) {
   const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -80,6 +83,81 @@ export function AttachmentPicker({
     onFilesChange(next);
   }
 
+  const fileInput = (
+    <input
+      ref={fileInputRef}
+      id={id}
+      type="file"
+      name="attachments"
+      multiple
+      className="hidden"
+      onChange={(event) => {
+        if (event.target.files && event.target.files.length > 0) addFiles(event.target.files);
+        event.target.value = "";
+      }}
+    />
+  );
+  const dropHandlers = {
+    onClick: () => fileInputRef.current?.click(),
+    onKeyDown: (event: React.KeyboardEvent) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        fileInputRef.current?.click();
+      }
+    },
+    onDragOver: (event: React.DragEvent) => {
+      event.preventDefault();
+      setDragOver(true);
+    },
+    onDragLeave: () => setDragOver(false),
+    onDrop: (event: React.DragEvent) => {
+      event.preventDefault();
+      setDragOver(false);
+      if (event.dataTransfer.files.length > 0) addFiles(event.dataTransfer.files);
+    },
+  };
+  const fileList = files.length > 0 && (
+    <ul className="mt-2 space-y-1">
+      {files.map((file, index) => (
+        <li key={`${file.name}-${file.size}`}>
+          <AttachmentFileRow
+            name={file.name}
+            size={file.size}
+            onRemove={() => onFilesChange(files.filter((_, position) => position !== index))}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+
+  if (variant === "compact") {
+    return (
+      <div>
+        <Label htmlFor={id} className="sr-only">Attachments</Label>
+        <div
+          data-testid="attachment-dropzone"
+          role="button"
+          tabIndex={0}
+          {...dropHandlers}
+          className={cn(
+            "flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-dashed px-3.5 py-2.5 transition-colors",
+            dragOver ? "border-primary bg-primary/10" : "border-input bg-muted/30",
+          )}
+        >
+          <div className="flex min-w-0 items-center gap-2.5 text-xs text-muted-foreground">
+            <Paperclip className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span>
+              拖拽文件到这里，或 <span className="font-medium text-foreground underline underline-offset-2">浏览</span> · 最多 {MAX_ATTACHMENT_COUNT} 个文件，每个 {MAX_ATTACHMENT_MB} MB
+            </span>
+          </div>
+          <span className="shrink-0 text-[11px] text-muted-foreground">投影到 {ownerLabel} workdir</span>
+          {fileInput}
+        </div>
+        {fileList}
+      </div>
+    );
+  }
+
   return (
     <div>
       <Label htmlFor={id}>Attachments</Label>
@@ -87,23 +165,7 @@ export function AttachmentPicker({
         data-testid="attachment-dropzone"
         role="button"
         tabIndex={0}
-        onClick={() => fileInputRef.current?.click()}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            fileInputRef.current?.click();
-          }
-        }}
-        onDragOver={(event) => {
-          event.preventDefault();
-          setDragOver(true);
-        }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={(event) => {
-          event.preventDefault();
-          setDragOver(false);
-          if (event.dataTransfer.files.length > 0) addFiles(event.dataTransfer.files);
-        }}
+        {...dropHandlers}
         className={`mt-1 flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-dashed p-4 text-sm transition-colors ${
           dragOver ? "border-primary bg-primary/10" : "border-border bg-background/50"
         }`}
@@ -113,32 +175,9 @@ export function AttachmentPicker({
         <span className="text-xs text-muted-foreground">
           Up to {MAX_ATTACHMENT_COUNT} files, {MAX_ATTACHMENT_MB} MB each. Projected into the {ownerLabel} workdir.
         </span>
-        <input
-          ref={fileInputRef}
-          id={id}
-          type="file"
-          name="attachments"
-          multiple
-          className="hidden"
-          onChange={(event) => {
-            if (event.target.files && event.target.files.length > 0) addFiles(event.target.files);
-            event.target.value = "";
-          }}
-        />
+        {fileInput}
       </div>
-      {files.length > 0 && (
-        <ul className="mt-2 space-y-1">
-          {files.map((file, index) => (
-            <li key={`${file.name}-${file.size}`}>
-              <AttachmentFileRow
-                name={file.name}
-                size={file.size}
-                onRemove={() => onFilesChange(files.filter((_, position) => position !== index))}
-              />
-            </li>
-          ))}
-        </ul>
-      )}
+      {fileList}
     </div>
   );
 }

--- a/web/src/components/ProjectNav.tsx
+++ b/web/src/components/ProjectNav.tsx
@@ -3,7 +3,7 @@ import { NavLink, useParams } from "react-router-dom";
 import { apiGet, type Project } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type NavItem = { to: string; label: string; end?: boolean };
+type NavItem = { to: string; label: string; end?: boolean; count?: number };
 
 /**
  * Project navigation order from the operator IA (read contract §19.1):
@@ -12,14 +12,27 @@ type NavItem = { to: string; label: string; end?: boolean };
 export function ProjectNav() {
   const { projectId } = useParams<{ projectId: string }>();
   const [kind, setKind] = useState<string>("pentest");
+  const [counts, setCounts] = useState<Record<string, number>>({});
 
   useEffect(() => {
     if (!projectId) return;
     let cancelled = false;
     (async () => {
       try {
-        const project = await apiGet<Project>(`/api/projects/${projectId}`);
-        if (!cancelled) setKind(project.kind || "pentest");
+        const [project, dashboard] = await Promise.all([
+          apiGet<Project>(`/api/projects/${projectId}`),
+          // Counts are advisory chrome; a dashboard failure must not break nav.
+          apiGet<{ counts?: { tasks?: number; findings?: number; evidence?: number } }>(
+            `/api/projects/${projectId}/dashboard`,
+          ).catch(() => ({ counts: {} as { tasks?: number; findings?: number; evidence?: number } })),
+        ]);
+        if (cancelled) return;
+        setKind(project.kind || "pentest");
+        setCounts({
+          tasks: dashboard.counts?.tasks ?? 0,
+          findings: dashboard.counts?.findings ?? 0,
+          evidence: dashboard.counts?.evidence ?? 0,
+        });
       } catch {
         if (!cancelled) setKind("pentest");
       }
@@ -29,16 +42,16 @@ export function ProjectNav() {
     };
   }, [projectId]);
 
-  const isCTF = kind === "ctf_challenge";
   const base = `/projects/${projectId}`;
+  const isCTF = kind === "ctf_challenge";
   const links: NavItem[] = [
     { to: "", label: "Overview", end: true },
-    { to: "/tasks", label: "Tasks" },
+    { to: "/tasks", label: "Tasks", count: counts.tasks },
     { to: "/blackboard", label: "Blackboard" },
     isCTF
       ? { to: "/solution", label: "Solution" }
-      : { to: "/findings", label: "Findings" },
-    { to: "/evidence", label: "Evidence" },
+      : { to: "/findings", label: "Findings", count: counts.findings },
+    { to: "/evidence", label: "Evidence", count: counts.evidence },
     ...(!isCTF ? [{ to: "/report", label: "Report" } satisfies NavItem] : []),
     { to: "/scope", label: "Scope" },
   ];
@@ -60,6 +73,9 @@ export function ProjectNav() {
           }
         >
           {link.label}
+          {link.count != null && link.count > 0 && (
+            <span className="ml-1 rounded-sm bg-muted px-1 text-[10px]">{link.count}</span>
+          )}
         </NavLink>
       ))}
     </nav>

--- a/web/src/components/ProjectNav.tsx
+++ b/web/src/components/ProjectNav.tsx
@@ -44,10 +44,7 @@ export function ProjectNav() {
   ];
 
   return (
-    <nav
-      aria-label="Project sections"
-      className="flex w-full gap-1 rounded-lg border border-border bg-card p-1 shadow-sm"
-    >
+    <nav aria-label="Project sections" className="flex w-full flex-wrap gap-1 text-sm">
       {links.map((link) => (
         <NavLink
           key={link.to}
@@ -55,14 +52,14 @@ export function ProjectNav() {
           end={link.end}
           className={({ isActive }) =>
             cn(
-              "min-w-0 flex-1 rounded-md border px-1.5 py-1.5 text-center text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:px-2",
+              "rounded-md px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
               isActive
-                ? "border-signal/30 bg-signal/10 font-medium text-foreground shadow-sm"
-                : "border-transparent text-muted-foreground hover:bg-accent hover:text-foreground",
+                ? "bg-secondary font-medium text-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
             )
           }
         >
-          <span className="block truncate">{link.label}</span>
+          {link.label}
         </NavLink>
       ))}
     </nav>

--- a/web/src/components/ProjectPageShell.test.tsx
+++ b/web/src/components/ProjectPageShell.test.tsx
@@ -23,6 +23,9 @@ describe("ProjectPageShell", () => {
 
     const chrome = screen.getByTestId("project-page-shell-chrome");
     expect(chrome).toHaveClass("sticky", "top-0");
+    expect(chrome).toHaveClass("w-full", "border-b");
+    expect(chrome.parentElement).toHaveClass("min-w-0", "max-w-full");
+    expect(screen.getByTestId("project-page-shell-header").parentElement).toHaveClass("min-w-0", "w-full");
     expect(screen.getByRole("link", { name: /All projects/i })).toHaveAttribute("href", "/");
     const nav = screen.getByRole("navigation", { name: "Project sections" });
     expect(nav).toHaveClass("w-full");
@@ -40,7 +43,7 @@ describe("ProjectPageShell", () => {
       "Report",
       "Scope",
     ]) {
-      expect(screen.getByRole("link", { name: label })).toHaveClass("flex-1", "text-center");
+      expect(screen.getByRole("link", { name: label })).toHaveClass("rounded-md", "px-3");
     }
 
     const chromeText = chrome.textContent ?? "";

--- a/web/src/components/ProjectPageShell.tsx
+++ b/web/src/components/ProjectPageShell.tsx
@@ -57,7 +57,7 @@ export const ProjectPageShell = forwardRef<HTMLDivElement, ProjectPageShellProps
 
         <div
           className={cn(
-            "mx-auto flex w-full max-w-6xl min-w-0 flex-1 flex-col px-6 pb-6 lg:px-8 lg:pb-8",
+            "mx-auto flex w-full max-w-6xl min-w-0 flex-1 flex-col min-h-0 px-6 pb-6 lg:px-8 lg:pb-8",
             hideChrome && "max-w-none p-0 lg:p-0",
             contentClassName,
           )}

--- a/web/src/components/ProjectPageShell.tsx
+++ b/web/src/components/ProjectPageShell.tsx
@@ -10,6 +10,7 @@ export type ProjectPageShellProps = {
   children?: ReactNode;
   className?: string;
   bodyClassName?: string;
+  contentClassName?: string;
   hideChrome?: boolean;
 } & Omit<HTMLAttributes<HTMLDivElement>, "title">;
 
@@ -26,6 +27,7 @@ export const ProjectPageShell = forwardRef<HTMLDivElement, ProjectPageShellProps
       children,
       className,
       bodyClassName,
+      contentClassName,
       hideChrome = false,
       ...props
     },
@@ -36,46 +38,56 @@ export const ProjectPageShell = forwardRef<HTMLDivElement, ProjectPageShellProps
     return (
       <PageContainer
         ref={ref}
-        className={cn("mx-auto w-full max-w-6xl", className)}
+        className={cn("flex w-full max-w-full min-w-0 flex-col p-0 lg:p-0", className)}
         {...props}
       >
         {!hideChrome && (
           <div
             data-testid="project-page-shell-chrome"
-            className="sticky top-0 z-20 -mx-6 mb-6 w-[calc(100%+3rem)] max-w-none space-y-3 border-b border-border bg-background/90 px-6 pb-3 backdrop-blur-sm supports-[backdrop-filter]:bg-background/80 lg:-mx-8 lg:w-[calc(100%+4rem)] lg:px-8"
+            className="sticky top-0 z-20 mb-6 w-full border-b border-border bg-background/90 px-6 py-3 backdrop-blur-sm supports-[backdrop-filter]:bg-background/80 lg:px-8"
           >
-            <BackLink to="/" className="mb-0">
-              All projects
-            </BackLink>
-            <ProjectNav />
+            <div className="mx-auto w-full max-w-6xl space-y-2">
+              <BackLink to="/" className="mb-0">
+                All projects
+              </BackLink>
+              <ProjectNav />
+            </div>
           </div>
         )}
 
-        {hasHeader && (
-          <div
-            data-testid="project-page-shell-header"
-            className="mb-6 flex w-full flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
-          >
-            <div className="min-w-0 flex-1">
-              {title != null &&
-                (typeof title === "string" || typeof title === "number" ? (
-                  <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
-                ) : (
-                  title
-                ))}
-              {description != null && (
-                <div className="mt-1 text-sm leading-6 text-muted-foreground">
-                  {description}
-                </div>
+        <div
+          className={cn(
+            "mx-auto flex w-full max-w-6xl min-w-0 flex-1 flex-col px-6 pb-6 lg:px-8 lg:pb-8",
+            hideChrome && "max-w-none p-0 lg:p-0",
+            contentClassName,
+          )}
+        >
+          {hasHeader && (
+            <div
+              data-testid="project-page-shell-header"
+              className="mb-6 flex min-w-0 w-full max-w-full flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+            >
+              <div className="min-w-0 flex-1">
+                {title != null &&
+                  (typeof title === "string" || typeof title === "number" ? (
+                    <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+                  ) : (
+                    title
+                  ))}
+                {description != null && (
+                  <div className="mt-1 text-sm leading-6 text-muted-foreground">
+                    {description}
+                  </div>
+                )}
+              </div>
+              {actions != null && (
+                <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>
               )}
             </div>
-            {actions != null && (
-              <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>
-            )}
-          </div>
-        )}
+          )}
 
-        <div className={cn("w-full", bodyClassName)}>{children}</div>
+          <div className={cn("min-w-0 w-full max-w-full", bodyClassName)}>{children}</div>
+        </div>
       </PageContainer>
     );
   },

--- a/web/src/components/RuntimeLaunchControls.tsx
+++ b/web/src/components/RuntimeLaunchControls.tsx
@@ -355,17 +355,17 @@ export function RuntimeLaunchControls({
   const engineLabel = form.runner === "host" ? "host" : containerCLI;
   const runnerSummary = form.runner === "host"
     ? "Host"
-    : `${engineLabel === "podman" ? "Podman" : "Docker"} · ${sandboxNetwork === "host_proxy_only" ? "Host proxy only" : "Default bridge"} · VPN TUN ${sandboxVPNTun ? "开" : "关"}`;
+    : `${engineLabel === "podman" ? "Podman" : "Docker"} · ${sandboxNetwork === "host_proxy_only" ? "Host proxy only" : "Default bridge"} · VPN TUN ${sandboxVPNTun ? "on" : "off"}`;
   const skillsSummary = skillsPreviewLoading
     ? "Loading…"
     : skillsPreviewError
       ? "Error"
-      : `${enabledSkillsPreview.length} 个已启用`;
+      : `${enabledSkillsPreview.length} enabled`;
   const blackboardModeCards: { mode: BlackboardConclusionMode; icon: LucideIcon; title: string; description: string; disabled: boolean }[] = [
-    { mode: "interactive", icon: UserCheck, title: "Interactive", description: "由你决定何时把 Runtime 工作写入 Blackboard。", disabled: false },
-    { mode: "assisted", icon: Sparkles, title: "Assisted", description: "Harness 检测语义债务并自动派发 Conclude Turn。", disabled: !assistedConclusionSupported },
+    { mode: "interactive", icon: UserCheck, title: "Interactive", description: "You decide when Runtime work is committed to the Blackboard.", disabled: false },
+    { mode: "assisted", icon: Sparkles, title: "Assisted", description: "The harness detects semantic debt and dispatches a Conclude Turn automatically.", disabled: !assistedConclusionSupported },
     ...(allowDisabledBlackboardMode
-      ? [{ mode: "disabled" as const, icon: Ban, title: "Disabled", description: ownerLabel === "task" ? "此 Task 不写入 Blackboard。" : "此 Session 不写入 Blackboard。", disabled: false }]
+      ? [{ mode: "disabled" as const, icon: Ban, title: "Disabled", description: ownerLabel === "task" ? "This Task does not write to the Blackboard." : "This Session does not write to the Blackboard.", disabled: false }]
       : []),
   ];
 
@@ -373,7 +373,7 @@ export function RuntimeLaunchControls({
     <>
       <section className="rounded-lg border border-border bg-card shadow-sm">
         <div className="border-b border-border px-4 py-3">
-          <span className="text-sm font-medium">Runtime 与模型</span>
+          <span className="text-sm font-medium">Runtime and model</span>
         </div>
         <div className="grid grid-cols-2 gap-x-4 gap-y-4 p-4">
           <div>
@@ -434,9 +434,9 @@ export function RuntimeLaunchControls({
       </section>
 
 <div>
-        <SectionLabel className="mb-2 px-0.5">高级配置</SectionLabel>
+        <SectionLabel className="mb-2 px-0.5">Advanced configuration</SectionLabel>
         <div className="space-y-2">
-          <ConfigAccordion icon={Container} title="Runner 与网络" summary={runnerSummary}>
+          <ConfigAccordion icon={Container} title="Runner and network" summary={runnerSummary}>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <Label htmlFor="launch-runner">Runner</Label>
@@ -554,8 +554,8 @@ export function RuntimeLaunchControls({
           {controller.profiles.length > 0 && (
             <ConfigAccordion
               icon={Bookmark}
-              title="使用已保存的 Runtime Profile"
-              summary={presetMode ? (controller.profiles.find((profile) => profile.id === presetId)?.name ?? presetId) : "未选择"}
+              title="Use a saved Runtime Profile"
+              summary={presetMode ? (controller.profiles.find((profile) => profile.id === presetId)?.name ?? presetId) : "Not selected"}
               open={presetOpen}
               onOpenChange={setPresetOpen}
             >
@@ -662,14 +662,14 @@ export function LaunchSummaryRail({
   const modelDisplay = [summaryProvider?.name, form.modelOverride || "Default model"].filter(Boolean).join(" · ") || "—";
   const runnerDisplay = form.runner === "host" ? "Host" : containerCLI === "podman" ? "Podman" : "Docker";
   const blackboardDisplay = blackboardConclusionMode === "assisted" ? "Assisted" : blackboardConclusionMode === "disabled" ? "Disabled" : "Interactive";
-  const profileDisplay = presetMode ? `Runtime Profile: ${profiles.find((profile) => profile.id === presetId)?.name ?? presetId}` : "直接配置";
+  const profileDisplay = presetMode ? `Runtime Profile: ${profiles.find((profile) => profile.id === presetId)?.name ?? presetId}` : "Direct configuration";
   const apiKeyEnv = summaryProvider?.api_key_env ?? "";
   const credentialConfigured = bindings !== null && bindings.some((binding) => binding.credential_ref === apiKeyEnv && !binding.disabled);
 
   return (
     <aside className="h-fit lg:sticky lg:top-6">
       <div className="rounded-lg border border-border bg-card shadow-sm">
-        <div className="border-b border-border px-4 py-3"><span className="text-sm font-medium">Launch 摘要</span></div>
+        <div className="border-b border-border px-4 py-3"><span className="text-sm font-medium">Launch summary</span></div>
         <dl className="space-y-2.5 px-4 py-3.5 text-xs">
           <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Runtime</dt><dd className="min-w-0 truncate font-medium">{runtimeDisplay}</dd></div>
           <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Model</dt><dd className="min-w-0 truncate font-mono">{modelDisplay}</dd></div>
@@ -682,11 +682,11 @@ export function LaunchSummaryRail({
           <Button type={submit ? "submit" : "button"} onClick={onClick} disabled={disabled} className="w-full">
             <Rocket className="h-4 w-4" /> {busy ? busyLabel : label}
           </Button>
-          <p className="mt-2 text-center text-xs text-muted-foreground">启动前会自动运行 Preflight 检查</p>
+          <p className="mt-2 text-center text-xs text-muted-foreground">Preflight checks run automatically before launch.</p>
         </div>
       </div>
       <div className="mt-3 rounded-lg border border-dashed border-border p-3.5 text-xs text-muted-foreground">
-        <div className="flex items-center gap-2 font-medium text-foreground"><ShieldCheck className="h-4 w-4 text-success" />Preflight 预览</div>
+        <div className="flex items-center gap-2 font-medium text-foreground"><ShieldCheck className="h-4 w-4 text-success" />Preflight preview</div>
         <p className="mt-1">
           {profileDisplay}
           {apiKeyEnv && (
@@ -694,8 +694,8 @@ export function LaunchSummaryRail({
               {" · "}
               <span className="font-mono">{apiKeyEnv}</span>
               {bindings !== null && (credentialConfigured
-                ? <span className="text-success"> 已配置</span>
-                : <span className="text-warning"> 未配置</span>)}
+                ? <span className="text-success"> configured</span>
+                : <span className="text-warning"> not configured</span>)}
             </>
           )}
         </p>

--- a/web/src/components/RuntimeLaunchControls.tsx
+++ b/web/src/components/RuntimeLaunchControls.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { AlertTriangle, BookOpen, Bookmark, CheckCircle2, ChevronRight, Container, GitBranch, XCircle, type LucideIcon } from "lucide-react";
+import { AlertTriangle, Ban, BookOpen, Bookmark, CheckCircle2, ChevronRight, ChevronsUpDown, Container, GitBranch, Rocket, ShieldCheck, Sparkles, Terminal, UserCheck, XCircle, type LucideIcon } from "lucide-react";
 import {
   apiGet,
   apiPost,
   type BlackboardConclusionMode,
+  type CredentialBinding,
   type Health,
   type ModelProvider,
   type PreflightResult,
@@ -12,7 +13,7 @@ import {
   type RuntimeProfile,
   type Skill,
 } from "@/lib/api";
-import { Card, Label, Select } from "@/components/ui";
+import { Button, Card, Label, Select, type SelectProps } from "@/components/ui";
 import { SectionLabel } from "@/components/shared";
 import { cn } from "@/lib/utils";
 import { displayReasoningEffort, REASONING_EFFORT_VALUES, selectableModelProviders } from "@/pages/runtimeProfileForm";
@@ -343,7 +344,7 @@ export function RuntimeLaunchControls({
     ? assistedConclusionUnavailableReason
     : launchUnavailableReason({
         input: initialInput,
-        inputLabel: ownerLabel === "task" ? "Task goal" : "initial input",
+        inputLabel: ownerLabel === "task" ? "Task goal" : "Session goal",
         form,
         presetMode,
         compatibleProviderCount: compatibleProviders.length,
@@ -359,7 +360,14 @@ export function RuntimeLaunchControls({
     ? "Loading…"
     : skillsPreviewError
       ? "Error"
-      : `${enabledSkillsPreview.length} enabled`;
+      : `${enabledSkillsPreview.length} 个已启用`;
+  const blackboardModeCards: { mode: BlackboardConclusionMode; icon: LucideIcon; title: string; description: string; disabled: boolean }[] = [
+    { mode: "interactive", icon: UserCheck, title: "Interactive", description: "由你决定何时把 Runtime 工作写入 Blackboard。", disabled: false },
+    { mode: "assisted", icon: Sparkles, title: "Assisted", description: "Harness 检测语义债务并自动派发 Conclude Turn。", disabled: !assistedConclusionSupported },
+    ...(allowDisabledBlackboardMode
+      ? [{ mode: "disabled" as const, icon: Ban, title: "Disabled", description: ownerLabel === "task" ? "此 Task 不写入 Blackboard。" : "此 Session 不写入 Blackboard。", disabled: false }]
+      : []),
+  ];
 
   return (
     <>
@@ -370,21 +378,21 @@ export function RuntimeLaunchControls({
         <div className="grid grid-cols-2 gap-x-4 gap-y-4 p-4">
           <div>
             <Label htmlFor="launch-runtime">Runtime</Label>
-            <Select id="launch-runtime" name="runtime" value={form.runtime} disabled={presetMode} onChange={(event) => updateRuntime(event.target.value)}>
+            <ControlSelect leadingIcon={Terminal} id="launch-runtime" name="runtime" value={form.runtime} disabled={presetMode} onChange={(event) => updateRuntime(event.target.value)}>
               {launchRuntimePlugins.map((plugin) => <option key={plugin.id} value={plugin.id}>{plugin.name}</option>)}
-            </Select>
+            </ControlSelect>
           </div>
           <div>
             <Label htmlFor="launch-model-provider">Model provider</Label>
-            <Select id="launch-model-provider" name="model_provider" value={form.modelProviderId} disabled={presetMode} onChange={(event) => updateModelProvider(event.target.value)}>
+            <ControlSelect id="launch-model-provider" name="model_provider" value={form.modelProviderId} disabled={presetMode} onChange={(event) => updateModelProvider(event.target.value)}>
               {compatibleProviders.length === 0
                 ? <option value="">No compatible providers</option>
                 : compatibleProviders.map((provider) => <option key={provider.id} value={provider.id}>{provider.name}</option>)}
-            </Select>
+            </ControlSelect>
           </div>
           <div>
             <Label htmlFor="launch-model">Model</Label>
-            <Select
+            <ControlSelect
               id="launch-model"
               name="model"
               value={form.modelOverride}
@@ -399,7 +407,7 @@ export function RuntimeLaunchControls({
                   {modelOptions.map((model) => <option key={model} value={model}>{model}</option>)}
                 </>
               )}
-            </Select>
+            </ControlSelect>
           </div>
           <div>
             <Label id="launch-reasoning-effort-label">Reasoning effort</Label>
@@ -432,7 +440,7 @@ export function RuntimeLaunchControls({
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <Label htmlFor="launch-runner">Runner</Label>
-                <Select
+                <ControlSelect
                   id="launch-runner"
                   name="runner"
                   value={runnerSelectValue}
@@ -451,7 +459,7 @@ export function RuntimeLaunchControls({
                   <option value="docker">Docker</option>
                   <option value="podman">Podman</option>
                   <option value="host">Host</option>
-                </Select>
+                </ControlSelect>
                 {form.runner === "sandbox" && (
                   <p className="mt-1 text-xs text-muted-foreground">
                     Container engine <span className="font-mono">{engineLabel}</span> runs the isolated task workdir.
@@ -461,7 +469,7 @@ export function RuntimeLaunchControls({
               {form.runner === "sandbox" && (
                 <div>
                   <Label htmlFor="launch-sandbox-network">{engineLabel === "podman" ? "Podman network" : "Docker network"}</Label>
-                  <Select
+                  <ControlSelect
                     id="launch-sandbox-network"
                     name="sandbox_network"
                     value={sandboxNetwork}
@@ -476,7 +484,7 @@ export function RuntimeLaunchControls({
                   >
                     <option value="">Default bridge</option>
                     <option value="host_proxy_only">Host proxy only</option>
-                  </Select>
+                  </ControlSelect>
                 </div>
               )}
             </div>
@@ -508,13 +516,31 @@ export function RuntimeLaunchControls({
           </ConfigAccordion>
 
           <ConfigAccordion icon={GitBranch} title="Blackboard conclusions" summary={blackboardConclusionMode === "assisted" ? "Assisted" : blackboardConclusionMode === "disabled" ? "Disabled" : "Interactive"}>
-            <Label htmlFor="launch-blackboard-conclusions">Blackboard conclusions</Label>
-            <Select id="launch-blackboard-conclusions" name="blackboard_conclusion_mode" value={blackboardConclusionMode} onChange={(event) => { setBlackboardConclusionMode(event.target.value as BlackboardConclusionMode); setPreflight(null); }}>
-              <option value="interactive">Interactive</option>
-              <option value="assisted" disabled={!assistedConclusionSupported}>Assisted</option>
-              {allowDisabledBlackboardMode && <option value="disabled">Disabled</option>}
-            </Select>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <div role="radiogroup" aria-label="Blackboard conclusions" className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {blackboardModeCards.map((card) => {
+                const CardIcon = card.icon;
+                const selected = blackboardConclusionMode === card.mode;
+                return (
+                  <button
+                    key={card.mode}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    disabled={card.disabled}
+                    onClick={() => { setBlackboardConclusionMode(card.mode); setPreflight(null); }}
+                    className={cn(
+                      "rounded-lg border-2 p-3 text-left transition-colors",
+                      selected ? "border-primary bg-primary/[0.03]" : "border-border hover:border-ring",
+                      card.disabled && "cursor-not-allowed opacity-50",
+                    )}
+                  >
+                    <div className="flex items-center gap-2 text-sm font-medium"><CardIcon className="h-4 w-4" />{card.title}</div>
+                    <p className="mt-1 text-xs text-muted-foreground">{card.description}</p>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
               {blackboardConclusionMode === "disabled"
                 ? "The Runtime does not receive Blackboard state or Blackboard access. All non-Blackboard launch context remains available."
                 : blackboardConclusionMode === "assisted"
@@ -528,17 +554,17 @@ export function RuntimeLaunchControls({
           {controller.profiles.length > 0 && (
             <ConfigAccordion
               icon={Bookmark}
-              title="Use saved preset"
-              summary={presetMode ? (controller.profiles.find((profile) => profile.id === presetId)?.name ?? presetId) : "Direct configuration"}
+              title="使用已保存的 Runtime Profile"
+              summary={presetMode ? (controller.profiles.find((profile) => profile.id === presetId)?.name ?? presetId) : "未选择"}
               open={presetOpen}
               onOpenChange={setPresetOpen}
             >
               <div className="space-y-2">
-                <Label htmlFor="launch-preset">Runtime profile preset</Label>
-                <Select id="launch-preset" name="runtime_profile_preset" value={presetId} onChange={(event) => updatePreset(event.target.value)}>
+                <Label htmlFor="launch-preset">Runtime Profile</Label>
+                <ControlSelect id="launch-preset" name="runtime_profile" value={presetId} onChange={(event) => updatePreset(event.target.value)}>
                   <option value="">Direct configuration</option>
                   {runtimePresets.map((profile) => <option key={profile.id} value={profile.id}>{profile.name}</option>)}
-                </Select>
+                </ControlSelect>
                 <p className="text-xs text-muted-foreground">A Runtime Profile copies its full advanced configuration into this new {ownerLabel}. Later Profile edits do not change it.</p>
               </div>
             </ConfigAccordion>
@@ -569,6 +595,112 @@ export function RuntimeLaunchControls({
         </p>
       )}
     </>
+  );
+}
+
+function ControlSelect({ leadingIcon: LeadingIcon, className, children, ...props }: SelectProps & { leadingIcon?: LucideIcon }) {
+  return (
+    <div className="relative mt-1.5">
+      {LeadingIcon && <LeadingIcon className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />}
+      <Select
+        {...props}
+        className={cn("h-[34px] appearance-none rounded-lg bg-card px-2.5 pr-8 text-[13px] shadow-none", LeadingIcon && "pl-8", className)}
+      >
+        {children}
+      </Select>
+      <ChevronsUpDown className="pointer-events-none absolute right-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+    </div>
+  );
+}
+
+// Shared sticky launch-summary rail so the Task and Session launch surfaces
+// cannot drift: summary rows + primary launch button + preflight preview.
+export function LaunchSummaryRail({
+  controller,
+  disabled,
+  busy,
+  label,
+  busyLabel = "Launching…",
+  onClick,
+  submit = false,
+}: {
+  controller: RuntimeLaunchController;
+  disabled: boolean;
+  busy: boolean;
+  label: string;
+  busyLabel?: string;
+  onClick?: () => void;
+  submit?: boolean;
+}) {
+  const {
+    form,
+    presetId,
+    presetMode,
+    profiles,
+    plugins,
+    compatibleProviders,
+    containerCLI,
+    blackboardConclusionMode,
+    enabledSkillsPreview,
+  } = controller;
+  // Best-effort credential readiness preview: on failure, show the env name only.
+  const [bindings, setBindings] = useState<CredentialBinding[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<{ bindings: CredentialBinding[] }>("/api/credential-bindings")
+      .then((data) => {
+        if (!cancelled) setBindings(data.bindings ?? []);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const runtimeDisplay = plugins.find((plugin) => plugin.id === form.runtime)?.name ?? (form.runtime || "—");
+  const summaryProvider = compatibleProviders.find((provider) => provider.id === form.modelProviderId);
+  const modelDisplay = [summaryProvider?.name, form.modelOverride || "Default model"].filter(Boolean).join(" · ") || "—";
+  const runnerDisplay = form.runner === "host" ? "Host" : containerCLI === "podman" ? "Podman" : "Docker";
+  const blackboardDisplay = blackboardConclusionMode === "assisted" ? "Assisted" : blackboardConclusionMode === "disabled" ? "Disabled" : "Interactive";
+  const profileDisplay = presetMode ? `Runtime Profile: ${profiles.find((profile) => profile.id === presetId)?.name ?? presetId}` : "直接配置";
+  const apiKeyEnv = summaryProvider?.api_key_env ?? "";
+  const credentialConfigured = bindings !== null && bindings.some((binding) => binding.credential_ref === apiKeyEnv && !binding.disabled);
+
+  return (
+    <aside className="h-fit lg:sticky lg:top-6">
+      <div className="rounded-lg border border-border bg-card shadow-sm">
+        <div className="border-b border-border px-4 py-3"><span className="text-sm font-medium">Launch 摘要</span></div>
+        <dl className="space-y-2.5 px-4 py-3.5 text-xs">
+          <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Runtime</dt><dd className="min-w-0 truncate font-medium">{runtimeDisplay}</dd></div>
+          <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Model</dt><dd className="min-w-0 truncate font-mono">{modelDisplay}</dd></div>
+          <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Effort</dt><dd className="font-medium">{displayReasoningEffort(form.reasoningEffort)}</dd></div>
+          <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Runner</dt><dd className="font-medium">{runnerDisplay}</dd></div>
+          <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Blackboard</dt><dd className="font-medium">{blackboardDisplay}</dd></div>
+          <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Skills</dt><dd className="font-medium">{enabledSkillsPreview.length} enabled</dd></div>
+        </dl>
+        <div className="border-t border-border p-3.5">
+          <Button type={submit ? "submit" : "button"} onClick={onClick} disabled={disabled} className="w-full">
+            <Rocket className="h-4 w-4" /> {busy ? busyLabel : label}
+          </Button>
+          <p className="mt-2 text-center text-xs text-muted-foreground">启动前会自动运行 Preflight 检查</p>
+        </div>
+      </div>
+      <div className="mt-3 rounded-lg border border-dashed border-border p-3.5 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2 font-medium text-foreground"><ShieldCheck className="h-4 w-4 text-success" />Preflight 预览</div>
+        <p className="mt-1">
+          {profileDisplay}
+          {apiKeyEnv && (
+            <>
+              {" · "}
+              <span className="font-mono">{apiKeyEnv}</span>
+              {bindings !== null && (credentialConfigured
+                ? <span className="text-success"> 已配置</span>
+                : <span className="text-warning"> 未配置</span>)}
+            </>
+          )}
+        </p>
+      </div>
+    </aside>
   );
 }
 

--- a/web/src/components/WorkspaceSidebar.test.tsx
+++ b/web/src/components/WorkspaceSidebar.test.tsx
@@ -391,12 +391,14 @@ describe("WorkspaceSidebar", () => {
 
     const nonProject = await screen.findByRole("region", { name: /non-project/i });
     const sessionLinks = await within(nonProject).findAllByRole("link", { name: /session conversation/i });
-    expect(sessionLinks.map((link) => link.textContent?.trim())).toEqual([
-      "Busy session session conversation",
-      "Idle session 1 session conversation",
-      "Idle session 2 session conversation",
-      "Idle session 3 session conversation",
-      "Current session session conversation",
+    // Rows are two-line now (title + "time · state"): assert the title order,
+    // which is what this test is about, without pinning the relative-time text.
+    expect(sessionLinks.map((link) => link.textContent ?? "")).toEqual([
+      expect.stringContaining("Busy session"),
+      expect.stringContaining("Idle session 1"),
+      expect.stringContaining("Idle session 2"),
+      expect.stringContaining("Idle session 3"),
+      expect.stringContaining("Current session"),
     ]);
     expect(within(nonProject).getByRole("img", { name: "Runtime busy" })).toBeInTheDocument();
   });
@@ -794,7 +796,7 @@ describe("WorkspaceSidebar", () => {
     expect(within(projects).getByText(/no projects match/i)).toBeInTheDocument();
   });
 
-  it("disambiguates sessions sharing a title with a relative-time suffix", async () => {
+  it("shows a relative time · state second line on every session row, disambiguating shared titles", async () => {
     const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
     const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
     vi.stubGlobal(
@@ -826,12 +828,14 @@ describe("WorkspaceSidebar", () => {
     const nonProject = await screen.findByRole("region", { name: /non-project/i });
     const duplicateLinks = await within(nonProject).findAllByRole("link", { name: /duplicate session conversation/i });
     expect(duplicateLinks).toHaveLength(2);
-    // Recent-first ordering: the two-day-old duplicate ranks above the five-day one.
-    expect(duplicateLinks[0]).toHaveTextContent("2 days ago");
-    expect(duplicateLinks[1]).toHaveTextContent("5 days ago");
-    // A uniquely-named Session never gets the suffix.
+    // Every row carries the time · state line, so same-titled Sessions stay
+    // distinguishable. Recent-first ordering: the two-day-old duplicate ranks
+    // above the five-day one.
+    expect(duplicateLinks[0]).toHaveTextContent("2 days ago · 已停止");
+    expect(duplicateLinks[1]).toHaveTextContent("5 days ago · 已停止");
+    // The line is not conditional on duplicates: unique rows show it too.
     const uniqueLink = within(nonProject).getByRole("link", { name: /unique session conversation/i });
-    expect(uniqueLink).not.toHaveTextContent(/ago/);
+    expect(uniqueLink).toHaveTextContent("2 days ago · 已停止");
   });
 
   it("shows item counts on the Non-project and Projects group headers", async () => {
@@ -874,7 +878,7 @@ describe("WorkspaceSidebar", () => {
     expect(projectsLink.parentElement).toHaveTextContent("Projects3");
   });
 
-  it("renders runtime activity as colored status dots", async () => {
+  it("renders runtime activity as colored status dots with mockup state text", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn((input: RequestInfo | URL) => {
@@ -895,6 +899,15 @@ describe("WorkspaceSidebar", () => {
                 ...session("session-offline", "Offline session", "2026-07-30T00:00:00Z"),
                 runtime_activity: { liveness: "offline" },
               },
+              {
+                ...session("session-orphaned", "Orphaned session", "2026-07-29T00:00:00Z"),
+                runtime_activity: { liveness: "orphaned" },
+              },
+              {
+                ...session("session-failed", "Failed session", "2026-07-28T00:00:00Z"),
+                runtime_activity: { liveness: "offline" },
+                latest_continuation: { status: "failed" },
+              },
             ],
           });
         }
@@ -912,11 +925,25 @@ describe("WorkspaceSidebar", () => {
 
     const nonProject = await screen.findByRole("region", { name: /non-project/i });
     await within(nonProject).findByRole("link", { name: /busy session/i });
+
+    // Dot color per state (mockup stateDot mapping).
     const busyDot = within(nonProject).getByRole("img", { name: "Runtime busy" }).firstElementChild;
     expect(busyDot).toHaveClass("bg-success", "animate-pulse");
     const idleDot = within(nonProject).getByRole("img", { name: "Runtime live idle" }).firstElementChild;
     expect(idleDot).toHaveClass("bg-info");
     const offlineDot = within(nonProject).getByRole("img", { name: "Runtime offline" }).firstElementChild;
     expect(offlineDot).toHaveClass("bg-muted-foreground/40");
+    // Undetermined liveness is amber, never confused with a durable failure.
+    const orphanedDot = within(nonProject).getByRole("img", { name: "Runtime failure (orphaned)" }).firstElementChild;
+    expect(orphanedDot).toHaveClass("bg-warning");
+    const failedDot = within(nonProject).getByRole("img", { name: "Runtime failure" }).firstElementChild;
+    expect(failedDot).toHaveClass("bg-destructive");
+
+    // Visible second-line state text per row (mockup: time · state).
+    expect(within(nonProject).getByRole("link", { name: /busy session/i })).toHaveTextContent("· 运行中");
+    expect(within(nonProject).getByRole("link", { name: /idle session/i })).toHaveTextContent("· 空闲");
+    expect(within(nonProject).getByRole("link", { name: /offline session/i })).toHaveTextContent("· 已停止");
+    expect(within(nonProject).getByRole("link", { name: /orphaned session/i })).toHaveTextContent("· 状态未知");
+    expect(within(nonProject).getByRole("link", { name: /failed session/i })).toHaveTextContent("· 失败");
   });
 });

--- a/web/src/components/WorkspaceSidebar.test.tsx
+++ b/web/src/components/WorkspaceSidebar.test.tsx
@@ -831,11 +831,11 @@ describe("WorkspaceSidebar", () => {
     // Every row carries the time · state line, so same-titled Sessions stay
     // distinguishable. Recent-first ordering: the two-day-old duplicate ranks
     // above the five-day one.
-    expect(duplicateLinks[0]).toHaveTextContent("2 days ago · 已停止");
-    expect(duplicateLinks[1]).toHaveTextContent("5 days ago · 已停止");
+    expect(duplicateLinks[0]).toHaveTextContent("2 days ago · Stopped");
+    expect(duplicateLinks[1]).toHaveTextContent("5 days ago · Stopped");
     // The line is not conditional on duplicates: unique rows show it too.
     const uniqueLink = within(nonProject).getByRole("link", { name: /unique session conversation/i });
-    expect(uniqueLink).toHaveTextContent("2 days ago · 已停止");
+    expect(uniqueLink).toHaveTextContent("2 days ago · Stopped");
   });
 
   it("shows item counts on the Non-project and Projects group headers", async () => {
@@ -940,10 +940,10 @@ describe("WorkspaceSidebar", () => {
     expect(failedDot).toHaveClass("bg-destructive");
 
     // Visible second-line state text per row (mockup: time · state).
-    expect(within(nonProject).getByRole("link", { name: /busy session/i })).toHaveTextContent("· 运行中");
-    expect(within(nonProject).getByRole("link", { name: /idle session/i })).toHaveTextContent("· 空闲");
-    expect(within(nonProject).getByRole("link", { name: /offline session/i })).toHaveTextContent("· 已停止");
-    expect(within(nonProject).getByRole("link", { name: /orphaned session/i })).toHaveTextContent("· 状态未知");
-    expect(within(nonProject).getByRole("link", { name: /failed session/i })).toHaveTextContent("· 失败");
+    expect(within(nonProject).getByRole("link", { name: /busy session/i })).toHaveTextContent("· Running");
+    expect(within(nonProject).getByRole("link", { name: /idle session/i })).toHaveTextContent("· Idle");
+    expect(within(nonProject).getByRole("link", { name: /offline session/i })).toHaveTextContent("· Stopped");
+    expect(within(nonProject).getByRole("link", { name: /orphaned session/i })).toHaveTextContent("· Unknown");
+    expect(within(nonProject).getByRole("link", { name: /failed session/i })).toHaveTextContent("· Failed");
   });
 });

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -847,24 +847,21 @@ function RuntimeActivityIndicator({ activity, failed = false, className }: { act
   );
 }
 
-// Direction A status dots with the mockup's state text: a busy Runtime pulses
-// green (运行中), a live-but-idle one is blue (空闲), offline/missing activity
-// falls back to muted gray (已停止), and liveness the daemon cannot determine
-// is amber (状态未知). Durable failures keep a red dot (失败) so they never
-// visually collapse into offline. `label` stays English for aria; `text` is
-// the visible second-line state from the mockup.
+// Direction A status dots keep the visible state text aligned with the
+// accessible Runtime Activity label. Durable failures remain distinct from an
+// offline Runtime so operators never mistake failure for a normal stop.
 function runtimeActivityState(activity?: RuntimeActivity, failed = false) {
-  if (failed) return { label: "Runtime failure", text: "失败", dot: "bg-destructive", busy: false };
+  if (failed) return { label: "Runtime failure", text: "Failed", dot: "bg-destructive", busy: false };
   if (activity?.liveness === "live" && activity.turn_activity === "busy") {
-    return { label: "Runtime busy", text: "运行中", dot: "bg-success", busy: true };
+    return { label: "Runtime busy", text: "Running", dot: "bg-success", busy: true };
   }
-  if (activity?.liveness === "live") return { label: "Runtime live idle", text: "空闲", dot: "bg-info", busy: false };
-  if (activity?.liveness === "offline") return { label: "Runtime offline", text: "已停止", dot: "bg-muted-foreground/40", busy: false };
+  if (activity?.liveness === "live") return { label: "Runtime live idle", text: "Idle", dot: "bg-info", busy: false };
+  if (activity?.liveness === "offline") return { label: "Runtime offline", text: "Stopped", dot: "bg-muted-foreground/40", busy: false };
   if (activity?.liveness === "orphaned") {
-    return { label: "Runtime failure (orphaned)", text: "状态未知", dot: "bg-warning", busy: false };
+    return { label: "Runtime failure (orphaned)", text: "Unknown", dot: "bg-warning", busy: false };
   }
-  if (activity?.liveness === "unknown") return { label: "Runtime unavailable (unknown)", text: "状态未知", dot: "bg-warning", busy: false };
-  return { label: "Runtime activity unavailable", text: "已停止", dot: "bg-muted-foreground/40", busy: false };
+  if (activity?.liveness === "unknown") return { label: "Runtime unavailable (unknown)", text: "Unknown", dot: "bg-warning", busy: false };
+  return { label: "Runtime activity unavailable", text: "Stopped", dot: "bg-muted-foreground/40", busy: false };
 }
 
 function isSessionBusy(session: Session) {

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -29,6 +29,7 @@ import { ThemeToggle } from "@/components/ThemeProvider";
 import { PromptDialog } from "@/components/ConfirmDialog";
 import { useDocumentVisibility } from "@/lib/useDocumentVisibility";
 import { cn } from "@/lib/utils";
+import { formatRelativeTime } from "@/lib/format";
 
 // Dense sidebar rows: keep a visible focus target without the outer black
 // ring-offset frame that reads as a heavy selection box.
@@ -230,14 +231,6 @@ export function WorkspaceSidebar({ onNavigate }: WorkspaceSidebarProps) {
     [sortedProjects, normalizedQuery],
   );
 
-  // Sessions sharing a title get a relative-time suffix so the rows stay
-  // distinguishable; counts cover every loaded Session, not just visible rows.
-  const sessionNameCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const session of sessions) counts.set(session.title, (counts.get(session.title) ?? 0) + 1);
-    return counts;
-  }, [sessions]);
-
   const toggleProject = (projectId: string, defaultOpen: boolean) => {
     setProjectDisclosure((previous) => {
       const next = !(previous[projectId] ?? defaultOpen);
@@ -341,7 +334,6 @@ export function WorkspaceSidebar({ onNavigate }: WorkspaceSidebarProps) {
                     session={session}
                     current={session.id === currentSessionId}
                     busy={sessionActionId === session.id}
-                    duplicate={(sessionNameCounts.get(session.title) ?? 0) > 1}
                     onNavigate={onNavigate}
                     onRename={(session) => setRenameTarget(session)}
                     onArchive={handleSessionArchive}
@@ -528,7 +520,7 @@ function ProjectRow({
         </NavLink>
       </div>
 
-      <div id={taskPanelId} hidden={!open} className="ml-4 mt-0.5 space-y-0.5 border-l border-sidebar-border/70 pl-2">
+      <div id={taskPanelId} hidden={!open} className="mt-0.5 space-y-0.5">
         {tasksLoading ? (
           <SidebarStatus label={`Loading tasks for ${project.name}`} />
         ) : tasksError ? (
@@ -544,7 +536,7 @@ function ProjectRow({
               to={`/projects/${encodeURIComponent(project.id)}/tasks`}
               onClick={onNavigate}
               className={cn(
-                "inline-flex h-8 w-full items-center rounded-md px-2 text-xs text-muted-foreground transition-colors hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground",
+                "inline-flex h-8 w-full items-center rounded-md pl-7 pr-2 text-xs text-muted-foreground transition-colors hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground",
                 sidebarFocusClass,
               )}
             >
@@ -561,7 +553,6 @@ function SessionRow({
   session,
   current,
   busy,
-  duplicate,
   onNavigate,
   onRename,
   onArchive,
@@ -569,29 +560,31 @@ function SessionRow({
   session: Session;
   current: boolean;
   busy: boolean;
-  duplicate: boolean;
   onNavigate?: () => void;
   onRename: (session: Session) => void;
   onArchive: (session: Session) => Promise<void>;
 }) {
+  const failed = session.latest_continuation?.status === "failed";
+  const state = runtimeActivityState(session.runtime_activity, failed);
+  const time = formatRelativeTime(session.last_activity_at ?? session.updated_at);
   return (
-    <div className="group flex items-center gap-1">
+    <div className="group flex items-start gap-1">
       <NavLink
         to={`/sessions/${encodeURIComponent(session.id)}`}
         end
-        aria-label={`Open ${session.title} session conversation. ${runtimeActivityState(session.runtime_activity, session.latest_continuation?.status === "failed").label}.`}
+        aria-label={`Open ${session.title} session conversation. ${state.label}.`}
         onClick={onNavigate}
-        className={({ isActive }) => navItemClasses(isActive, "min-w-0 flex-1")}
+        className={({ isActive }) => navItemClasses(isActive, "h-auto min-w-0 flex-1 items-start")}
       >
         {({ isActive }) => (
           <>
-            <RuntimeActivityIndicator activity={session.runtime_activity} failed={session.latest_continuation?.status === "failed"} />
-            <span className="truncate">{session.title}</span>
-            {duplicate && (
-              <span className="shrink-0 text-xs text-muted-foreground">
-                {formatRelativeTime(session.last_activity_at ?? session.updated_at)}
+            <RuntimeActivityIndicator activity={session.runtime_activity} failed={failed} className="mt-0.5" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate">{session.title}</span>
+              <span className="mt-0.5 block truncate text-[11px] leading-[1.3] text-muted-foreground">
+                {time ? `${time} · ${state.text}` : state.text}
               </span>
-            )}
+            </span>
             <span className="sr-only"> session conversation</span>
             <ActiveIndicator active={isActive || current} />
           </>
@@ -609,7 +602,7 @@ function TaskRow({ task, current, onNavigate }: { task: Task; current: boolean; 
       end
       aria-label={`Open ${task.goal || "Untitled task"} task conversation. ${runtimeActivityState(task.runtime_activity, task.status === "failed").label}.`}
       onClick={onNavigate}
-      className={({ isActive }) => navItemClasses(isActive || current, "min-w-0 w-full")}
+      className={({ isActive }) => navItemClasses(isActive || current, "h-auto min-w-0 w-full py-1 pl-7 text-xs")}
     >
       {({ isActive }) => (
         <>
@@ -671,6 +664,9 @@ function SessionOverflowMenu({
         onClick={() => setOpen((previous) => !previous)}
         className={cn(
           "inline-flex size-8 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:border-sidebar-border hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground",
+          // Mockup parity: the overflow action is hover-revealed, but stays
+          // visible while the menu is open or the button has keyboard focus.
+          open ? "opacity-100" : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
           sidebarFocusClass,
         )}
       >
@@ -839,10 +835,10 @@ function SidebarEmpty({
   );
 }
 
-function RuntimeActivityIndicator({ activity, failed = false }: { activity?: RuntimeActivity; failed?: boolean }) {
+function RuntimeActivityIndicator({ activity, failed = false, className }: { activity?: RuntimeActivity; failed?: boolean; className?: string }) {
   const state = runtimeActivityState(activity, failed);
   return (
-    <span role="img" title={state.label} aria-label={state.label} className="inline-flex size-4 shrink-0 items-center justify-center">
+    <span role="img" title={state.label} aria-label={state.label} className={cn("inline-flex size-4 shrink-0 items-center justify-center", className)}>
       <span
         aria-hidden="true"
         className={cn("size-1.5 rounded-full", state.dot, state.busy && "animate-pulse motion-reduce:animate-none")}
@@ -851,21 +847,24 @@ function RuntimeActivityIndicator({ activity, failed = false }: { activity?: Run
   );
 }
 
-// Direction A status dots: a busy Runtime pulses green, a live-but-idle one is
-// blue, and offline/unknown/missing activity falls back to muted gray. Durable
-// failures keep a red dot so they never visually collapse into offline.
+// Direction A status dots with the mockup's state text: a busy Runtime pulses
+// green (运行中), a live-but-idle one is blue (空闲), offline/missing activity
+// falls back to muted gray (已停止), and liveness the daemon cannot determine
+// is amber (状态未知). Durable failures keep a red dot (失败) so they never
+// visually collapse into offline. `label` stays English for aria; `text` is
+// the visible second-line state from the mockup.
 function runtimeActivityState(activity?: RuntimeActivity, failed = false) {
-  if (failed) return { label: "Runtime failure", dot: "bg-destructive", busy: false };
+  if (failed) return { label: "Runtime failure", text: "失败", dot: "bg-destructive", busy: false };
   if (activity?.liveness === "live" && activity.turn_activity === "busy") {
-    return { label: "Runtime busy", dot: "bg-success", busy: true };
+    return { label: "Runtime busy", text: "运行中", dot: "bg-success", busy: true };
   }
-  if (activity?.liveness === "live") return { label: "Runtime live idle", dot: "bg-info", busy: false };
-  if (activity?.liveness === "offline") return { label: "Runtime offline", dot: "bg-muted-foreground/40", busy: false };
+  if (activity?.liveness === "live") return { label: "Runtime live idle", text: "空闲", dot: "bg-info", busy: false };
+  if (activity?.liveness === "offline") return { label: "Runtime offline", text: "已停止", dot: "bg-muted-foreground/40", busy: false };
   if (activity?.liveness === "orphaned") {
-    return { label: "Runtime failure (orphaned)", dot: "bg-destructive", busy: false };
+    return { label: "Runtime failure (orphaned)", text: "状态未知", dot: "bg-warning", busy: false };
   }
-  if (activity?.liveness === "unknown") return { label: "Runtime unavailable (unknown)", dot: "bg-muted-foreground/40", busy: false };
-  return { label: "Runtime activity unavailable", dot: "bg-muted-foreground/40", busy: false };
+  if (activity?.liveness === "unknown") return { label: "Runtime unavailable (unknown)", text: "状态未知", dot: "bg-warning", busy: false };
+  return { label: "Runtime activity unavailable", text: "已停止", dot: "bg-muted-foreground/40", busy: false };
 }
 
 function isSessionBusy(session: Session) {
@@ -894,34 +893,6 @@ function activityTime(...values: (string | undefined)[]) {
   return Math.max(...values.map((value) => (value ? Date.parse(value) : Number.NEGATIVE_INFINITY)));
 }
 
-const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
-
-const RELATIVE_TIME_DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
-  { amount: 60, unit: "second" },
-  { amount: 60, unit: "minute" },
-  { amount: 24, unit: "hour" },
-  { amount: 7, unit: "day" },
-  { amount: 4.34524, unit: "week" },
-  { amount: 12, unit: "month" },
-  { amount: Number.POSITIVE_INFINITY, unit: "year" },
-];
-
-// Compact "2 days ago"-style timestamp that disambiguates same-named Sessions
-// in the Sidebar. The repo's format helpers are all absolute, so this is the
-// one relative-time formatter.
-function formatRelativeTime(value: string | undefined) {
-  if (!value) return "";
-  const time = Date.parse(value);
-  if (Number.isNaN(time)) return "";
-  let delta = (time - Date.now()) / 1000;
-  for (const division of RELATIVE_TIME_DIVISIONS) {
-    if (Math.abs(delta) < division.amount) {
-      return relativeTimeFormatter.format(Math.round(delta), division.unit);
-    }
-    delta /= division.amount;
-  }
-  return "";
-}
 
 function takeRecentWithCurrent<T>(
   items: T[],

--- a/web/src/components/icon-source.test.ts
+++ b/web/src/components/icon-source.test.ts
@@ -36,7 +36,7 @@ function sourceFiles(dir: string): string[] {
 describe("icon source policy", () => {
   it("uses lucide icons instead of inline svg/emoji/image icons", () => {
     const violations = sourceFiles(srcRoot).flatMap((file) => {
-      const rel = relative(srcRoot, file);
+      const rel = relative(srcRoot, file).replaceAll("\\", "/");
       if (rel === "components/Logo.tsx") return [];
 
       const source = readFileSync(file, "utf8");

--- a/web/src/components/shared.tsx
+++ b/web/src/components/shared.tsx
@@ -97,7 +97,7 @@ export function SettingsPageShell({
   return (
     <PageContainer
       className={cn(
-        "flex w-full max-w-6xl flex-col lg:min-h-0 lg:flex-1 lg:overflow-hidden",
+        "mx-auto flex w-full max-w-6xl flex-col lg:min-h-0 lg:flex-1 lg:overflow-hidden",
         className,
       )}
       {...props}

--- a/web/src/components/task-transcript/AgentTranscriptView.tsx
+++ b/web/src/components/task-transcript/AgentTranscriptView.tsx
@@ -5,6 +5,7 @@ import {
   ArrowDownNarrowWide,
   ArrowUpNarrowWide,
   Bot,
+  Brain,
   Check,
   CheckCircle2,
   ChevronRight,
@@ -12,8 +13,6 @@ import {
   Copy,
   Filter,
   Loader2,
-  OctagonPause,
-  User,
   XCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -94,28 +93,6 @@ export function AgentTranscriptView({ owner, items, profileName, isLive = false,
     () => (sortDirection === "newest_first" ? [...filteredItems].reverse() : filteredItems),
     [filteredItems, sortDirection],
   );
-
-  // Pair each tool call with the immediately following result for the same
-  // tool so the pair renders as one compressed tool row (Direction A). The
-  // source order is chronological, so the result always trails its call.
-  const toolPairs = useMemo(() => {
-    const resultForCall = new Map<TimelineItem, TimelineItem>();
-    const absorbedResults = new Set<TimelineItem>();
-    for (let index = 0; index + 1 < filteredItems.length; index += 1) {
-      const item = filteredItems[index]!;
-      if (item.type !== "tool_use") continue;
-      const next = filteredItems[index + 1]!;
-      if (next.type === "tool_result" && (!next.tool || !item.tool || next.tool === item.tool)) {
-        resultForCall.set(item, next);
-        absorbedResults.add(next);
-      }
-    }
-    return { resultForCall, absorbedResults };
-  }, [filteredItems]);
-
-  // Timeline lane per displayed row; a lane change starts a new turn-group
-  // marker on the rail.
-  const lanes = useMemo(() => displayItems.map(turnLane), [displayItems]);
 
   // Virtualized rendering window: DOM size stays bounded while loaded older
   // pages accumulate in state (#202). The container element is stored in
@@ -397,30 +374,22 @@ export function AgentTranscriptView({ owner, items, profileName, isLive = false,
             )}
           </div>
         ) : (
-          <div>
+          <div className="divide-y">
             {sortDirection === "chronological" && footer}
             {displayWindow.spacerBefore > 0 && (
               <div aria-hidden="true" style={{ height: displayWindow.spacerBefore }} />
             )}
-            {visibleItems.map((item, visibleIndex) => {
-              if (toolPairs.absorbedResults.has(item)) return null;
-              const absoluteIndex = (displayWindow.virtualized ? displayWindow.startIndex : 0) + visibleIndex;
-              const lane = lanes[absoluteIndex] ?? "runtime";
-              return (
-                <TranscriptEventRow
-                  key={`${item.id ?? `${item.seq}-${visibleIndex}`}-${item.type === "reasoning" ? item.status ?? "" : ""}`}
-                  ref={(el) => {
-                    if (el) eventRefs.current.set(item.seq, el);
-                    else eventRefs.current.delete(item.seq);
-                  }}
-                  item={item}
-                  isSelected={selectedSeq === item.seq}
-                  pairedResult={toolPairs.resultForCall.get(item)}
-                  lane={lane}
-                  laneStart={absoluteIndex === 0 || lanes[absoluteIndex - 1] !== lane}
-                />
-              );
-            })}
+            {visibleItems.map((item, visibleIndex) => (
+              <TranscriptEventRow
+                key={`${item.id ?? `${item.seq}-${visibleIndex}`}-${item.type === "reasoning" ? item.status ?? "" : ""}`}
+                ref={(el) => {
+                  if (el) eventRefs.current.set(item.seq, el);
+                  else eventRefs.current.delete(item.seq);
+                }}
+                item={item}
+                isSelected={selectedSeq === item.seq}
+              />
+            ))}
             {displayWindow.spacerAfter > 0 && (
               <div aria-hidden="true" style={{ height: displayWindow.spacerAfter }} />
             )}
@@ -580,247 +549,46 @@ function TimelineBar({
   );
 }
 
-type TurnLane = "user" | "runtime" | "system" | "divider";
-
-/** Maps a timeline item onto its Direction A lane: operator input, runtime
- * work, system workflow markers, or a full-width lifecycle divider. */
-function turnLane(item: TimelineItem): TurnLane {
-  if (item.type === "lifecycle") return "divider";
-  if (item.type === "steering") return "user";
-  if (item.type === "harness") return "system";
-  return "runtime";
-}
-
-/** Timeline rail grouping one runtime turn: a circular lane marker on the
- * left rail ties the turn's rows into a single visual unit. */
-function TurnGroup({
-  children,
-  marker,
-  showMarker = true,
-}: {
-  children: ReactNode;
-  marker: Exclude<TurnLane, "divider">;
-  showMarker?: boolean;
-}) {
-  return (
-    <div className="relative pl-6">
-      {showMarker && (
-        <span
-          className={cn(
-            "absolute left-0 top-1 flex h-4 w-4 items-center justify-center rounded-full border",
-            marker === "user" && "border-border bg-card",
-            marker === "runtime" && "border-signal/40 bg-signal/10 text-signal",
-            marker === "system" && "border-border bg-muted",
-          )}
-        >
-          {marker === "user" && <User className="h-2.5 w-2.5" />}
-          {marker === "runtime" && <Bot className="h-2.5 w-2.5" />}
-          {marker === "system" && <OctagonPause className="h-2.5 w-2.5" />}
-        </span>
-      )}
-      <div className="border-l border-border pl-4">{children}</div>
-    </div>
-  );
-}
-
-/** Lifecycle events degrade to centered dividers instead of posing as rows. */
-function SystemEventDivider({ item }: { item: TimelineItem }) {
-  return (
-    <div className="flex items-center gap-3 py-1">
-      <span className="h-px flex-1 bg-border" />
-      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <OctagonPause className="h-3 w-3" />
-        {getEventSummary(item) || getEventLabel(item)}
-        <span className="text-muted-foreground/50">· #{item.seq}</span>
-      </span>
-      <span className="h-px flex-1 bg-border" />
-    </div>
-  );
-}
-
-/** One compressed row per tool call: status icon, tool name, one-line command
- * summary, optional failure status, and call→result duration. The call input
- * and the paired result output stay folded behind the row until expanded. */
-function ToolCallRow({
-  call,
-  result,
-  expanded,
-  onToggle,
-}: {
-  call?: TimelineItem;
-  result?: TimelineItem;
-  expanded: boolean;
-  onToggle: () => void;
-}) {
-  const item = call ?? result;
-  if (!item) return null;
-  const hasInput = Boolean(call?.input && Object.keys(call.input).length > 0);
-  const hasOutput = Boolean(result?.output && result.output.length > 0);
-  const hasDetail = hasInput || hasOutput;
-  const failed = Boolean(result?.status && result.status !== "completed" && result.status !== "success");
-  const duration =
-    call?.created_at && result?.created_at ? formatDuration(call.created_at, result.created_at) : null;
-  return (
-    <div className="py-0.5">
-      <button
-        type="button"
-        disabled={!hasDetail}
-        onClick={onToggle}
-        className={cn(
-          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-          hasDetail ? "hover:bg-muted/50" : "cursor-default",
-        )}
-      >
-        {failed ? (
-          <XCircle className="h-3.5 w-3.5 flex-none text-destructive" />
-        ) : result ? (
-          <CheckCircle2 className="h-3.5 w-3.5 flex-none text-success" />
-        ) : (
-          <Clock className="h-3.5 w-3.5 flex-none text-muted-foreground" />
-        )}
-        <span className="flex-none font-mono text-xs text-muted-foreground">
-          {item.tool ?? (call ? "Tool" : "Result")}
-        </span>
-        <span className="min-w-0 flex-1 truncate font-mono text-xs">{getEventSummary(item) || "(empty)"}</span>
-        {failed && (
-          <span className="flex-none rounded-sm bg-destructive/10 px-1 text-[10px] text-destructive">
-            {result?.status}
-          </span>
-        )}
-        {duration && <span className="flex-none text-xs text-muted-foreground">{duration}</span>}
-        {hasDetail && (
-          <ChevronRight
-            className={cn("h-3.5 w-3.5 flex-none text-muted-foreground transition-transform", expanded && "rotate-90")}
-          />
-        )}
-      </button>
-      {expanded && hasDetail && (
-        <div
-          data-testid="timeline-event-detail"
-          className="ml-5 rounded-md border border-border bg-muted/40 font-mono text-xs leading-relaxed text-muted-foreground"
-        >
-          {hasInput && call && <EventDetailContent item={call} />}
-          {hasOutput && result && <EventDetailContent item={result} />}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/** Reasoning entries fold behind a single italic summary line by default. */
-function ReasoningRow({
+function TranscriptEventRow({
+  ref,
   item,
-  expanded,
-  onToggle,
+  isSelected,
 }: {
+  ref?: React.Ref<HTMLDivElement>;
   item: TimelineItem;
-  expanded: boolean;
-  onToggle: () => void;
+  isSelected: boolean;
 }) {
-  const hasDetail = Boolean(item.content && item.content.length > 0);
-  const summary = getEventSummary(item);
-  return (
-    <div className="py-1.5">
-      <button
-        type="button"
-        disabled={!hasDetail}
-        onClick={onToggle}
-        className={cn(
-          "flex w-full items-center gap-1.5 rounded text-left text-xs italic text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-          hasDetail ? "hover:text-foreground" : "cursor-default",
-        )}
-      >
-        {hasDetail && (
-          <ChevronRight className={cn("h-3.5 w-3.5 flex-none transition-transform", expanded && "rotate-90")} />
-        )}
-        <span className="min-w-0 flex-1 truncate">
-          {getEventLabel(item)} · {summary || "(empty)"}
-        </span>
-      </button>
-      {expanded && hasDetail && (
-        <div data-testid="timeline-event-detail" className="mt-1 pl-5 text-xs text-muted-foreground">
-          <EventDetailContent item={item} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-/** Assistant messages drop the card chrome for a signal-colored left accent. */
-function AssistantMessageRow({
-  item,
-  expanded,
-  onToggle,
-}: {
-  item: TimelineItem;
-  expanded: boolean;
-  onToggle: () => void;
-}) {
-  const hasDetail = Boolean(item.content && item.content.length > 0);
-  const summary = getEventSummary(item);
-  return (
-    <div className="py-1.5">
-      <div className="border-l-2 border-signal/40 pl-4 text-sm leading-relaxed">
-        <button
-          type="button"
-          disabled={!hasDetail}
-          onClick={onToggle}
-          className={cn(
-            "w-full rounded text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-            hasDetail ? "cursor-pointer hover:text-foreground" : "cursor-default",
-          )}
-        >
-          <div className="flex items-start gap-1.5">
-            {hasDetail && (
-              <ChevronRight
-                className={cn(
-                  "mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/50 transition-transform",
-                  expanded && "rotate-90",
-                )}
-              />
-            )}
-            <span className="truncate">{summary || "(empty)"}</span>
-          </div>
-        </button>
-        {expanded && hasDetail && (
-          <div data-testid="timeline-event-detail" className="mt-1">
-            <EventDetailContent item={item} />
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/** Rows the Direction A redesign leaves on the classic layout: errors,
- * Harness workflow markers, subagent activity, and steering directives. */
-function GenericEventRow({
-  item,
-  expanded,
-  onToggle,
-  date,
-}: {
-  item: TimelineItem;
-  expanded: boolean;
-  onToggle: () => void;
-  date: Date | null;
-}) {
+  const [expanded, setExpanded] = useState(item.type === "reasoning" && item.status === "streaming");
   const color = getEventColor(item);
   const label = getEventLabel(item);
   const summary = getEventSummary(item);
-  const hasDetail = Boolean(
-    (item.type === "harness" || item.type === "error") && item.content && item.content.length > 0,
-  );
+  const date = useMemo(() => (item.created_at ? new Date(item.created_at) : null), [item.created_at]);
+
+  const hasDetail =
+    (item.type === "tool_use" && item.input && Object.keys(item.input).length > 0) ||
+    (item.type === "tool_result" && item.output && item.output.length > 0) ||
+    (item.type === "reasoning" && item.content && item.content.length > 0) ||
+    (item.type === "text" && item.content && item.content.length > 0) ||
+    (item.type === "harness" && item.content && item.content.length > 0) ||
+    (item.type === "error" && item.content && item.content.length > 0);
 
   return (
-    <>
-      <div className="flex items-start gap-2 py-2">
+    <div
+      ref={ref}
+      data-testid="transcript-event-row"
+      className={cn(
+        "group [contain-intrinsic-size:48px] [content-visibility:auto] transition-colors",
+        isSelected && "bg-accent/50",
+      )}
+    >
+      <div className="flex items-start gap-2 px-4 py-2">
         <span
           className={cn(
             "mt-0.5 inline-flex min-w-[60px] shrink-0 items-center justify-center rounded px-1.5 py-0.5 text-[11px] font-medium",
             colorClasses[color].label,
           )}
         >
+          {item.type === "reasoning" && <Brain className="mr-1 h-3 w-3 shrink-0" />}
           {item.type === "error" && <AlertCircle className="mr-1 h-3 w-3 shrink-0" />}
           {label}
         </span>
@@ -828,7 +596,7 @@ function GenericEventRow({
         <button
           type="button"
           disabled={!hasDetail}
-          onClick={onToggle}
+          onClick={() => hasDetail && setExpanded((open) => !open)}
           className={cn(
             "min-w-0 flex-1 rounded py-0.5 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
             hasDetail ? "cursor-pointer hover:text-foreground" : "cursor-default",
@@ -861,63 +629,11 @@ function GenericEventRow({
       </div>
 
       {hasDetail && expanded && (
-        <div data-testid="timeline-event-detail" className="pb-3">
+        <div data-testid="timeline-event-detail" className="px-4 pb-3">
           <div className="ml-[72px] border-l-2 border-border/60">
             <EventDetailContent item={item} />
           </div>
         </div>
-      )}
-    </>
-  );
-}
-
-function TranscriptEventRow({
-  ref,
-  item,
-  isSelected,
-  pairedResult,
-  lane,
-  laneStart,
-}: {
-  ref?: React.Ref<HTMLDivElement>;
-  item: TimelineItem;
-  isSelected: boolean;
-  pairedResult?: TimelineItem;
-  lane: TurnLane;
-  laneStart: boolean;
-}) {
-  const [expanded, setExpanded] = useState(item.type === "reasoning" && item.status === "streaming");
-  const toggle = useCallback(() => setExpanded((open) => !open), []);
-  const date = useMemo(() => (item.created_at ? new Date(item.created_at) : null), [item.created_at]);
-
-  return (
-    <div
-      ref={ref}
-      data-testid="transcript-event-row"
-      className={cn(
-        "group px-4 [contain-intrinsic-size:48px] [content-visibility:auto] transition-colors",
-        isSelected && "bg-accent/50",
-      )}
-    >
-      {lane === "divider" ? (
-        <SystemEventDivider item={item} />
-      ) : (
-        <TurnGroup marker={lane} showMarker={laneStart}>
-          {item.type === "tool_use" || item.type === "tool_result" ? (
-            <ToolCallRow
-              call={item.type === "tool_use" ? item : undefined}
-              result={item.type === "tool_use" ? pairedResult : item}
-              expanded={expanded}
-              onToggle={toggle}
-            />
-          ) : item.type === "reasoning" ? (
-            <ReasoningRow item={item} expanded={expanded} onToggle={toggle} />
-          ) : item.type === "text" ? (
-            <AssistantMessageRow item={item} expanded={expanded} onToggle={toggle} />
-          ) : (
-            <GenericEventRow item={item} expanded={expanded} onToggle={toggle} date={date} />
-          )}
-        </TurnGroup>
       )}
     </div>
   );

--- a/web/src/components/ui.test.tsx
+++ b/web/src/components/ui.test.tsx
@@ -155,14 +155,14 @@ describe("Badge", () => {
 });
 
 describe("Input", () => {
-  it("is h-8 with a tight radius", () => {
+  it("uses the rounded shadowless mockup control style", () => {
     const { getByRole } = render(<Input />);
-    expect(getByRole("textbox")).toHaveClass("h-8", "rounded-md");
+    expect(getByRole("textbox")).toHaveClass("h-8", "rounded-lg", "shadow-none");
   });
 
-  it("has a Vercel-style focus ring", () => {
+  it("uses border-only focus treatment", () => {
     const { getByRole } = render(<Input />);
-    expect(getByRole("textbox")).toHaveClass("focus-visible:ring-2");
+    expect(getByRole("textbox")).toHaveClass("focus-visible:border-ring", "focus-visible:ring-0");
   });
 
   it("uses a neutral background surface instead of transparent dark overlays", () => {
@@ -186,9 +186,9 @@ describe("Input", () => {
 });
 
 describe("Textarea", () => {
-  it("has a Vercel-style focus ring", () => {
+  it("uses border-only focus treatment", () => {
     const { container } = render(<Textarea />);
-    expect(container.firstChild).toHaveClass("focus-visible:ring-2");
+    expect(container.firstChild).toHaveClass("focus-visible:border-ring", "focus-visible:ring-0");
   });
 
   it("exposes sizes and validation variants", () => {
@@ -221,7 +221,7 @@ describe("Select", () => {
       </Select>,
     );
     expect(container.firstChild?.nodeName).toBe("SELECT");
-    expect(container.firstChild).toHaveClass("h-8", "rounded-md");
+    expect(container.firstChild).toHaveClass("h-8", "rounded-lg", "shadow-none");
   });
 
   it("is a controlled-compatible select (forwards value/onChange)", () => {

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -161,7 +161,7 @@ export function Chip({ className, variant, dot, children, ...props }: ChipProps)
 }
 
 const controlBaseClasses =
-  "w-full rounded-md border bg-background text-sm text-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
+  "w-full rounded-lg border bg-background text-sm text-foreground shadow-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50";
 const controlToneVariants = {
   default: "border-input",
   invalid: "border-destructive focus-visible:border-destructive focus-visible:ring-destructive/30",

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -15,6 +15,17 @@ const clockTimeFormatter = new Intl.DateTimeFormat(undefined, {
   minute: "2-digit",
   second: "2-digit",
 });
+const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+const RELATIVE_TIME_DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
+  { amount: 60, unit: "second" },
+  { amount: 60, unit: "minute" },
+  { amount: 24, unit: "hour" },
+  { amount: 7, unit: "day" },
+  { amount: 4.34524, unit: "week" },
+  { amount: 12, unit: "month" },
+  { amount: Number.POSITIVE_INFINITY, unit: "year" },
+];
 
 function toDate(value: string | number | Date): Date {
   return value instanceof Date ? value : new Date(value);
@@ -30,4 +41,18 @@ export function formatCompactDateTime(value: string | number | Date): string {
 
 export function formatClockTime(value: string | number | Date): string {
   return clockTimeFormatter.format(toDate(value));
+}
+
+export function formatRelativeTime(value: string | number | Date | undefined): string {
+  if (value === undefined) return "";
+  const time = toDate(value).getTime();
+  if (Number.isNaN(time)) return "";
+  let delta = (time - Date.now()) / 1000;
+  for (const division of RELATIVE_TIME_DIVISIONS) {
+    if (Math.abs(delta) < division.amount) {
+      return relativeTimeFormatter.format(Math.round(delta), division.unit);
+    }
+    delta /= division.amount;
+  }
+  return "";
 }

--- a/web/src/pages/CredentialBindingsPage.tsx
+++ b/web/src/pages/CredentialBindingsPage.tsx
@@ -249,7 +249,7 @@ export function CredentialBindingsPage() {
           <div className="flex items-center justify-between lg:shrink-0">
             <div>
               <h2 className="text-base font-semibold">Credential library</h2>
-              <p className="mt-0.5 text-xs text-muted-foreground">Bindings 在 preflight 时解析，用于 runtime profiles 和 model providers。</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">Bindings resolve during preflight for Runtime Profiles and Model Providers.</p>
             </div>
             <div className="text-right">
               <span className="text-xl font-semibold">{activeCount}</span>
@@ -616,11 +616,11 @@ export function CredentialBindingsPage() {
               className="rounded-lg border border-border bg-card p-4 shadow-sm"
             >
               <h3 className="text-sm font-medium">Library actions</h3>
-              <p className="mt-1.5 text-xs text-muted-foreground">引用现有密钥源而不在 UI 中存储值，除非选择 literal。</p>
+              <p className="mt-1.5 text-xs text-muted-foreground">Reference existing credential sources without storing values in the UI unless you choose a literal source.</p>
               <Button onClick={startCreate} className="mt-3 w-full">
                 <Plus className="h-4 w-4" /> New binding
               </Button>
-              <p className="mt-3 text-xs text-muted-foreground">优先在 Model providers 页面管理模型 provider API key，当密钥仅用于 LLM 认证时。</p>
+              <p className="mt-3 text-xs text-muted-foreground">Manage Model Provider API keys on the Model Providers page when a credential is used only for LLM authentication.</p>
             </div>
           ) : (
             <SettingsDetailPane

--- a/web/src/pages/ModelProvidersPage.tsx
+++ b/web/src/pages/ModelProvidersPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { LoaderCircle, Plus, RefreshCw, Server, Trash2, X, Zap } from "lucide-react";
 import { apiDelete, apiGet, apiPatch, apiPost, apiPut, ApiError, type CredentialBinding, type ModelProvider } from "@/lib/api";
@@ -95,7 +95,7 @@ export function ModelProvidersPage() {
     }
   }
 
-  async function load() {
+  const load = useCallback(async () => {
     try {
       const [data, credentialData] = await Promise.all([
         apiGet<{ providers: ModelProvider[] }>("/api/model-providers"),
@@ -119,16 +119,16 @@ export function ModelProvidersPage() {
     } catch (e) {
       setError((e as Error).message);
     }
-  }
+  }, [searchParams]);
 
-  async function loadCapabilityCacheStatus() {
+  const loadCapabilityCacheStatus = useCallback(async () => {
     try {
       const status = await apiGet<{ refreshed_at?: string }>("/api/model-capability-cache");
       setCacheRefreshedAt(status.refreshed_at ?? "");
     } catch {
       // Cache status is advisory; the form still works without it.
     }
-  }
+  }, []);
 
   // Initial load. Both async loaders dispatch state updates only after an await;
   // the rule cannot prove that for this canonical fetch-on-mount pattern.
@@ -137,7 +137,7 @@ export function ModelProvidersPage() {
     void load();
     void loadCapabilityCacheStatus();
     /* eslint-enable react-hooks/set-state-in-effect */
-  }, []);
+  }, [load, loadCapabilityCacheStatus]);
 
   useEffect(() => {
     return () => {

--- a/web/src/pages/ModelProvidersPage.tsx
+++ b/web/src/pages/ModelProvidersPage.tsx
@@ -492,7 +492,7 @@ export function ModelProvidersPage() {
             <>
               <section className="rounded-lg border border-border bg-card shadow-sm">
                 <div className="border-b border-border px-4 py-3">
-                  <span className="text-sm font-medium">连接与协议</span>
+                  <span className="text-sm font-medium">Connections and protocols</span>
                 </div>
                 <div className="grid gap-3 p-4 md:grid-cols-2">
                   <div>
@@ -597,7 +597,7 @@ export function ModelProvidersPage() {
                                   [protocol]: e.target.value,
                                 },
                               })}
-                              placeholder="未配置"
+                              placeholder="Not configured"
                               disabled={!enabled}
                               autoComplete="off"
                               spellCheck={false}

--- a/web/src/pages/ProjectDashboardPage.test.tsx
+++ b/web/src/pages/ProjectDashboardPage.test.tsx
@@ -57,6 +57,7 @@ const tasks = {
       project_id: "project-1",
       goal: "Enumerate api.acme.example",
       status: "running",
+      runtime_activity: { liveness: "live", turn_activity: "busy" },
       runner: "pi",
       runtime_profile_id: "profile-1",
       run_controls: {},
@@ -142,7 +143,8 @@ describe("ProjectDashboardPage", () => {
 
     expect(await screen.findByRole("heading", { level: 1, name: "Acme External" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /launch task/i })).toHaveClass("rounded-md", "bg-primary");
-    expect(screen.getByRole("link", { name: /open report/i })).toBeInTheDocument();
+    // Pentest projects get the mockup's outline Open report button in the footer.
+    expect(screen.getByRole("link", { name: /open report/i })).toHaveClass("border-border", "bg-background");
     expect(screen.getByRole("link", { name: "Blackboard" })).toHaveAttribute(
       "href",
       "/projects/project-1/blackboard",
@@ -171,7 +173,7 @@ describe("ProjectDashboardPage", () => {
     const tasksCard = screen.getByRole("link", { name: /view 3 tasks/i });
     expect(tasksCard).toHaveClass("rounded-lg", "border", "bg-card");
     expect(within(tasksCard).getByText("1 运行中")).toBeInTheDocument();
-    expect(within(tasksCard).getByText(/最近：Enumerate api\.acme\.example · 12m ago/)).toBeInTheDocument();
+    expect(within(tasksCard).getByText(/最近：Enumerate api\.acme\.example · .* ago/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /view 8 facts/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /view 1 finding/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /view 5 evidence items/i })).toBeInTheDocument();
@@ -179,10 +181,11 @@ describe("ProjectDashboardPage", () => {
     // Recent activity lists recent tasks with status text and relative time.
     const activity = screen.getByText("Recent activity").closest("section");
     expect(activity).not.toBeNull();
-    expect(activity!).toHaveTextContent("Enumerate api.acme.example — running");
-    expect(activity!).toHaveTextContent("12m ago");
-    expect(activity!).toHaveTextContent("Port scan 203.0.113.10 — completed");
-    expect(activity!).toHaveTextContent("2h ago");
+    expect(activity!).toHaveTextContent("Enumerate api.acme.example — 运行中");
+    expect(activity!).toHaveTextContent("12 minutes ago");
+    expect(activity!).toHaveTextContent("Port scan 203.0.113.10 — 已完成");
+    expect(activity!).toHaveTextContent("2 hours ago");
+    expect(activity!).toHaveTextContent("Fingerprint cdn.acme.example — 已停止");
     expect(within(activity!).getByRole("link", { name: "查看全部" })).toHaveAttribute(
       "href",
       "/projects/project-1/tasks",
@@ -200,7 +203,8 @@ describe("ProjectDashboardPage", () => {
       "/projects/project-1/blackboard",
     );
 
-    expect(screen.getByText("Pentest Project")).toBeInTheDocument();
+    // Project kind is a signal Chip with dot beside the title.
+    expect(screen.getByText("Pentest Project")).toHaveClass("border-signal/25", "bg-signal/10", "text-signal");
   });
 
   it("previews and confirms a blocker-free Project Kind Conversion", async () => {
@@ -231,5 +235,7 @@ describe("ProjectDashboardPage", () => {
     expect(await screen.findByText(/conversion is ready/i)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /confirm conversion/i }));
     expect(await screen.findByText("CTF Challenge Project")).toBeInTheDocument();
+    // The report route does not exist for CTF projects, so the footer button hides.
+    expect(screen.queryByRole("link", { name: /open report/i })).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/ProjectDashboardPage.test.tsx
+++ b/web/src/pages/ProjectDashboardPage.test.tsx
@@ -142,7 +142,10 @@ describe("ProjectDashboardPage", () => {
     renderPage();
 
     expect(await screen.findByRole("heading", { level: 1, name: "Acme External" })).toBeInTheDocument();
-    expect(screen.getByTestId("project-page-shell-header").parentElement).toHaveClass("p-6", "lg:p-8");
+    expect(screen.getByTestId("project-page-shell-header").parentElement).toHaveClass("mx-auto", "max-w-6xl", "px-6", "lg:px-8");
+    // Overview now rides the shared chrome: back link plus section tabs live in
+    // the same sticky plane as every other project tab.
+    expect(screen.getByRole("link", { name: /All projects/i })).toHaveAttribute("href", "/");
     expect(screen.getByRole("link", { name: /launch task/i })).toHaveClass("rounded-md", "bg-primary");
     // Pentest projects get the mockup's outline Open report button in the footer.
     expect(screen.getByRole("link", { name: /open report/i })).toHaveClass("border-border", "bg-background");
@@ -151,9 +154,8 @@ describe("ProjectDashboardPage", () => {
       "/projects/project-1/blackboard",
     );
 
-    // Pill-style project nav with count badges, rendered in page markup.
+    // Shared ProjectNav chrome with count badges from the dashboard payload.
     const nav = screen.getByRole("navigation", { name: /project sections/i });
-    expect(within(nav).getByRole("link", { name: "Overview" })).toHaveClass("bg-secondary", "font-medium");
     expect(within(nav).getByRole("link", { name: /tasks/i })).toHaveTextContent("3");
     expect(within(nav).getByRole("link", { name: /evidence/i })).toHaveTextContent("5");
     expect(within(nav).getByRole("link", { name: /findings/i })).toHaveTextContent("1");

--- a/web/src/pages/ProjectDashboardPage.test.tsx
+++ b/web/src/pages/ProjectDashboardPage.test.tsx
@@ -142,6 +142,7 @@ describe("ProjectDashboardPage", () => {
     renderPage();
 
     expect(await screen.findByRole("heading", { level: 1, name: "Acme External" })).toBeInTheDocument();
+    expect(screen.getByTestId("project-page-shell-header").parentElement).toHaveClass("p-6", "lg:p-8");
     expect(screen.getByRole("link", { name: /launch task/i })).toHaveClass("rounded-md", "bg-primary");
     // Pentest projects get the mockup's outline Open report button in the footer.
     expect(screen.getByRole("link", { name: /open report/i })).toHaveClass("border-border", "bg-background");
@@ -160,11 +161,11 @@ describe("ProjectDashboardPage", () => {
     // Scope readiness checklist (scope is incomplete in this fixture).
     const scope = screen.getByRole("region", { name: /scope readiness/i });
     expect(scope).toHaveClass("rounded-lg", "border-warning/30");
-    expect(scope).toHaveTextContent("2 / 3 项完成");
-    expect(scope).toHaveTextContent("添加至少一个 in-scope 资产");
+    expect(scope).toHaveTextContent("2 / 3 complete");
+    expect(scope).toHaveTextContent("Add at least one in-scope asset");
     expect(scope).toHaveTextContent("Scope notes");
     expect(scope).toHaveTextContent("Testing limits");
-    expect(within(scope).getByRole("link", { name: /添加资产/ })).toHaveAttribute(
+    expect(within(scope).getByRole("link", { name: /add asset/i })).toHaveAttribute(
       "href",
       "/projects/project-1/scope",
     );
@@ -172,8 +173,9 @@ describe("ProjectDashboardPage", () => {
     // Stat cards link to their sections; the Tasks card carries a running chip.
     const tasksCard = screen.getByRole("link", { name: /view 3 tasks/i });
     expect(tasksCard).toHaveClass("rounded-lg", "border", "bg-card");
-    expect(within(tasksCard).getByText("1 运行中")).toBeInTheDocument();
-    expect(within(tasksCard).getByText(/最近：Enumerate api\.acme\.example · .* ago/)).toBeInTheDocument();
+    expect(within(tasksCard).getByText("1 running")).toBeInTheDocument();
+    expect(tasksCard).toHaveClass("min-w-0", "overflow-hidden");
+    expect(within(tasksCard).getByText(/Latest: Enumerate api\.acme\.example · .* ago/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /view 8 facts/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /view 1 finding/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /view 5 evidence items/i })).toBeInTheDocument();
@@ -181,12 +183,13 @@ describe("ProjectDashboardPage", () => {
     // Recent activity lists recent tasks with status text and relative time.
     const activity = screen.getByText("Recent activity").closest("section");
     expect(activity).not.toBeNull();
-    expect(activity!).toHaveTextContent("Enumerate api.acme.example — 运行中");
+    expect(activity!).toHaveClass("min-w-0");
+    expect(activity!).toHaveTextContent("Enumerate api.acme.example — Running");
     expect(activity!).toHaveTextContent("12 minutes ago");
-    expect(activity!).toHaveTextContent("Port scan 203.0.113.10 — 已完成");
+    expect(activity!).toHaveTextContent("Port scan 203.0.113.10 — Completed");
     expect(activity!).toHaveTextContent("2 hours ago");
-    expect(activity!).toHaveTextContent("Fingerprint cdn.acme.example — 已停止");
-    expect(within(activity!).getByRole("link", { name: "查看全部" })).toHaveAttribute(
+    expect(activity!).toHaveTextContent("Fingerprint cdn.acme.example — Stopped");
+    expect(within(activity!).getByRole("link", { name: "View all" })).toHaveAttribute(
       "href",
       "/projects/project-1/tasks",
     );
@@ -194,11 +197,12 @@ describe("ProjectDashboardPage", () => {
     // Current work summarizes open work and links into the Blackboard.
     const currentWork = screen.getByText("Current work").closest("section");
     expect(currentWork).not.toBeNull();
+    expect(currentWork!).toHaveClass("min-w-0");
     expect(currentWork!).toHaveTextContent("Exploration objectives");
-    expect(currentWork!).toHaveTextContent("1 开放");
-    expect(currentWork!).toHaveTextContent("1 进行中");
+    expect(currentWork!).toHaveTextContent("1 open");
+    expect(currentWork!).toHaveTextContent("1 in progress");
     expect(currentWork!).toHaveTextContent("1 current");
-    expect(within(currentWork!).getByRole("link", { name: /打开 Blackboard/ })).toHaveAttribute(
+    expect(within(currentWork!).getByRole("link", { name: /open Blackboard/i })).toHaveAttribute(
       "href",
       "/projects/project-1/blackboard",
     );

--- a/web/src/pages/ProjectDashboardPage.tsx
+++ b/web/src/pages/ProjectDashboardPage.tsx
@@ -132,20 +132,20 @@ export function ProjectDashboardPage() {
     {
       id: "assets",
       done: namedAssets > 0,
-      label: "添加至少一个 in-scope 资产（domain / IP / CIDR / URL），否则 task 结果不可依赖",
-      action: { label: "添加资产", to: `${base}/scope` },
+      label: "Add at least one in-scope asset (domain, IP, CIDR, or URL) before relying on Task results.",
+      action: { label: "Add asset", to: `${base}/scope` },
     },
     {
       id: "notes",
       done: dash.scope.has_notes,
       optional: true,
-      label: "可选：填写 Scope notes 说明授权边界",
+      label: "Optional: add Scope notes that explain the authorization boundary.",
     },
     {
       id: "limits",
       done: dash.scope.has_testing_limits,
       optional: true,
-      label: "可选：设置 Testing limits 约束测试窗口",
+      label: "Optional: define Testing limits for the permitted testing window.",
     },
   ];
   const completedCount = checklistItems.filter((item) => item.done).length;
@@ -220,9 +220,10 @@ export function ProjectDashboardPage() {
           <Rocket className="h-4 w-4" /> Launch task
         </Link>
       }
-      bodyClassName="space-y-5"
+      bodyClassName="min-w-0 max-w-full space-y-5"
+      contentClassName="min-w-0 max-w-full p-6 lg:p-8"
     >
-      <nav aria-label="Project sections" className="flex flex-wrap gap-1 text-sm">
+      <nav aria-label="Project sections" className="flex min-w-0 max-w-full flex-wrap gap-1 text-sm">
         {navItems.map((item) => (
           <NavLink
             key={item.to}
@@ -254,7 +255,7 @@ export function ProjectDashboardPage() {
               <AlertTriangle className="h-4 w-4 text-warning" /> Scope readiness
             </div>
             <span className="text-xs font-medium text-[hsl(28_90%_32%)]">
-              {completedCount} / {checklistItems.length} 项完成
+              {completedCount} / {checklistItems.length} complete
             </span>
           </div>
           <div className="px-4 py-3.5">
@@ -290,14 +291,14 @@ export function ProjectDashboardPage() {
         </section>
       )}
 
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <div className="grid min-w-0 max-w-full grid-cols-2 gap-3 lg:grid-cols-4">
         <StatCard
           icon={<ListChecks className="h-3.5 w-3.5" />}
           label="Tasks"
           n={dash.counts.tasks}
           to={`${base}/tasks`}
-          chip={runningCount > 0 ? `${runningCount} 运行中` : undefined}
-          sub={latestTask ? `最近：${latestTask.goal} · ${formatRelativeTime(latestTask.updated_at)}` : undefined}
+          chip={runningCount > 0 ? `${runningCount} running` : undefined}
+          sub={latestTask ? `Latest: ${latestTask.goal} · ${formatRelativeTime(latestTask.updated_at)}` : undefined}
         />
         <StatCard icon={<FileText className="h-3.5 w-3.5" />} label="Facts" n={dash.counts.facts} to={`${base}/facts`} />
         <StatCard
@@ -305,20 +306,20 @@ export function ProjectDashboardPage() {
           label="Findings"
           n={dash.counts.findings}
           to={`${base}/findings`}
-          zeroHint="尚无 Finding — 从 Task 结论中产生"
+          zeroHint="No Findings yet — generated from Task conclusions"
         />
         <StatCard icon={<FolderLock className="h-3.5 w-3.5" />} label="Evidence" n={dash.counts.evidence} to={`${base}/evidence`} />
       </div>
 
-      <div className="grid gap-5 lg:grid-cols-5">
+      <div className="grid min-w-0 max-w-full gap-5 lg:grid-cols-5">
         <section
           aria-labelledby="recent-activity-title"
-          className="rounded-lg border border-border bg-card shadow-sm lg:col-span-3"
+          className="min-w-0 rounded-lg border border-border bg-card shadow-sm lg:col-span-3"
         >
           <div className="flex items-center justify-between border-b border-border px-4 py-3">
             <span id="recent-activity-title" className="text-sm font-medium">Recent activity</span>
             <Link to={`${base}/tasks`} className="text-xs text-muted-foreground hover:text-foreground">
-              查看全部
+              View all
             </Link>
           </div>
           {recentTasks.length === 0 ? (
@@ -342,7 +343,7 @@ export function ProjectDashboardPage() {
 
         <section
           aria-labelledby="current-work-title"
-          className="rounded-lg border border-border bg-card shadow-sm lg:col-span-2"
+          className="min-w-0 rounded-lg border border-border bg-card shadow-sm lg:col-span-2"
         >
           <div className="border-b border-border px-4 py-3">
             <span id="current-work-title" className="text-sm font-medium">Current work</span>
@@ -352,13 +353,13 @@ export function ProjectDashboardPage() {
               <span className="flex items-center gap-2">
                 <Compass className="h-4 w-4 text-muted-foreground" /> Exploration objectives
               </span>
-              <span className="font-semibold">{openTaskCount} 开放</span>
+              <span className="font-semibold">{openTaskCount} open</span>
             </div>
             <div className="flex items-center justify-between">
               <span className="flex items-center gap-2">
                 <FlaskConical className="h-4 w-4 text-muted-foreground" /> Attempts
               </span>
-              <span className="font-semibold">{runningCount} 进行中</span>
+              <span className="font-semibold">{runningCount} in progress</span>
             </div>
             <div className="flex items-center justify-between">
               <span className="flex items-center gap-2">
@@ -371,13 +372,13 @@ export function ProjectDashboardPage() {
               to={`${base}/blackboard`}
               className="mt-1 flex h-8 items-center justify-center gap-1.5 rounded-md border border-border text-xs font-medium hover:bg-muted"
             >
-              <LayoutGrid className="h-3.5 w-3.5" /> 打开 Blackboard
+              <LayoutGrid className="h-3.5 w-3.5" /> Open Blackboard
             </Link>
           </div>
         </section>
       </div>
 
-      <Card role="region" aria-labelledby="project-kind-title" className="gap-4">
+      <Card role="region" aria-labelledby="project-kind-title" className="min-w-0 gap-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <CardTitle id="project-kind-title">Project kind</CardTitle>
@@ -465,7 +466,7 @@ function StatCard({
       to={to}
       aria-label={`View ${n} ${countLabel(label, n)}`}
       className={cn(
-        "group rounded-lg border p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "group min-w-0 overflow-hidden rounded-lg border p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         empty
           ? "border-dashed border-border bg-card/50 hover:border-ring"
           : "border-border bg-card shadow-sm hover:border-ring",
@@ -515,30 +516,25 @@ function statusDotClass(status: string): string {
   }
 }
 
-/**
- * Chinese state phrase for the activity feed, mapped from Task status plus the
- * live Runtime Activity signal: a live runtime that is busy reads 运行中, live
- * and idle reads 空闲，等待输入; otherwise the durable lifecycle wins.
- */
+/** Maps durable Task state and live Runtime Activity to operator-facing text. */
 function activityStatusText(task: Task): string {
   const activity = task.runtime_activity;
   if (activity?.liveness === "live") {
-    return activity.turn_activity === "busy" ? "运行中" : "空闲，等待输入";
+    return activity.turn_activity === "busy" ? "Running" : "Idle, awaiting input";
   }
   switch (task.status) {
     case "running":
-      return "运行中";
+      return "Running";
     case "completed":
-      return "已完成";
+      return "Completed";
     case "failed":
-      return "失败";
+      return "Failed";
     case "paused":
-      return "已暂停";
+      return "Paused";
     case "pending":
-      return "排队中";
+      return "Queued";
     default:
-      // stopped / interrupted, or a non-live (offline/orphaned) runtime.
-      return "已停止";
+      return "Stopped";
   }
 }
 

--- a/web/src/pages/ProjectDashboardPage.tsx
+++ b/web/src/pages/ProjectDashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, NavLink, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import {
   AlertTriangle,
   ArrowUpRight,
@@ -12,13 +12,12 @@ import {
   FolderLock,
   LayoutGrid,
   ListChecks,
-  Plus,
   RefreshCw,
+  Plus,
   Rocket,
 } from "lucide-react";
 import { apiGet, apiPost, type Dashboard, type Project, type ProjectKind, type Task } from "@/lib/api";
 import { ProjectPageShell } from "@/components/ProjectPageShell";
-import { BackLink } from "@/components/shared";
 import { Button, buttonVariants, Card, CardDescription, CardTitle, Chip } from "@/components/ui";
 import { formatRelativeTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -100,22 +99,9 @@ export function ProjectDashboardPage() {
   const projectKindLabel = project.kind === "ctf_challenge" ? "CTF Challenge Project" : "Pentest Project";
   const targetKind: ProjectKind = project.kind === "ctf_challenge" ? "pentest" : "ctf_challenge";
 
-  // Direction A pill tabs rendered in page markup: ProjectNav is shared chrome
-  // and cannot carry live count badges, so the dashboard ships its own nav in
-  // the same item order (Overview → Tasks → Blackboard → Findings|Solution →
-  // Evidence → Report? → Scope).
+  // Count badges on the section tabs come from the shared ProjectNav chrome,
+  // so the dashboard renders no second nav (keeps every tab on one plane).
   const isCTF = project.kind === "ctf_challenge";
-  const navItems: { to: string; label: string; end?: boolean; count?: number }[] = [
-    { to: "", label: "Overview", end: true },
-    { to: "/tasks", label: "Tasks", count: dash.counts.tasks },
-    { to: "/blackboard", label: "Blackboard" },
-    isCTF
-      ? { to: "/solution", label: "Solution" }
-      : { to: "/findings", label: "Findings", count: dash.counts.findings },
-    { to: "/evidence", label: "Evidence", count: dash.counts.evidence },
-    ...(!isCTF ? [{ to: "/report", label: "Report" }] : []),
-    { to: "/scope", label: "Scope" },
-  ];
 
   // Scope readiness checklist derived from the scope summary the dashboard
   // already loads: one required item (at least one named in-scope asset — the
@@ -199,17 +185,13 @@ export function ProjectDashboardPage() {
 
   return (
     <ProjectPageShell
-      hideChrome
       title={
         <div>
-          <BackLink to="/" className="mb-2 w-fit">
-            All projects
-          </BackLink>
           <p className="mb-1 font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
             Engagement
           </p>
           <div className="mt-0.5 flex flex-wrap items-center gap-3">
-            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{project.name}</h1>
+            <h1 className="text-2xl font-semibold tracking-tight">{project.name}</h1>
             <Chip variant="signal" dot>{projectKindLabel}</Chip>
           </div>
         </div>
@@ -221,28 +203,8 @@ export function ProjectDashboardPage() {
         </Link>
       }
       bodyClassName="min-w-0 max-w-full space-y-5"
-      contentClassName="min-w-0 max-w-full p-6 lg:p-8"
+      contentClassName="mx-auto min-w-0 max-w-6xl px-6 pb-6 lg:px-8 lg:pb-8"
     >
-      <nav aria-label="Project sections" className="flex min-w-0 max-w-full flex-wrap gap-1 text-sm">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={`${base}${item.to}`}
-            end={item.end}
-            className={({ isActive }) =>
-              cn(
-                "rounded-md px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                isActive ? "bg-secondary font-medium" : "text-muted-foreground hover:bg-muted",
-              )
-            }
-          >
-            {item.label}
-            {item.count != null && item.count > 0 && (
-              <span className="ml-1 rounded-sm bg-muted px-1 text-[10px]">{item.count}</span>
-            )}
-          </NavLink>
-        ))}
-      </nav>
 
       {!scopeReady && (
         <section

--- a/web/src/pages/ProjectDashboardPage.tsx
+++ b/web/src/pages/ProjectDashboardPage.tsx
@@ -19,8 +19,8 @@ import {
 import { apiGet, apiPost, type Dashboard, type Project, type ProjectKind, type Task } from "@/lib/api";
 import { ProjectPageShell } from "@/components/ProjectPageShell";
 import { BackLink } from "@/components/shared";
-import { Badge, Button, buttonVariants, Card, CardDescription, CardTitle, Chip } from "@/components/ui";
-import { formatCompactDateTime } from "@/lib/format";
+import { Button, buttonVariants, Card, CardDescription, CardTitle, Chip } from "@/components/ui";
+import { formatRelativeTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 /** Lifecycle states whose Task is still open work. Mirrors TasksPage's ACTIVE set plus pending. */
@@ -208,8 +208,10 @@ export function ProjectDashboardPage() {
           <p className="mb-1 font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
             Engagement
           </p>
-          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{project.name}</h1>
-          <Badge variant="outline" className="mt-2 w-fit">{projectKindLabel}</Badge>
+          <div className="mt-0.5 flex flex-wrap items-center gap-3">
+            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{project.name}</h1>
+            <Chip variant="signal" dot>{projectKindLabel}</Chip>
+          </div>
         </div>
       }
       description={project.description || undefined}
@@ -327,7 +329,7 @@ export function ProjectDashboardPage() {
                 <li key={task.id} className="flex items-center gap-3 px-4 py-2.5">
                   <span className={cn("h-1.5 w-1.5 flex-none rounded-full", statusDotClass(task.status))} />
                   <span className="min-w-0 flex-1 truncate">
-                    {task.goal} — {task.status}
+                    {task.goal} — {activityStatusText(task)}
                   </span>
                   <span className="flex-none text-xs text-muted-foreground">
                     {formatRelativeTime(task.updated_at)}
@@ -408,11 +410,13 @@ export function ProjectDashboardPage() {
         )}
       </Card>
 
-      <div className="flex flex-wrap items-center gap-2 border-t border-border/60 pt-6">
-        <Link to={`${base}/report`} className={buttonVariants({ variant: "secondary", size: "sm" })}>
-          <ClipboardList className="h-4 w-4" /> Open report
-        </Link>
-      </div>
+      {!isCTF && (
+        <div className="flex flex-wrap items-center gap-2 border-t border-border/60 pt-6">
+          <Link to={`${base}/report`} className={buttonVariants({ variant: "outline", size: "sm" })}>
+            <ClipboardList className="h-4 w-4" /> Open report
+          </Link>
+        </div>
+      )}
     </ProjectPageShell>
   );
 }
@@ -511,20 +515,33 @@ function statusDotClass(status: string): string {
   }
 }
 
-/** Compact relative timestamp for the activity feed (e.g. "12m ago"). */
-function formatRelativeTime(value: string): string {
-  const time = Date.parse(value);
-  if (Number.isNaN(time)) return "";
-  const diffMs = Date.now() - time;
-  const minutes = Math.floor(diffMs / 60_000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return formatCompactDateTime(time);
+/**
+ * Chinese state phrase for the activity feed, mapped from Task status plus the
+ * live Runtime Activity signal: a live runtime that is busy reads 运行中, live
+ * and idle reads 空闲，等待输入; otherwise the durable lifecycle wins.
+ */
+function activityStatusText(task: Task): string {
+  const activity = task.runtime_activity;
+  if (activity?.liveness === "live") {
+    return activity.turn_activity === "busy" ? "运行中" : "空闲，等待输入";
+  }
+  switch (task.status) {
+    case "running":
+      return "运行中";
+    case "completed":
+      return "已完成";
+    case "failed":
+      return "失败";
+    case "paused":
+      return "已暂停";
+    case "pending":
+      return "排队中";
+    default:
+      // stopped / interrupted, or a non-live (offline/orphaned) runtime.
+      return "已停止";
+  }
 }
+
 
 function countLabel(label: string, count: number) {
   if (label === "Evidence") return count === 1 ? "evidence item" : "evidence items";

--- a/web/src/pages/RuntimeProfilesPage.test.tsx
+++ b/web/src/pages/RuntimeProfilesPage.test.tsx
@@ -189,7 +189,8 @@ describe("RuntimeProfilesPage", () => {
     expect(layout).toHaveClass(
       "grid",
       "min-w-0",
-      "lg:grid-cols-[minmax(220px,280px)_minmax(0,1fr)]",
+      "gap-0",
+      "lg:grid-cols-[320px_minmax(0,1fr)]",
       "lg:min-h-0",
       "lg:flex-1",
     );
@@ -199,11 +200,13 @@ describe("RuntimeProfilesPage", () => {
       "lg:min-h-0",
       "lg:overflow-hidden",
     );
+    expect(screen.getByTestId("runtime-profiles-settings-list")).toHaveClass("border-r", "bg-card");
     expect(screen.getByTestId("runtime-profiles-settings-detail")).toHaveClass(
       "min-w-0",
       "lg:min-h-0",
       "lg:overflow-hidden",
     );
+    expect(screen.getByTestId("runtime-profiles-settings-detail")).toHaveClass("rounded-none", "border-0", "shadow-none");
 
     const profileButton = await screen.findByRole("button", { name: /Codex Layout/i });
     expect(profileButton).toHaveAttribute("aria-current", "true");

--- a/web/src/pages/RuntimeProfilesPage.test.tsx
+++ b/web/src/pages/RuntimeProfilesPage.test.tsx
@@ -186,6 +186,7 @@ describe("RuntimeProfilesPage", () => {
     renderPage();
 
     const layout = await screen.findByTestId("runtime-profiles-settings-layout");
+    expect(screen.getByTestId("runtime-profiles-page")).toHaveClass("mx-auto", "max-w-6xl");
     expect(layout).toHaveClass(
       "grid",
       "min-w-0",

--- a/web/src/pages/RuntimeProfilesPage.tsx
+++ b/web/src/pages/RuntimeProfilesPage.tsx
@@ -446,7 +446,7 @@ export function RuntimeProfilesPage() {
   }
 
   return (
-    <SettingsPageShell className="max-w-none gap-0 p-0 lg:overflow-hidden lg:p-0">
+    <SettingsPageShell data-testid="runtime-profiles-page" className="mx-auto max-w-6xl gap-0 p-0 lg:overflow-hidden lg:p-0">
       <header className="flex-none border-b border-border px-6 py-5 lg:px-8">
         <SettingsPageHeader
           className="mb-0"

--- a/web/src/pages/RuntimeProfilesPage.tsx
+++ b/web/src/pages/RuntimeProfilesPage.tsx
@@ -446,9 +446,10 @@ export function RuntimeProfilesPage() {
   }
 
   return (
-    <SettingsPageShell>
-      <SettingsPageHeader
-        className="mb-4 shrink-0"
+    <SettingsPageShell className="max-w-none gap-0 p-0 lg:overflow-hidden lg:p-0">
+      <header className="flex-none border-b border-border px-6 py-5 lg:px-8">
+        <SettingsPageHeader
+          className="mb-0"
         title="Runtime profiles"
         eyebrow="Configuration"
         actions={
@@ -465,30 +466,22 @@ export function RuntimeProfilesPage() {
           </Button>
         }
       />
-      <div className="mb-3 shrink-0 rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
-        Runtime Profiles are user-created advanced configurations for MCP, Skills, extensions, and Runtime settings. Direct launches do not create Profiles.
-      </div>
+      </header>
 
-      {error && <SettingsAlert className="mb-3 shrink-0">{error}</SettingsAlert>}
+      {error && <SettingsAlert className="mx-4 my-3 shrink-0 lg:mx-6">{error}</SettingsAlert>}
 
-      <SettingsSplitLayout data-testid="runtime-profiles-settings-layout" fill>
-        <SettingsListColumn data-testid="runtime-profiles-settings-list">
-          <SettingsPanel className="gap-3 p-3 lg:shrink-0">
+      <SettingsSplitLayout
+        data-testid="runtime-profiles-settings-layout"
+        className="gap-0 lg:grid-cols-[320px_minmax(0,1fr)]"
+        fill
+      >
+        <SettingsListColumn className="gap-0 border-r border-border bg-card" data-testid="runtime-profiles-settings-list">
+          <SettingsPanel className="gap-2 rounded-none border-0 border-b border-border p-4 shadow-none lg:shrink-0">
             <div className="flex items-center justify-between gap-2">
-              <div>
-                <p className="text-sm font-medium">Profiles</p>
-                <p className="mt-0.5 text-[11px] text-muted-foreground">
-                  Select a user-created Runtime Profile
-                </p>
-              </div>
-              <div className="shrink-0 text-right tabular-nums">
-                <span className="text-lg font-semibold tracking-tight">
-                  {normalizedProfileQuery ? visibleProfileCount : profiles.length}
-                </span>
-                <span className="ml-1 text-[11px] text-muted-foreground">
-                  {normalizedProfileQuery ? `of ${profiles.length}` : "total"}
-                </span>
-              </div>
+              <p className="text-[13px] font-medium">Profiles</p>
+              <p className="text-[11px] text-muted-foreground tabular-nums">
+                {normalizedProfileQuery ? `${visibleProfileCount} of ${profiles.length}` : `${profiles.length} total`}
+              </p>
             </div>
             <div className="flex h-8 items-center gap-2 rounded-md border border-input bg-background px-2">
               <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
@@ -503,7 +496,7 @@ export function RuntimeProfilesPage() {
             </div>
           </SettingsPanel>
 
-          <SettingsScrollPanel>
+          <SettingsScrollPanel className="rounded-none border-0 shadow-none">
             <div className="space-y-3">
               {providerIds.map((provider) => {
                 const items = filteredGrouped.get(provider) ?? [];
@@ -545,7 +538,8 @@ export function RuntimeProfilesPage() {
         {creating ? (
           <SettingsDetailPane
             data-testid="runtime-profiles-settings-detail"
-            bodyClassName="px-6"
+            className="rounded-none border-0 shadow-none"
+            bodyClassName="px-6 py-5"
             header={
               <div className="min-w-0">
                 <h3 className="font-medium">New profile</h3>
@@ -581,7 +575,8 @@ export function RuntimeProfilesPage() {
         ) : selected && draft ? (
           <SettingsDetailPane
             data-testid="runtime-profiles-settings-detail"
-            bodyClassName="px-6"
+            className="rounded-none border-0 shadow-none"
+            bodyClassName="px-6 py-5"
             header={
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="min-w-0">
@@ -659,7 +654,7 @@ export function RuntimeProfilesPage() {
         ) : (
           <SettingsDetailPane
             data-testid="runtime-profiles-settings-detail"
-            empty
+            className="rounded-none border-0 shadow-none"
             emptyContent="Select a profile or create a new one."
           />
         )}
@@ -985,7 +980,7 @@ function ProfileEditor({
       {title && <h3 className="font-medium">{title}</h3>}
       <section className="rounded-lg border border-border bg-card shadow-sm">
         <div className="border-b border-border px-4 py-3">
-          <span className="text-sm font-medium">基本与模型</span>
+          <span className="text-sm font-medium">Basics and model</span>
         </div>
         <div className="grid grid-cols-2 gap-x-4 gap-y-4 p-4">
         <div>
@@ -1186,7 +1181,7 @@ function ProfileEditor({
       </section>
       <section className="rounded-lg border border-border bg-card shadow-sm">
         <div className="border-b border-border px-4 py-3">
-          <span className="text-sm font-medium">环境与高级</span>
+          <span className="text-sm font-medium">Environment and advanced</span>
         </div>
         <div className="grid grid-cols-2 gap-x-4 gap-y-4 p-4">
         {has("custom_args") && <div className="col-span-2">
@@ -1492,7 +1487,7 @@ function ProfileEditor({
       </section>
       {form.provider === "claude_code" && form.endpoint.includes("bigmodel.cn") && (
         <div className="space-y-1 rounded-lg border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
-          <p className="font-medium text-foreground">智谱 GLM runtime notes</p>
+          <p className="font-medium text-foreground">Zhipu GLM runtime notes</p>
           <p>Endpoint: use <code className="text-[11px]">https://open.bigmodel.cn/api/anthropic</code> (not Minimax).</p>
           <p>Launch adds <code className="text-[11px]">--strict-mcp-config --mcp-config workdir/.mcp.json</code>; smoke may need <code className="text-[11px]">--permission-mode bypassPermissions</code> in custom args.</p>
           <p>Third-party APIs may not expose local MCP tools in the model tool list — allow JSON-RPC fallback to PENTEST_MCP_URL.</p>

--- a/web/src/pages/RuntimeProfilesPage.tsx
+++ b/web/src/pages/RuntimeProfilesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { CheckCircle2, Plus, Trash2 } from "lucide-react";
+import { CheckCircle2, Plus, Search, Trash2 } from "lucide-react";
 import { apiGet, apiPost, apiPatch, apiDelete, mergedConfigPreview, projectedConfig, type ModelProvider, type RuntimeExtension, type RuntimeExtensionCatalogItem, type RuntimePlugin, type RuntimeProfile } from "@/lib/api";
 import { ModelProviderMigrationPanel } from "@/pages/ModelProviderMigrationPanel";
 import { codexMultiAgentTOMLLines, enrichPreviewWithModelProvider } from "@/pages/runtimeProfilePreview";
@@ -175,6 +175,7 @@ export function RuntimeProfilesPage() {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [form, setForm] = useState<ProfileForm>(emptyForm);
   const [draft, setDraft] = useState<ProfileForm | null>(null);
+  const [profileQuery, setProfileQuery] = useState("");
 
   const selected = profiles.find((p) => p.id === selectedId) ?? null;
   const fallbackPlugins = useMemo(() => fallbackRuntimePlugins(), []);
@@ -197,6 +198,29 @@ export function RuntimeProfilesPage() {
     }
     return buckets;
   }, [profiles, providerIds]);
+
+  const normalizedProfileQuery = profileQuery.trim().toLowerCase();
+  const filteredGrouped = useMemo(() => {
+    if (!normalizedProfileQuery) return grouped;
+    const buckets = new Map<string, RuntimeProfile[]>();
+    for (const [provider, items] of grouped) {
+      buckets.set(
+        provider,
+        items.filter((profile) =>
+          [
+            profile.name,
+            pluginLabel(effectivePlugins, profile.provider),
+            profileListModelHint(profile.fields, modelProviders) ?? "",
+          ].some((value) => value.toLowerCase().includes(normalizedProfileQuery)),
+        ),
+      );
+    }
+    return buckets;
+  }, [grouped, normalizedProfileQuery, effectivePlugins, modelProviders]);
+  const visibleProfileCount = useMemo(
+    () => Array.from(filteredGrouped.values()).reduce((sum, items) => sum + items.length, 0),
+    [filteredGrouped],
+  );
 
   async function load() {
     try {
@@ -458,16 +482,31 @@ export function RuntimeProfilesPage() {
                 </p>
               </div>
               <div className="shrink-0 text-right tabular-nums">
-                <span className="text-lg font-semibold tracking-tight">{profiles.length}</span>
-                <span className="ml-1 text-[11px] text-muted-foreground">total</span>
+                <span className="text-lg font-semibold tracking-tight">
+                  {normalizedProfileQuery ? visibleProfileCount : profiles.length}
+                </span>
+                <span className="ml-1 text-[11px] text-muted-foreground">
+                  {normalizedProfileQuery ? `of ${profiles.length}` : "total"}
+                </span>
               </div>
+            </div>
+            <div className="flex h-8 items-center gap-2 rounded-md border border-input bg-background px-2">
+              <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <input
+                type="search"
+                aria-label="Filter runtime profiles"
+                placeholder="Search name, provider, model…"
+                value={profileQuery}
+                onChange={(event) => setProfileQuery(event.target.value)}
+                className="w-full bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+              />
             </div>
           </SettingsPanel>
 
           <SettingsScrollPanel>
             <div className="space-y-3">
               {providerIds.map((provider) => {
-                const items = grouped.get(provider) ?? [];
+                const items = filteredGrouped.get(provider) ?? [];
                 if (items.length === 0) return null;
                 return (
                   <div key={provider}>
@@ -493,6 +532,11 @@ export function RuntimeProfilesPage() {
               })}
               {profiles.length === 0 && (
                 <p className="px-1 text-sm text-muted-foreground">No profiles yet. Add one to get started.</p>
+              )}
+              {profiles.length > 0 && visibleProfileCount === 0 && (
+                <p className="px-1 text-sm text-muted-foreground">
+                  No profiles match &quot;{profileQuery.trim()}&quot;.
+                </p>
               )}
             </div>
           </SettingsScrollPanel>
@@ -1127,9 +1171,15 @@ function ProfileEditor({
               <Chip variant="neutral">{plugin.id}</Chip>
               <Chip variant="neutral">{plugin.config_projection.primitive}</Chip>
               <Chip variant="neutral">{plugin.transcript.parser}</Chip>
-              {plugin.capabilities.sandbox && <Chip variant="signal">sandbox</Chip>}
-              {plugin.capabilities.host && <Chip variant="signal">host</Chip>}
-              {plugin.capabilities.mcp_config && <Chip variant="signal">mcp</Chip>}
+              {plugin.capabilities.sandbox && (
+                <Chip className="border-transparent bg-primary text-primary-foreground">sandbox</Chip>
+              )}
+              {plugin.capabilities.host && (
+                <Chip className="border-transparent bg-primary text-primary-foreground">host</Chip>
+              )}
+              {plugin.capabilities.mcp_config && (
+                <Chip className="border-transparent bg-primary text-primary-foreground">mcp</Chip>
+              )}
             </div>
           </div>
         )}

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -99,7 +99,7 @@ describe("SessionDetailPage", () => {
     );
 
     expect(await screen.findByTestId("task-session-header")).toHaveTextContent("Reuse the task workspace");
-    expect(screen.getByTestId("task-detail-shell")).toHaveClass("w-full", "max-w-none", "p-0", "lg:p-0");
+    expect(screen.getByTestId("task-detail-shell")).toHaveClass("mx-auto", "w-full", "max-w-6xl", "p-0", "lg:p-0");
     expect(screen.getByTestId("task-workspace")).toBeInTheDocument();
     expect(screen.getByTestId("task-composer")).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Session message" })).toBeInTheDocument();

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -99,6 +99,7 @@ describe("SessionDetailPage", () => {
     );
 
     expect(await screen.findByTestId("task-session-header")).toHaveTextContent("Reuse the task workspace");
+    expect(screen.getByTestId("task-detail-shell")).toHaveClass("w-full", "max-w-none", "p-0", "lg:p-0");
     expect(screen.getByTestId("task-workspace")).toBeInTheDocument();
     expect(screen.getByTestId("task-composer")).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Session message" })).toBeInTheDocument();

--- a/web/src/pages/SessionHomePage.test.tsx
+++ b/web/src/pages/SessionHomePage.test.tsx
@@ -83,13 +83,13 @@ describe("SessionHomePage", () => {
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    await user.type(screen.getByLabelText("Initial input"), "Inspect the standalone target");
+    await user.type(screen.getByLabelText("你想探索什么？"), "Inspect the standalone target");
     await user.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
-    const mode = screen.getByLabelText("Blackboard conclusions");
-    expect(screen.getByRole("option", { name: "Disabled" })).toBeEnabled();
-    await user.selectOptions(mode, "disabled");
+    const disabledCard = screen.getByRole("radio", { name: /^disabled/i });
+    expect(disabledCard).toBeEnabled();
+    await user.click(disabledCard);
     expect(screen.getByText(/does not receive Blackboard state or Blackboard access/i)).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /create session/i }));
+    await user.click(screen.getByRole("button", { name: /launch session/i }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -128,11 +128,11 @@ describe("SessionHomePage", () => {
     expect(screen.getByLabelText("Reasoning effort")).toBeInTheDocument();
     expect(screen.queryByLabelText("Runtime profile")).not.toBeInTheDocument();
 
-    await user.type(screen.getByLabelText("Initial input"), "Inspect the standalone target");
-await user.click(screen.getByRole("button", { name: "xhigh" }));
+    await user.type(screen.getByLabelText("你想探索什么？"), "Inspect the standalone target");
+    await user.click(screen.getByRole("button", { name: "xhigh" }));
     await user.click(screen.getByRole("button", { name: /blackboard conclusions/i }));
-    await user.selectOptions(screen.getByLabelText("Blackboard conclusions"), "assisted");
-    await user.click(screen.getByRole("button", { name: /create session/i }));
+    await user.click(screen.getByRole("radio", { name: /^assisted/i }));
+    await user.click(screen.getByRole("button", { name: /launch session/i }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -187,8 +187,8 @@ await user.click(screen.getByRole("button", { name: "xhigh" }));
 
     renderPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Non-Project Sessions" })).toBeInTheDocument();
-    expect(screen.getByText(/this is non-project mode/i)).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { level: 1, name: "New session" })).toBeInTheDocument();
+    expect(screen.getByText("Non-project")).toBeInTheDocument();
     expect(await screen.findByRole("link", { name: /open investigate a host session/i })).toHaveAttribute(
       "href",
       "/sessions/session-open",
@@ -222,7 +222,7 @@ await user.click(screen.getByRole("button", { name: "xhigh" }));
     expect(screen.queryByRole("heading", { name: /new session/i })).not.toBeInTheDocument();
   });
 
-  it("creates a session from the accessible initial-input form", async () => {
+  it("creates a session from the accessible goal form", async () => {
     const fetchMock = mockApi({
       ...sessionLaunchRoutes,
       "/api/sessions?lifecycle=archived": { sessions: [] },
@@ -233,9 +233,9 @@ await user.click(screen.getByRole("button", { name: "xhigh" }));
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    const input = await screen.findByRole("textbox", { name: /initial input/i });
+    const input = await screen.findByRole("textbox", { name: "你想探索什么？" });
     await user.type(input, "Check the exposed service");
-    await user.click(screen.getByRole("button", { name: /create session/i }));
+    await user.click(screen.getByRole("button", { name: /launch session/i }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -267,8 +267,8 @@ await user.click(screen.getByRole("button", { name: "xhigh" }));
     renderPage();
 
     const dropzone = await screen.findByTestId("attachment-dropzone");
-    expect(dropzone).toHaveTextContent("Drag & drop files here, or click to browse");
-    expect(dropzone).toHaveTextContent("Up to 25 files, 100 MB each");
+    expect(dropzone).toHaveTextContent("拖拽文件到这里，或 浏览");
+    expect(dropzone).toHaveTextContent("最多 25 个文件，每个 100 MB");
 
     await user.upload(screen.getByLabelText("Attachments"), new File(["notes"], "notes.txt", { type: "text/plain" }));
     expect(screen.getByText("notes.txt")).toBeInTheDocument();
@@ -288,10 +288,10 @@ await user.click(screen.getByRole("button", { name: "xhigh" }));
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    await user.type(await screen.findByRole("textbox", { name: /initial input/i }), "Inspect the standalone target");
-await user.click(screen.getByRole("button", { name: /blackboard conclusions/i }));
-    await user.selectOptions(screen.getByRole("combobox", { name: /blackboard conclusions/i }), "assisted");
-    await user.click(screen.getByRole("button", { name: /create session/i }));
+    await user.type(await screen.findByRole("textbox", { name: "你想探索什么？" }), "Inspect the standalone target");
+    await user.click(screen.getByRole("button", { name: /blackboard conclusions/i }));
+    await user.click(screen.getByRole("radio", { name: /^Assisted/ }));
+    await user.click(screen.getByRole("button", { name: /launch session/i }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -320,7 +320,7 @@ await user.click(screen.getByRole("button", { name: /blackboard conclusions/i })
 
     renderPage(["/sessions#new-session"]);
 
-    expect(await screen.findByRole("textbox", { name: /initial input/i })).toHaveFocus();
+    expect(await screen.findByRole("textbox", { name: "你想探索什么？" })).toHaveFocus();
   });
 
   it("navigates to the created session page after creation", async () => {
@@ -363,8 +363,8 @@ await user.click(screen.getByRole("button", { name: /blackboard conclusions/i })
     render(<RouterProvider router={router} />);
 
     await screen.findByRole("option", { name: "MiMo" });
-    await user.type(await screen.findByRole("textbox", { name: /initial input/i }), "Check the exposed service");
-    await user.click(screen.getByRole("button", { name: /create session/i }));
+    await user.type(await screen.findByRole("textbox", { name: "你想探索什么？" }), "Check the exposed service");
+    await user.click(screen.getByRole("button", { name: /launch session/i }));
 
     await waitFor(() => {
       expect(router.state.location.pathname).toBe("/sessions/session-new");

--- a/web/src/pages/SessionHomePage.test.tsx
+++ b/web/src/pages/SessionHomePage.test.tsx
@@ -83,7 +83,7 @@ describe("SessionHomePage", () => {
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    await user.type(screen.getByLabelText("你想探索什么？"), "Inspect the standalone target");
+    await user.type(screen.getByLabelText("What do you want to explore?"), "Inspect the standalone target");
     await user.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
     const disabledCard = screen.getByRole("radio", { name: /^disabled/i });
     expect(disabledCard).toBeEnabled();
@@ -128,7 +128,7 @@ describe("SessionHomePage", () => {
     expect(screen.getByLabelText("Reasoning effort")).toBeInTheDocument();
     expect(screen.queryByLabelText("Runtime profile")).not.toBeInTheDocument();
 
-    await user.type(screen.getByLabelText("你想探索什么？"), "Inspect the standalone target");
+    await user.type(screen.getByLabelText("What do you want to explore?"), "Inspect the standalone target");
     await user.click(screen.getByRole("button", { name: "xhigh" }));
     await user.click(screen.getByRole("button", { name: /blackboard conclusions/i }));
     await user.click(screen.getByRole("radio", { name: /^assisted/i }));
@@ -233,7 +233,7 @@ describe("SessionHomePage", () => {
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    const input = await screen.findByRole("textbox", { name: "你想探索什么？" });
+    const input = await screen.findByRole("textbox", { name: "What do you want to explore?" });
     await user.type(input, "Check the exposed service");
     await user.click(screen.getByRole("button", { name: /launch session/i }));
 
@@ -267,8 +267,8 @@ describe("SessionHomePage", () => {
     renderPage();
 
     const dropzone = await screen.findByTestId("attachment-dropzone");
-    expect(dropzone).toHaveTextContent("拖拽文件到这里，或 浏览");
-    expect(dropzone).toHaveTextContent("最多 25 个文件，每个 100 MB");
+    expect(dropzone).toHaveTextContent("Drag files here, or browse");
+    expect(dropzone).toHaveTextContent("up to 25 files, 100 MB each");
 
     await user.upload(screen.getByLabelText("Attachments"), new File(["notes"], "notes.txt", { type: "text/plain" }));
     expect(screen.getByText("notes.txt")).toBeInTheDocument();
@@ -288,7 +288,7 @@ describe("SessionHomePage", () => {
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    await user.type(await screen.findByRole("textbox", { name: "你想探索什么？" }), "Inspect the standalone target");
+    await user.type(await screen.findByRole("textbox", { name: "What do you want to explore?" }), "Inspect the standalone target");
     await user.click(screen.getByRole("button", { name: /blackboard conclusions/i }));
     await user.click(screen.getByRole("radio", { name: /^Assisted/ }));
     await user.click(screen.getByRole("button", { name: /launch session/i }));
@@ -320,7 +320,7 @@ describe("SessionHomePage", () => {
 
     renderPage(["/sessions#new-session"]);
 
-    expect(await screen.findByRole("textbox", { name: "你想探索什么？" })).toHaveFocus();
+    expect(await screen.findByRole("textbox", { name: "What do you want to explore?" })).toHaveFocus();
   });
 
   it("navigates to the created session page after creation", async () => {
@@ -363,7 +363,7 @@ describe("SessionHomePage", () => {
     render(<RouterProvider router={router} />);
 
     await screen.findByRole("option", { name: "MiMo" });
-    await user.type(await screen.findByRole("textbox", { name: "你想探索什么？" }), "Check the exposed service");
+    await user.type(await screen.findByRole("textbox", { name: "What do you want to explore?" }), "Check the exposed service");
     await user.click(screen.getByRole("button", { name: /launch session/i }));
 
     await waitFor(() => {

--- a/web/src/pages/SessionHomePage.tsx
+++ b/web/src/pages/SessionHomePage.tsx
@@ -160,13 +160,13 @@ export function SessionHomePage({ view = "open" }: { view?: "open" | "archived" 
           <div className="space-y-5">
             <section className="rounded-lg border border-border bg-card shadow-sm">
               <div className="p-4">
-                <Label htmlFor="session-initial-input" className="text-sm font-medium">你想探索什么？</Label>
+                <Label htmlFor="session-initial-input" className="text-sm font-medium">What do you want to explore?</Label>
                 <Textarea
                   id="session-initial-input"
                   name="input"
                   value={draft}
                   onChange={(event) => setDraft(event.target.value)}
-                  placeholder="描述目标，例如：对 staging.example.com 做认证面枚举…"
+                  placeholder="Describe the goal, for example: enumerate the authenticated surface of staging.example.com…"
                   rows={4}
                   className="mt-2 w-full resize-none rounded-lg border border-input bg-background px-3.5 py-3 text-sm leading-relaxed outline-none placeholder:text-muted-foreground focus:border-ring"
                 />

--- a/web/src/pages/SessionHomePage.tsx
+++ b/web/src/pages/SessionHomePage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Archive, ArchiveRestore, FilePlus2, MessageSquareText, Pencil, Plus, Trash2 } from "lucide-react";
-import { RuntimeLaunchControls, useRuntimeLaunchControls } from "@/components/RuntimeLaunchControls";
+import { Archive, ArchiveRestore, MessageSquareText, Pencil, Trash2 } from "lucide-react";
+import { LaunchSummaryRail, RuntimeLaunchControls, useRuntimeLaunchControls } from "@/components/RuntimeLaunchControls";
 import { AttachmentPicker } from "@/components/AttachmentPicker";
 import {
   archiveSession,
@@ -13,9 +13,9 @@ import {
   type Session,
 } from "@/lib/api";
 import { formatCompactDateTime } from "@/lib/format";
-import { LoadingState, PageContainer, RichEmptyState, SettingsAlert } from "@/components/shared";
+import { LoadingState, PageContainer, RichEmptyState, SectionLabel, SettingsAlert } from "@/components/shared";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { Badge, Button, Card, CardDescription, CardTitle, Input, Label, Textarea } from "@/components/ui";
+import { Badge, Button, Card, Input, Label, Textarea } from "@/components/ui";
 
 export function SessionHomePage({ view = "open" }: { view?: "open" | "archived" }) {
   const archivedView = view === "archived";
@@ -134,75 +134,65 @@ export function SessionHomePage({ view = "open" }: { view?: "open" | "archived" 
 
   return (
     <PageContainer className="mx-auto max-w-6xl space-y-8">
-      <header className="max-w-3xl">
-        <p className="mb-1 font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">Workspace</p>
-        <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight sm:text-3xl">
-          <MessageSquareText className="size-6 text-signal" aria-hidden="true" />
-          {archivedView ? "Archived Sessions" : "Non-Project Sessions"}
-        </h1>
-        <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          Durable exploratory conversations with their own Events and managed Workdir.
-        </p>
+      <header className="flex items-end justify-between gap-3">
+        <div>
+          <SectionLabel>Non-project</SectionLabel>
+          <h1 id="new-session-heading" className="mt-1 text-xl font-semibold tracking-tight sm:text-2xl">
+            {archivedView ? "Archived Sessions" : "New session"}
+          </h1>
+        </div>
+        <Link
+          to={archivedView ? "/sessions" : "/sessions/archived"}
+          className="inline-flex w-fit shrink-0 items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <Archive className="size-4" aria-hidden="true" />
+          {archivedView ? "Back to open Sessions" : "Archived Sessions"}
+        </Link>
       </header>
 
-      <Link
-        to={archivedView ? "/sessions" : "/sessions/archived"}
-        className="inline-flex w-fit items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <Archive className="size-4" aria-hidden="true" />
-        {archivedView ? "Back to open Sessions" : "Archived Sessions"}
-      </Link>
-
-      <div role="note" className="rounded-lg border border-info/20 bg-info/5 px-4 py-3 text-sm text-foreground">
-        <p className="font-medium">Non-Project Mode</p>
-        <p className="mt-1 text-muted-foreground">
-          This is Non-Project Mode. Sessions have no Project Scope; this statement is informational and does not
-          restrict Runtime execution.
-        </p>
-      </div>
-
-      {!archivedView && <Card as="section" id="new-session" aria-labelledby="new-session-heading" className="gap-5">
-        <div>
-          <CardTitle id="new-session-heading" className="flex items-center gap-2">
-            <Plus className="size-4 text-signal" aria-hidden="true" />
-            New session
-          </CardTitle>
-          <CardDescription className="mt-1">
-            The first non-empty line becomes the initial title. You can rename it later without changing the input.
-          </CardDescription>
-        </div>
-        <form className="grid gap-4" onSubmit={submit}>
-          <div>
-            <Label htmlFor="session-initial-input">Initial input</Label>
-            <Textarea
-              id="session-initial-input"
-              name="input"
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
-              placeholder="Describe what you want to explore…"
-              className="mt-1"
-              rows={4}
-            />
+      {!archivedView && (
+        <form
+          id="new-session"
+          aria-labelledby="new-session-heading"
+          onSubmit={submit}
+          className="mx-auto grid w-full max-w-[1080px] grid-cols-1 gap-6 lg:grid-cols-[1fr_300px]"
+        >
+          <div className="space-y-5">
+            <section className="rounded-lg border border-border bg-card shadow-sm">
+              <div className="p-4">
+                <Label htmlFor="session-initial-input" className="text-sm font-medium">你想探索什么？</Label>
+                <Textarea
+                  id="session-initial-input"
+                  name="input"
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  placeholder="描述目标，例如：对 staging.example.com 做认证面枚举…"
+                  rows={4}
+                  className="mt-2 w-full resize-none rounded-lg border border-input bg-background px-3.5 py-3 text-sm leading-relaxed outline-none placeholder:text-muted-foreground focus:border-ring"
+                />
+                <div className="mt-3">
+                  <AttachmentPicker
+                    id="session-attachments"
+                    variant="compact"
+                    files={attachments}
+                    onFilesChange={setAttachments}
+                    onError={launchControls.setError}
+                    ownerLabel="Session"
+                  />
+                </div>
+              </div>
+            </section>
+            <RuntimeLaunchControls controller={launchControls} ownerLabel="session" initialInput={draft} />
           </div>
-          <AttachmentPicker
-            id="session-attachments"
-            files={attachments}
-            onFilesChange={setAttachments}
-            onError={launchControls.setError}
-            ownerLabel="Session"
+          <LaunchSummaryRail
+            controller={launchControls}
+            disabled={creating || !launchControls.launchReady(draft) || (launchControls.form.runner === "host" && !launchControls.hostActivated)}
+            busy={creating}
+            label="Launch session"
+            submit
           />
-          <RuntimeLaunchControls controller={launchControls} ownerLabel="session" initialInput={draft} />
-          <div className="flex justify-end">
-            <Button
-              type="submit"
-              disabled={creating || !launchControls.launchReady(draft) || (launchControls.form.runner === "host" && !launchControls.hostActivated)}
-            >
-              <FilePlus2 className="size-4" aria-hidden="true" />
-              {creating ? "Creating…" : "Create session"}
-            </Button>
-          </div>
         </form>
-      </Card>}
+      )}
 
       {error && <SettingsAlert>{error}</SettingsAlert>}
 

--- a/web/src/pages/SkillsPage.test.tsx
+++ b/web/src/pages/SkillsPage.test.tsx
@@ -326,6 +326,32 @@ describe("SkillsPage", () => {
     );
   });
 
+  it("shows default-on Skill state when no Runtime Profile exists", async () => {
+    mockApi({
+      "/api/runtime-profiles": { profiles: [] },
+      "/api/skills": {
+        skills: [
+          {
+            id: "api-security",
+            name: "API Security",
+            description: "API assessment guidance",
+            enabled: true,
+            source_provenance: { kind: "builtin" },
+            created_at: "",
+            updated_at: "",
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    const switchControl = await screen.findByRole("switch", { name: /create a Runtime Profile to manage API Security/i });
+    expect(switchControl).toBeDisabled();
+    expect(switchControl).toHaveAttribute("aria-checked", "true");
+    expect(within(screen.getByTestId("skill-card-api-security")).queryByText("—")).not.toBeInTheDocument();
+  });
+
   it("keeps the create form collapsed until New skill is chosen", async () => {
     mockApi({
       "/api/runtime-profiles": {
@@ -377,8 +403,13 @@ describe("SkillsPage", () => {
     renderPage();
 
     await screen.findByRole("heading", { name: "Upload / edit Skill" });
+    const archiveInput = screen.getByLabelText("Skill bundle archive");
+    expect(archiveInput).toHaveClass("sr-only");
+    expect(screen.getByText("Choose file")).toBeInTheDocument();
+    expect(screen.getByText("No file selected")).toBeInTheDocument();
     const archive = new File(["archive bytes"], "recon-helper.zip", { type: "application/zip" });
-    await userEvent.upload(screen.getByLabelText("Skill bundle archive"), archive);
+    await userEvent.upload(archiveInput, archive);
+    expect(screen.getByText("recon-helper.zip")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Upload archive" }));
 
     expect(fetchMock).toHaveBeenCalledWith(

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -12,7 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { apiDelete, apiGet, apiPost, apiPostForm, apiPut, type RuntimeProfile, type Skill } from "@/lib/api";
-import { Button, Input, Label, Select, Textarea } from "@/components/ui";
+import { Button, Input, Label, Select, Textarea, buttonVariants } from "@/components/ui";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import {
   SettingsAlert,
@@ -469,19 +469,18 @@ export function SkillsPage() {
                         </td>
                         <td className="px-4 py-2.5 text-xs text-muted-foreground">{source}</td>
                         <td className="px-4 py-2.5">
-                          {selectedProfile ? (
-                            <EnableSwitch
-                              enabled={skill.enabled}
-                              onClick={() => toggleOptOut(skill)}
-                              ariaLabel={
-                                skill.enabled
+                          <EnableSwitch
+                            enabled={skill.enabled}
+                            disabled={!selectedProfile}
+                            onClick={() => toggleOptOut(skill)}
+                            ariaLabel={
+                              selectedProfile
+                                ? skill.enabled
                                   ? `Opt out for ${selectedProfile.name}`
                                   : `Enable for ${selectedProfile.name}`
-                              }
-                            />
-                          ) : (
-                            <span className="text-xs text-muted-foreground">—</span>
-                          )}
+                                : `Create a Runtime Profile to manage ${name}`
+                            }
+                          />
                         </td>
                         <td className="px-4 py-2.5">
                           <div className="flex items-center gap-0.5">
@@ -539,22 +538,37 @@ export function SkillsPage() {
               )}
             </div>
             <p className="mt-1 text-xs text-muted-foreground">
-              发布一个 canonical bundle 原子化。复用 Skill ID 会更新它。
+              Publish one canonical bundle atomically. Reusing a Skill ID updates it.
             </p>
 
             {formMode === "idle" ? (
               <div className="mt-4 space-y-3">
                 <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
                   <div>
-                    <Label htmlFor="skill-bundle-archive">Skill bundle archive</Label>
-                    <Input
-                      id="skill-bundle-archive"
-                      name="skill_bundle_archive"
-                      type="file"
-                      accept=".zip,.tar,.tar.gz,.tgz,application/zip,application/x-tar,application/gzip"
-                      onChange={(event) => setArchiveFile(event.target.files?.[0] ?? null)}
-                      className="mt-1.5"
-                    />
+                    <Label>Skill bundle archive</Label>
+                    <div className="mt-1.5 flex h-9 min-w-0 items-center gap-2 rounded-lg border border-input bg-background px-1.5">
+                      <input
+                        id="skill-bundle-archive"
+                        name="skill_bundle_archive"
+                        type="file"
+                        accept=".zip,.tar,.tar.gz,.tgz,application/zip,application/x-tar,application/gzip"
+                        aria-label="Skill bundle archive"
+                        onChange={(event) => setArchiveFile(event.target.files?.[0] ?? null)}
+                        className="peer sr-only"
+                      />
+                      <label
+                        htmlFor="skill-bundle-archive"
+                        className={cn(
+                          buttonVariants({ variant: "outline", size: "sm" }),
+                          "h-7 shrink-0 cursor-pointer px-2.5 text-xs peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2",
+                        )}
+                      >
+                        Choose file
+                      </label>
+                      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                        {archiveFile?.name ?? "No file selected"}
+                      </span>
+                    </div>
                     <p className="mt-1 text-xs text-muted-foreground">
                       Upload one .zip, .tar, .tar.gz, or .tgz bundle containing SKILL.md and optional scripts.
                     </p>
@@ -668,7 +682,7 @@ export function SkillsPage() {
               <Download className="h-4 w-4" /> Import skill from URL or repo
             </button>
             <p className="mt-1.5 text-xs text-muted-foreground">
-              结构化导入仅由 daemon 解析源本身，从不接受原始 shell 命令。
+              Structured imports let the daemon parse the source itself and never accept raw shell commands.
             </p>
             {importOpen && (
               <ImportForm
@@ -752,10 +766,12 @@ function ImportForm({
 
 function EnableSwitch({
   enabled,
+  disabled = false,
   onClick,
   ariaLabel,
 }: {
   enabled: boolean;
+  disabled?: boolean;
   onClick: () => void;
   ariaLabel: string;
 }) {
@@ -766,8 +782,9 @@ function EnableSwitch({
       aria-checked={enabled}
       aria-label={ariaLabel}
       onClick={onClick}
+      disabled={disabled}
       className={cn(
-        "relative h-6 w-10 shrink-0 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "relative h-6 w-10 shrink-0 rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         enabled
           ? "border-success/30 bg-success"
           : "border-border bg-muted",

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -243,6 +243,7 @@ describe("TaskDetailPage", () => {
     expect(screen.getByLabelText("Continuation reasoning effort")).toHaveClass("appearance-none");
     expect(screen.getByTestId("task-workspace")).toHaveClass("overflow-visible", "md:overflow-hidden");
     expect(screen.getByTestId("task-composer")).toHaveClass("fixed", "inset-x-0", "bottom-0", "md:static");
+    expect(screen.getByTestId("task-session-header").parentElement?.parentElement).toHaveClass("mx-auto", "max-w-6xl");
     expect(screen.getByTestId("conversation-workspace")).toHaveClass("pb-44", "md:pb-5");
     expect(screen.getByLabelText("Continuation reasoning effort").parentElement).toHaveClass("w-[5.25rem]", "shrink-0");
     expect(screen.queryByText(/Shift\+Enter for a new line/i)).not.toBeInTheDocument();
@@ -250,11 +251,15 @@ describe("TaskDetailPage", () => {
     expect(screen.queryByText("Timeline opened first")).not.toBeInTheDocument();
   });
 
-  it("does not draw an outer frame around the Runtime Owner Workspace", async () => {
+  it("frames the Runtime Owner Workspace as one continuous card", async () => {
     stubTaskDetailApi();
 
     renderPage();
 
+    expect(await screen.findByTestId("task-session-header")).toHaveClass("border", "bg-card");
+    expect(screen.getByRole("button", { name: "Conversation" }).parentElement).toHaveClass("border-x");
+    expect(await screen.findByTestId("task-workspace")).toHaveClass("rounded-b-xl", "border");
+    expect(screen.getByTestId("task-composer")).not.toHaveClass("border-t");
     expect(await screen.findByTestId("task-session-header")).not.toHaveClass("border-b");
     expect(screen.getByRole("button", { name: "Conversation" }).parentElement).not.toHaveClass("border-b");
     expect(await screen.findByTestId("task-workspace")).not.toHaveClass("border-x", "border-b");

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -233,9 +233,14 @@ describe("TaskDetailPage", () => {
     expect(tabs.map((tab) => tab.textContent?.trim())).toEqual(["Conversation", "Timeline"]);
     expect(tabs[0]).toHaveAttribute("aria-pressed", "true");
     expect(tabs[1]).toHaveAttribute("aria-pressed", "false");
+    expect(tabs[0]?.querySelector("svg")).toBeNull();
+    expect(tabs[1]?.querySelector("svg")).toBeNull();
     expect(await screen.findByText("Conversation should be hidden by default")).toBeInTheDocument();
     expect(screen.getByTestId("conversation-workspace")).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Task message" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Continuation model provider")).toHaveClass("appearance-none");
+    expect(screen.getByLabelText("Continuation model")).toHaveClass("appearance-none");
+    expect(screen.getByLabelText("Continuation reasoning effort")).toHaveClass("appearance-none");
     expect(screen.getByTestId("task-workspace")).toHaveClass("overflow-visible", "md:overflow-hidden");
     expect(screen.getByTestId("task-composer")).toHaveClass("fixed", "inset-x-0", "bottom-0", "md:static");
     expect(screen.getByTestId("conversation-workspace")).toHaveClass("pb-44", "md:pb-5");
@@ -434,14 +439,15 @@ describe("TaskDetailPage", () => {
     expect(searches.at(-1)).toBe("?view=timeline");
   });
 
-  it("uses shared Geist radii for conversation message surfaces", async () => {
+  it("renders assistant messages with the Direction A signal accent", async () => {
     stubTaskDetailApi();
 
     renderPage("/projects/project-1/tasks/task-1?view=conversation");
 
     expect(await screen.findByText("Conversation should be hidden by default")).toBeInTheDocument();
     const message = screen.getByTestId("transcript-message-bubble");
-    expect(message).toHaveClass("rounded-lg");
+    expect(message).toHaveClass("border-l-2", "border-signal/40");
+    expect(message).not.toHaveClass("rounded-lg");
   });
 
   it("renders safe Claude runtime text as a visible assistant message", async () => {
@@ -462,7 +468,7 @@ describe("TaskDetailPage", () => {
     expect(await screen.findByText("Inspecting the scoreboard now.")).toBeInTheDocument();
     const assistantMessage = screen.getByTestId("transcript-message-bubble");
     expect(assistantMessage).toBeInTheDocument();
-    expect(assistantMessage.previousElementSibling).toBeNull();
+    expect(assistantMessage.previousElementSibling).toHaveAttribute("data-testid", "transcript-turn-header");
     expect(screen.queryByText(/"type":"assistant"/)).not.toBeInTheDocument();
   });
 
@@ -504,13 +510,12 @@ describe("TaskDetailPage", () => {
 
     expect(await screen.findByText("I will inspect the target now.")).toBeInTheDocument();
     expect(screen.getByText("Bash · curl http://localhost:3000")).toBeInTheDocument();
-    expect(screen.getByText(/Result · HTTP\/1\.1 200 OK/)).toBeInTheDocument();
     expect(screen.getAllByText(/HTTP\/1\.1 200 OK/)).toHaveLength(2);
     expect(screen.queryByText(/"type":"assistant"/)).not.toBeInTheDocument();
     expect(screen.queryByText(/"type":"user"/)).not.toBeInTheDocument();
     const toolRows = screen.getAllByTestId("transcript-tool-row");
-    expect(toolRows).toHaveLength(2);
-    expect(toolRows[0]).toHaveClass("border-b");
+    expect(toolRows).toHaveLength(1);
+    expect(toolRows[0]).not.toHaveAttribute("open");
     expect(toolRows[0]).not.toHaveClass("rounded-md");
     expect(toolRows[0]).not.toHaveClass("bg-card/60");
     const resultBody = screen.getAllByText(/HTTP\/1\.1 200 OK/).find((element) => element.tagName === "PRE");
@@ -640,16 +645,18 @@ describe("TaskDetailPage", () => {
     renderPage();
 
     const rows = await screen.findAllByTestId("transcript-row");
-    // First row has no top spacing; user-turn starts get the roomier mt-4;
-    // everything inside an agent turn (assistant message, tool call, tool
-    // result, follow-up assistant message) stays tight at mt-1.
+    // The call/result pair is one compressed row. New user turns get breathing
+    // room; every row inside the Runtime turn stays tight.
+    expect(rows).toHaveLength(5);
     expect(rows[0]).not.toHaveClass("mt-1");
     expect(rows[0]).not.toHaveClass("mt-4");
-    expect(rows[1]).toHaveClass("mt-1"); // user turn start → agent turn begins tight
-    expect(rows[2]).toHaveClass("mt-1"); // tool call still in the same agent turn
-    expect(rows[3]).toHaveClass("mt-1"); // tool result still in the same agent turn
-    expect(rows[4]).toHaveClass("mt-1"); // assistant summary still tight
-    expect(rows[5]).toHaveClass("mt-4"); // new user turn gets breathing room
+    expect(rows[1]).toHaveClass("mt-1");
+    expect(rows[2]).toHaveClass("mt-1");
+    expect(rows[3]).toHaveClass("mt-1");
+    expect(rows[4]).toHaveClass("mt-4");
+    expect(screen.getAllByTestId("transcript-turn-header").map((header) => header.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining("你"), expect.stringContaining("Codex")]),
+    );
   });
 
   it("renders tool call arguments as labeled fields rather than a raw JSON envelope", async () => {
@@ -690,7 +697,7 @@ describe("TaskDetailPage", () => {
     expect(searches.at(-1)).toBe("?focus=1");
     expect(screen.queryByRole("navigation", { name: "Project sections" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Exit focus view" })).toBeInTheDocument();
-    expect(screen.getByTestId("task-session-header")).toHaveClass("h-12");
+    expect(screen.getByTestId("task-session-header")).toHaveClass("py-2");
     expect(screen.getByTestId("task-detail-shell")).toHaveClass("h-[calc(100dvh-3.5rem)]", "md:h-dvh");
   });
 
@@ -768,16 +775,19 @@ describe("TaskDetailPage", () => {
     }
   });
 
-  it("shows the latest continuation summary when present", async () => {
+  it("shows the compact continuation summary when present", async () => {
     stubTaskDetailApi();
 
     renderPage();
 
-    expect(await screen.findByText("continuation #1")).toBeInTheDocument();
-    expect(screen.getByText("runtime: codex")).toBeInTheDocument();
-    expect(screen.getByText("continuation status: completed")).toBeInTheDocument();
-    expect(screen.getByText("native session: captured")).toBeInTheDocument();
-    expect(screen.getByText("same runtime only")).toBeInTheDocument();
+    const summary = await screen.findByTestId("continuation-summary");
+    expect(summary).toHaveTextContent("continuation #1");
+    expect(summary).toHaveTextContent("runtime codex");
+    expect(summary).toHaveTextContent("runner docker");
+    expect(summary).not.toHaveTextContent("continuation status");
+    expect(summary).not.toHaveTextContent("native session");
+    expect(summary).toHaveAttribute("title", expect.stringContaining("status: completed"));
+    expect(summary).toHaveAttribute("title", expect.stringContaining("native session: captured"));
   });
 
   it("shows the prior terminal continuation next to the current writable one", async () => {
@@ -806,9 +816,9 @@ describe("TaskDetailPage", () => {
     renderPage();
 
     expect(await screen.findByText("continuation #1")).toBeInTheDocument();
-    expect(screen.getByText("continuation status: running")).toBeInTheDocument();
-    const prior = screen.getByTestId("prior-terminal-continuation");
-    expect(prior).toHaveTextContent("prior terminal: #2 (completed)");
+    const summary = screen.getByTestId("continuation-summary");
+    expect(summary).not.toHaveTextContent("continuation status");
+    expect(summary).toHaveAttribute("title", expect.stringContaining("prior terminal: #2 (completed)"));
   });
 
   it("does not repeat the same continuation as its own prior terminal", async () => {
@@ -836,9 +846,10 @@ describe("TaskDetailPage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("continuation #2")).toBeInTheDocument();
-    expect(screen.getByText("continuation status: running")).toBeInTheDocument();
-    expect(screen.queryByTestId("prior-terminal-continuation")).not.toBeInTheDocument();
+    const summary = await screen.findByTestId("continuation-summary");
+    expect(summary).toHaveTextContent("continuation #2");
+    expect(summary).not.toHaveTextContent("continuation status");
+    expect(summary).toHaveAttribute("title", expect.not.stringContaining("prior terminal"));
   });
 
   it("shows pending and failed Harness Steering states in the composer", async () => {
@@ -910,20 +921,16 @@ describe("TaskDetailPage", () => {
     });
   });
 
-  it("lets the continuation summary shrink instead of overflowing the header", async () => {
+  it("keeps the compact continuation summary bounded below the title row", async () => {
     stubTaskDetailApi();
 
     renderPage();
 
     expect(await screen.findByText("continuation #1")).toBeInTheDocument();
-    // The summary must be able to shrink (min-w-0) and clip rather than push
-    // the title to zero width and spill past the header border.
     const summary = screen.getByTestId("continuation-summary");
     expect(summary).toHaveClass("min-w-0", "overflow-hidden", "whitespace-nowrap");
-    // Status badges stay intact and are never compressed into wrapping text.
-    const blackboardBadge = screen.getByTestId("blackboard-conclusion-state");
-    expect(blackboardBadge).toHaveClass("min-w-0", "shrink");
-    expect(blackboardBadge.firstElementChild).toHaveClass("truncate", "whitespace-nowrap");
+    const blackboardChip = screen.getByTestId("blackboard-conclusion-state");
+    expect(blackboardChip).toHaveClass("min-w-0", "shrink");
   });
 
   it("shows native resume and queue steering controls", async () => {
@@ -1549,8 +1556,8 @@ describe("TaskDetailPage", () => {
 
     renderPage();
 
-    expect(await screen.findByTestId("runtime-activity")).toHaveTextContent(/runtime live · busy/i);
-    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(await screen.findByTestId("runtime-activity")).toHaveTextContent(/Runtime busy/i);
+    expect(screen.getByText("Running")).toBeInTheDocument();
   });
 
   it("offers Finish Task only when controls.finish_available is true", async () => {
@@ -1797,16 +1804,16 @@ describe("TaskDetailPage", () => {
 
     // Newer generation wins with idle; later stale busy must not overwrite.
     latest.resolve(taskPayload("live", "idle"));
-    expect(await screen.findByTestId("runtime-activity")).toHaveTextContent(/runtime live · idle/i);
+    expect(await screen.findByTestId("runtime-activity")).toHaveTextContent(/Runtime idle/i);
 
     if (stale !== latest && !stale.signal?.aborted) {
       stale.resolve(taskPayload("live", "busy"));
       await waitFor(() =>
-        expect(screen.getByTestId("runtime-activity")).toHaveTextContent(/runtime live · idle/i),
+        expect(screen.getByTestId("runtime-activity")).toHaveTextContent(/Runtime idle/i),
       );
     } else if (stale !== latest) {
-      // Aborted stale request rejects; UI must remain on the latest idle value.
-      expect(screen.getByTestId("runtime-activity")).toHaveTextContent(/runtime live · idle/i);
+      // Aborted stale request rejects; UI must remain on the latest idle state.
+      expect(screen.getByTestId("runtime-activity")).toHaveTextContent(/Runtime idle/i);
     }
   });
 

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -244,6 +244,9 @@ describe("TaskDetailPage", () => {
     expect(screen.getByTestId("task-workspace")).toHaveClass("overflow-visible", "md:overflow-hidden");
     expect(screen.getByTestId("task-composer")).toHaveClass("fixed", "inset-x-0", "bottom-0", "md:static");
     expect(screen.getByTestId("conversation-workspace")).toHaveClass("pb-44", "md:pb-5");
+    expect(screen.getByLabelText("Continuation reasoning effort").parentElement).toHaveClass("w-[5.25rem]", "shrink-0");
+    expect(screen.queryByText(/Shift\+Enter for a new line/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("composer-send").querySelector(".lucide-arrow-up")).not.toBeNull();
     expect(screen.queryByText("Timeline opened first")).not.toBeInTheDocument();
   });
 
@@ -655,7 +658,7 @@ describe("TaskDetailPage", () => {
     expect(rows[3]).toHaveClass("mt-1");
     expect(rows[4]).toHaveClass("mt-4");
     expect(screen.getAllByTestId("transcript-turn-header").map((header) => header.textContent)).toEqual(
-      expect.arrayContaining([expect.stringContaining("你"), expect.stringContaining("Codex")]),
+      expect.arrayContaining([expect.stringContaining("You"), expect.stringContaining("Codex")]),
     );
   });
 

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -802,7 +802,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
       projectChrome={owner.capabilities.projectChrome}
       hideChrome={focusMode}
       data-testid="task-detail-shell"
-      className={focusMode ? "h-[calc(100dvh-3.5rem)] max-w-none p-0 md:h-dvh lg:p-0" : "flex min-h-full flex-col"}
+      className={focusMode ? "h-[calc(100dvh-3.5rem)] max-w-none p-0 md:h-dvh lg:p-0" : "flex h-full flex-col lg:min-h-0 lg:overflow-hidden"}
       contentClassName={focusMode ? undefined : "mx-auto max-w-6xl px-0 pb-0 lg:px-0 lg:pb-0"}
       bodyClassName={focusMode ? "flex h-full min-h-0 flex-col" : "flex min-h-[32rem] flex-1 flex-col pb-0 lg:min-h-0"}
     >
@@ -1022,7 +1022,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
           <div
             ref={bindTranscriptViewport}
             data-testid="conversation-workspace"
-            className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain bg-background px-3 py-5 pb-44 sm:px-6 md:pb-5"
+            className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain bg-background px-3 pt-3 pb-44 sm:px-6 md:pb-5"
           >
             <div className="mx-auto max-w-[860px]">
               {history.transcriptHasOlder && (
@@ -1183,7 +1183,7 @@ function RuntimeOwnerShell({ projectChrome, children, bodyClassName, contentClas
       data-testid={props["data-testid"]}
       className={cn("mx-auto flex w-full max-w-6xl min-w-0 flex-col p-0 lg:p-0", props.className)}
     >
-      <div className={cn("flex min-w-0 w-full flex-1 flex-col", contentClassName, bodyClassName)}>{children}</div>
+      <div className={cn("flex min-h-0 min-w-0 w-full flex-1 flex-col", contentClassName, bodyClassName)}>{children}</div>
     </PageContainer>
   );
 }

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState, useRef, type KeyboardEvent, type ReactNode, type RefObject } from "react";
 import { flushSync } from "react-dom";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { Square, Send, Terminal, Activity, GitBranch, MessageSquare, Play, ChevronRight, Wrench, User, ArrowDown, ArrowUp, CheckCircle2, Trash2, CircleX, KeyRound, ListPlus, Loader2, Maximize2, Minimize2, Flag, RefreshCcw, TriangleAlert, Archive, ArchiveRestore, Pencil, Paperclip, Brain, PlugZap } from "lucide-react";
+import { Square, Send, Terminal, GitBranch, MessageSquare, Play, ChevronRight, ChevronsUpDown, Wrench, User, Bot, ArrowDown, ArrowUp, CheckCircle2, Trash2, CircleX, KeyRound, ListPlus, Loader2, Maximize2, Minimize2, Flag, RefreshCcw, TriangleAlert, Archive, ArchiveRestore, Pencil, Paperclip, Brain, PlugZap, Info } from "lucide-react";
 import { apiGet, type FinishReadiness, type ModelProvider, type ProviderPermissionRequest, type RuntimeActivity, type RuntimePlugin, type RuntimeProfile, type TaskTranscriptEntry } from "@/lib/api";
-import { Button, Badge, Input, Select, Textarea } from "@/components/ui";
+import { Button, Badge, Chip, Input, Select, Textarea } from "@/components/ui";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { ProjectPageShell } from "@/components/ProjectPageShell";
 import { ErrorState, LoadingState, PageContainer } from "@/components/shared";
@@ -12,12 +12,13 @@ import { AttachmentFileRow } from "@/components/AttachmentPicker";
 import { collapsedTranscriptTitle, toolCallFields } from "./taskDetailView";
 import { displayReasoningEffort, REASONING_EFFORT_VALUES, selectableModelProviders } from "./runtimeProfileForm";
 import { modelsForProvider } from "./taskLaunchForm";
-import { formatDateTime } from "@/lib/format";
+import { formatDateTime, formatRelativeTime } from "@/lib/format";
 import { mergeTimelineItems, mergeTranscriptEntries, prependTimelineItems, prependTranscriptEntries } from "@/lib/ownerEvents";
 import { useDocumentVisibility } from "@/lib/useDocumentVisibility";
 import { useVirtualWindow } from "@/lib/virtualWindow";
 import { taskRuntimeOwnerAdapter, sessionRuntimeOwnerAdapter, type RuntimeOwnerAdapter } from "@/lib/runtimeOwner/adapter";
 import { canPiNativeCrossProvider, conversationModeText, conversationQueueUnavailable, conversationSendLabel, newBlackboardRetryID, newSteerRequestID, resolveConversationAction, resolveConversationSendMode, steerPendingState } from "@/lib/runtimeOwner/conversationKernel";
+import { cn } from "@/lib/utils";
 import { emptyHistory, type ConversationSendMode, type OwnerHistory, type RuntimeOwnerKind, type RuntimeOwnerView } from "@/lib/runtimeOwner/types";
 
 const ACTIVE = new Set(["running", "paused"]);
@@ -779,6 +780,22 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
   ].includes(controls?.native_steer_error_code ?? "");
   const focusMode = searchParams.get("focus") === "1";
   const blackboardDisabled = runtimeOwnerBlackboardMode(owner) === "disabled";
+  const runtimeDisplayName = profiles.find((profile) => profile.id === owner.runtimeProfileID)?.name
+    ?? currentContinuation?.runtimeProvider
+    ?? "Runtime";
+  const continuationTitle = currentContinuation
+    ? [
+        `continuation #${currentContinuation.number}`,
+        `runtime: ${currentContinuation.runtimeProvider}`,
+        `runner: ${owner.runner}`,
+        `status: ${currentContinuation.status}`,
+        (controls?.native_session_captured || currentContinuation.nativeSessionID) ? "native session: captured" : "",
+        controls?.same_runtime_provider_only ? "same runtime only" : "",
+        owner.activeContinuation && owner.latestContinuation && owner.latestContinuation.id !== owner.activeContinuation.id
+          ? `prior terminal: #${owner.latestContinuation.number} (${owner.latestContinuation.status})`
+          : "",
+      ].filter(Boolean).join(" · ")
+    : "";
 
   return (
     <RuntimeOwnerShell
@@ -788,127 +805,106 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
       className={focusMode ? "h-[calc(100dvh-3.5rem)] max-w-none p-0 md:h-dvh lg:p-0" : "flex min-h-full flex-col"}
       bodyClassName={focusMode ? "flex h-full min-h-0 flex-col" : "flex min-h-[32rem] flex-1 flex-col pb-0 lg:min-h-0"}
     >
-      <div data-testid="task-session-header" className="flex h-12 shrink-0 items-center gap-2 px-2 sm:px-3">
-        <StatusBadge status={owner.status} />
-        <RuntimeActivityBadge activity={owner.runtimeActivity} />
-        <BlackboardConclusionBadge owner={owner} />
-        {owner.capabilities.rename && editingTitle ? (
-          <div className="flex min-w-0 flex-1 items-center gap-1.5">
-            <Input
-              aria-label="Session title"
-              value={titleDraft}
-              onChange={(event) => setTitleDraft(event.target.value)}
-              className="h-8 min-w-0"
-              autoFocus
-            />
-            <Button size="sm" onClick={() => void saveSessionTitle()} disabled={!titleDraft.trim()}>Save</Button>
-            <Button size="sm" variant="ghost" onClick={() => setEditingTitle(false)}>Cancel</Button>
-          </div>
-        ) : (
-          <h1 className="min-w-0 flex-1 truncate text-sm font-medium" title={owner.title}>{owner.title}</h1>
-        )}
-        {currentContinuation && (
-          <div
-            data-testid="continuation-summary"
-            title={`continuation #${currentContinuation.number} · runtime: ${currentContinuation.runtimeProvider} · runner: ${owner.runner} · status: ${currentContinuation.status}`}
-            className="hidden min-w-0 flex-1 items-center gap-1 overflow-hidden whitespace-nowrap font-mono text-xs text-muted-foreground lg:flex"
-          >
-            <span>continuation #{currentContinuation.number}</span>
-            <span aria-hidden="true">·</span>
-            <span>runtime: {currentContinuation.runtimeProvider}</span>
-            {owner.runtimeConfiguration && (
-              <>
-                <span aria-hidden="true">·</span>
-                <span>model provider: {owner.runtimeConfiguration.model_provider_name || owner.runtimeConfiguration.model_provider_id}</span>
-                <span aria-hidden="true">·</span>
-                <span>model: {owner.runtimeConfiguration.model}</span>
-                {owner.runtimeConfiguration.runtime_profile_name && (
-                  <>
-                    <span aria-hidden="true">·</span>
-                    <span>profile: {owner.runtimeConfiguration.runtime_profile_name}</span>
-                  </>
-                )}
-              </>
-            )}
-            <span aria-hidden="true">·</span>
-            <span>runner: {owner.runner}</span>
-            <span className="hidden xl:inline" aria-hidden="true">·</span>
-            <span className="hidden xl:inline">continuation status: {currentContinuation.status}</span>
-            {owner.activeContinuation &&
-              owner.latestContinuation &&
-              owner.latestContinuation.id !== owner.activeContinuation.id && (
-                <>
-                  <span aria-hidden="true">·</span>
-                  <span className="hidden 2xl:inline" data-testid="prior-terminal-continuation">
-                    prior terminal: #{owner.latestContinuation.number} ({owner.latestContinuation.status})
-                  </span>
-                </>
+      <header data-testid="task-session-header" className="shrink-0 px-2 py-2 sm:px-3">
+        <div className="flex min-w-0 items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              {owner.capabilities.rename && editingTitle ? (
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                  <Input
+                    aria-label="Session title"
+                    value={titleDraft}
+                    onChange={(event) => setTitleDraft(event.target.value)}
+                    className="h-8 min-w-0"
+                    autoFocus
+                  />
+                  <Button size="sm" onClick={() => void saveSessionTitle()} disabled={!titleDraft.trim()}>Save</Button>
+                  <Button size="sm" variant="ghost" onClick={() => setEditingTitle(false)}>Cancel</Button>
+                </div>
+              ) : (
+                <h1 className="min-w-0 truncate text-base font-semibold tracking-tight" title={owner.title}>{owner.title}</h1>
               )}
-            {(controls?.native_session_captured || currentContinuation.nativeSessionID) && (
-              <span className="hidden 2xl:inline">native session: captured</span>
+              <StatusBadge status={owner.status} />
+              <RuntimeActivityBadge activity={owner.runtimeActivity} />
+              <BlackboardConclusionBadge owner={owner} />
+            </div>
+            {currentContinuation && (
+              <div
+                data-testid="continuation-summary"
+                title={continuationTitle}
+                className="mt-1 hidden min-w-0 items-center gap-1 overflow-hidden whitespace-nowrap font-mono text-xs text-muted-foreground sm:flex"
+              >
+                <span>continuation #{currentContinuation.number}</span>
+                <span aria-hidden="true">·</span>
+                <span>runtime {currentContinuation.runtimeProvider}</span>
+                <span aria-hidden="true">·</span>
+                <span>runner {owner.runner}</span>
+                <span aria-hidden="true">·</span>
+                <span>{formatRelativeTime(owner.updatedAt)} 更新</span>
+              </div>
             )}
-            {controls?.same_runtime_provider_only && <span className="hidden 2xl:inline">same runtime only</span>}
           </div>
-        )}
-        <div className="flex shrink-0 items-center gap-1">
-		  {owner.kind === "task" && projectId && (
-			<Button size="sm" variant="ghost" onClick={() => navigate(`/projects/${projectId}/tasks/${owner.id}/challenges`)} aria-label="Challenge Workflow" title="Open Challenge Workflow">
-			  <Wrench className="h-4 w-4" /> <span className="hidden sm:inline">Challenges</span>
-			</Button>
-		  )}
-          {owner.capabilities.rename && !editingTitle && (
-            <Button size="icon" variant="ghost" onClick={() => setEditingTitle(true)} aria-label={`Rename ${owner.title}`} title="Rename Session" className="h-8 w-8">
-              <Pencil className="h-4 w-4" />
-            </Button>
-          )}
-          {owner.capabilities.archive && (
-            <Button size="icon" variant="ghost" onClick={() => void changeSessionLifecycle("archive")} aria-label="Archive" title="Archive Session" className="h-8 w-8">
-              <Archive className="h-4 w-4" />
-            </Button>
-          )}
-          {owner.capabilities.restore && (
-            <Button size="icon" variant="ghost" onClick={() => void changeSessionLifecycle("restore")} aria-label="Restore" title="Restore Session" className="h-8 w-8">
-              <ArchiveRestore className="h-4 w-4" />
-            </Button>
-          )}
-          {running && finishAvailable && (
+          <div className="flex shrink-0 items-center gap-1">
+            {owner.kind === "task" && projectId && (
+              <Button size="sm" variant="ghost" onClick={() => navigate(`/projects/${projectId}/tasks/${owner.id}/challenges`)} aria-label="Challenge Workflow" title="Open Challenge Workflow">
+                <Wrench className="h-4 w-4" /> <span className="hidden sm:inline">Challenges</span>
+              </Button>
+            )}
+            {owner.capabilities.rename && !editingTitle && (
+              <Button size="icon" variant="outline" onClick={() => setEditingTitle(true)} aria-label={`Rename ${owner.title}`} title="Rename Session" className="h-8 w-8">
+                <Pencil className="h-4 w-4" />
+              </Button>
+            )}
+            {owner.capabilities.archive && (
+              <Button size="icon" variant="outline" onClick={() => void changeSessionLifecycle("archive")} aria-label="Archive" title="Archive Session" className="h-8 w-8">
+                <Archive className="h-4 w-4" />
+              </Button>
+            )}
+            {owner.capabilities.restore && (
+              <Button size="icon" variant="outline" onClick={() => void changeSessionLifecycle("restore")} aria-label="Restore" title="Restore Session" className="h-8 w-8">
+                <ArchiveRestore className="h-4 w-4" />
+              </Button>
+            )}
+            {running && finishAvailable && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setConfirmAction("finish")}
+                aria-label="Finish task"
+                title="Finish Task: close Runtime and mark completed"
+                data-testid="finish-task"
+              >
+                <Flag className="h-4 w-4" /> <span className="hidden sm:inline">Finish</span>
+              </Button>
+            )}
+            {owner.capabilities.resumeWithoutMessage && !running && (
+              <Button size="sm" variant="ghost" onClick={resumeNative} disabled={!resumeAvailable} aria-label="Resume" title={nativeResumeAvailable ? "Resume native session" : "Start a fresh continuation from the current Task state"}>
+                <Play className="h-4 w-4" /> <span className="hidden sm:inline">Resume</span>
+              </Button>
+            )}
+            {owner.capabilities.delete && (
+              <Button size="icon" variant="outline" onClick={() => setConfirmAction("delete")} aria-label={`Delete ${owner.kind}`} title={`Delete ${owner.kind === "session" ? "Session" : "Task"}`} className="h-8 w-8 text-destructive hover:text-destructive">
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
             <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => setConfirmAction("finish")}
-              aria-label="Finish task"
-              title="Finish Task: close Runtime and mark completed"
-              data-testid="finish-task"
+              size="icon"
+              variant="outline"
+              onClick={() => selectFocus(!focusMode)}
+              aria-label={focusMode ? "Exit focus view" : "Enter focus view"}
+              title={focusMode ? "Exit focus view" : "Enter focus view"}
+              className="h-8 w-8"
             >
-              <Flag className="h-4 w-4" /> <span className="hidden sm:inline">Finish</span>
+              {focusMode ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
             </Button>
-          )}
-          {owner.capabilities.resumeWithoutMessage && !running && (
-            <Button size="sm" variant="ghost" onClick={resumeNative} disabled={!resumeAvailable} aria-label="Resume" title={nativeResumeAvailable ? "Resume native session" : "Start a fresh continuation from the current Task state"}>
-              <Play className="h-4 w-4" /> <span className="hidden sm:inline">Resume</span>
-            </Button>
-          )}
-          {owner.capabilities.delete && (
-            <Button size="icon" variant="ghost" onClick={() => setConfirmAction("delete")} aria-label={`Delete ${owner.kind}`} title={`Delete ${owner.kind === "session" ? "Session" : "Task"}`} className="h-8 w-8 text-destructive hover:text-destructive">
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          )}
-          <Button
-            size="icon"
-            variant="ghost"
-            onClick={() => selectFocus(!focusMode)}
-            aria-label={focusMode ? "Exit focus view" : "Enter focus view"}
-            title={focusMode ? "Exit focus view" : "Enter focus view"}
-            className="h-10 w-10"
-          >
-            {focusMode ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-          </Button>
+          </div>
         </div>
-      </div>
+      </header>
 
       {owner.kind === "session" && !focusMode && (
-        <div role="note" className="shrink-0 border-b border-info/20 bg-info/5 px-3 py-2 text-xs text-muted-foreground">
-          Non-Project Mode · no Project Scope; Runtime execution is unrestricted by Project Scope.
+        <div role="note" className="flex shrink-0 items-center gap-2 border-b border-info/20 bg-info/5 px-3 py-2 text-xs text-muted-foreground">
+          <Info className="h-4 w-4 shrink-0 text-info" aria-hidden="true" />
+          <span>Non-Project Mode — 无 Project Scope 约束，Runtime 执行不受 Scope 限制。</span>
         </div>
       )}
 
@@ -957,7 +953,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
           aria-pressed={activeView === "conversation"}
           onClick={() => selectView("conversation")}
         >
-          <MessageSquare className="h-4 w-4" /> Conversation
+          Conversation
         </button>
         <button
           type="button"
@@ -965,7 +961,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
           aria-pressed={activeView === "timeline"}
           onClick={() => selectView("timeline")}
         >
-          <Activity className="h-4 w-4" /> Timeline
+          Timeline
         </button>
         <div className="ml-auto">
           {activeView === "conversation" ? (
@@ -1027,7 +1023,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
             data-testid="conversation-workspace"
             className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain bg-background px-3 py-5 pb-44 sm:px-6 md:pb-5"
           >
-            <div className="mx-auto max-w-3xl">
+            <div className="mx-auto max-w-[860px]">
               {history.transcriptHasOlder && (
                 <div className="mb-2 flex justify-center">
                   <Button
@@ -1056,6 +1052,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
                   history.transcript,
                   owner.runtimeActivity?.liveness === "live" && owner.runtimeActivity.turn_activity === "busy",
                 )}
+                runtimeLabel={runtimeDisplayName}
               />
               {transcriptWindow.spacerAfter > 0 && (
                 <div aria-hidden="true" data-testid="transcript-spacer-after" style={{ height: transcriptWindow.spacerAfter }} />
@@ -1191,8 +1188,8 @@ function RuntimeOwnerShell({ projectChrome, children, bodyClassName, ...props }:
 
 function tabClass(active: boolean) {
   return [
-    "inline-flex items-center gap-1.5 rounded-t-md border-b-2 px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-    active ? "border-signal text-foreground" : "border-transparent text-muted-foreground hover:text-foreground",
+    "inline-flex h-full items-center border-b-2 px-3 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    active ? "border-primary font-medium text-foreground" : "border-transparent text-muted-foreground hover:text-foreground",
   ].join(" ");
 }
 
@@ -1439,46 +1436,55 @@ function RuntimeOwnerComposer({
                 </label>
               )}
               {onAttachmentsChange && <span className="mx-1 h-4 w-px bg-border" />}
-              <Select
-                size="sm"
-                className="h-7 min-w-0 w-auto max-w-full border-0 bg-transparent px-1.5 text-xs shadow-none focus-visible:ring-2 sm:max-w-[13rem]"
-                name="continuation_model_provider"
-                value={continuationModelProvider}
-                onChange={(event) => onSelectProvider(event.target.value)}
-                aria-label="Continuation model provider"
-              >
-                <option value="">Select model provider</option>
-                {continuationModelProviders.map((provider) => (
-                  <option key={provider.id} value={provider.id}>{provider.name}</option>
-                ))}
-              </Select>
-              <Select
-                size="sm"
-                className="h-7 min-w-0 w-auto max-w-full border-0 bg-transparent px-1.5 text-xs shadow-none focus-visible:ring-2 sm:max-w-[13rem]"
-                name="continuation_model"
-                value={continuationModelOverride}
-                onChange={(event) => onSelectModel(event.target.value)}
-                aria-label="Continuation model"
-                disabled={!continuationModelProvider || continuationModelOptions.length === 0}
-              >
-                {continuationModelOptions.length === 0 ? (
-                  <option value="">Default model</option>
-                ) : continuationModelOptions.map((model) => (
-                  <option key={model} value={model}>{model}</option>
-                ))}
-              </Select>
-              <Select
-                size="sm"
-                className="h-7 min-w-0 w-auto max-w-full border-0 bg-transparent px-1.5 text-xs shadow-none focus-visible:ring-2 sm:max-w-[9rem]"
-                name="continuation_reasoning_effort"
-                value={displayReasoningEffort(continuationReasoningEffort)}
-                onChange={(event) => onSelectReasoningEffort(event.target.value)}
-                aria-label="Continuation reasoning effort"
-              >
-                {REASONING_EFFORT_VALUES.map((effort) => (
-                  <option key={effort} value={effort}>{effort}</option>
-                ))}
-              </Select>
+              <div className="relative max-w-full sm:max-w-[13rem]">
+                <Select
+                  size="sm"
+                  className="h-7 min-w-0 w-auto max-w-full appearance-none border-0 bg-transparent px-1.5 pr-6 text-xs shadow-none focus-visible:ring-2"
+                  name="continuation_model_provider"
+                  value={continuationModelProvider}
+                  onChange={(event) => onSelectProvider(event.target.value)}
+                  aria-label="Continuation model provider"
+                >
+                  <option value="">Select model provider</option>
+                  {continuationModelProviders.map((provider) => (
+                    <option key={provider.id} value={provider.id}>{provider.name}</option>
+                  ))}
+                </Select>
+                <ChevronsUpDown className="pointer-events-none absolute right-1 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+              </div>
+              <div className="relative max-w-full sm:max-w-[13rem]">
+                <Select
+                  size="sm"
+                  className="h-7 min-w-0 w-auto max-w-full appearance-none border-0 bg-transparent px-1.5 pr-6 text-xs font-medium shadow-none focus-visible:ring-2"
+                  name="continuation_model"
+                  value={continuationModelOverride}
+                  onChange={(event) => onSelectModel(event.target.value)}
+                  aria-label="Continuation model"
+                  disabled={!continuationModelProvider || continuationModelOptions.length === 0}
+                >
+                  {continuationModelOptions.length === 0 ? (
+                    <option value="">Default model</option>
+                  ) : continuationModelOptions.map((model) => (
+                    <option key={model} value={model}>{model}</option>
+                  ))}
+                </Select>
+                <ChevronsUpDown className="pointer-events-none absolute right-1 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+              </div>
+              <div className="relative max-w-full sm:max-w-[9rem]">
+                <Select
+                  size="sm"
+                  className="h-7 min-w-0 w-auto max-w-full appearance-none border-0 bg-transparent px-1.5 pr-6 text-xs shadow-none focus-visible:ring-2"
+                  name="continuation_reasoning_effort"
+                  value={displayReasoningEffort(continuationReasoningEffort)}
+                  onChange={(event) => onSelectReasoningEffort(event.target.value)}
+                  aria-label="Continuation reasoning effort"
+                >
+                  {REASONING_EFFORT_VALUES.map((effort) => (
+                    <option key={effort} value={effort}>{effort}</option>
+                  ))}
+                </Select>
+                <ChevronsUpDown className="pointer-events-none absolute right-1 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+              </div>
               {!runtimeOffline && (
                 <Badge variant={sendMode === "unavailable" ? "warning" : "outline"} size="sm">
                   {providerSwitchRequested ? "switch provider" : conversationModeText(sendMode)}
@@ -1546,36 +1552,35 @@ function RuntimeOwnerComposer({
 
 function StatusBadge({ status }: { status: string }) {
   const variant =
-    status === "completed" ? "success" :
-    status === "running" ? "primary" :
-    status === "failed" ? "destructive" :
-    status === "stopped" ? "warning" :
-    status === "interrupted" ? "warning" : "outline";
-  return <Badge variant={variant} className="shrink-0 whitespace-nowrap">{status}</Badge>;
+    status === "running" ? "success" :
+    status === "failed" ? "danger" :
+    status === "paused" || status === "interrupted" ? "warning" : "neutral";
+  const label = status ? status[0]!.toUpperCase() + status.slice(1) : "Unknown";
+  return <Chip variant={variant} dot className="shrink-0 whitespace-nowrap">{label}</Chip>;
 }
 
 function RuntimeActivityBadge({ activity }: { activity?: RuntimeActivity }) {
   if (!activity?.liveness) return null;
-  const liveness = activity.liveness;
-  const turn = activity.turn_activity;
   const label =
-    liveness === "live" && turn
-      ? `runtime ${liveness} · ${turn}`
-      : `runtime ${liveness}`;
+    activity.liveness === "live"
+      ? activity.turn_activity === "busy" ? "Runtime busy" : "Runtime idle"
+      : activity.liveness === "offline"
+        ? "Runtime offline"
+        : "Runtime state unknown";
   const variant =
-    liveness === "live" ? "primary" :
-    liveness === "offline" ? "outline" :
-    liveness === "orphaned" ? "warning" :
-    liveness === "unknown" ? "warning" : "outline";
+    activity.liveness === "live"
+      ? activity.turn_activity === "busy" ? "success" : "info"
+      : activity.liveness === "offline" ? "danger" : "warning";
   return (
-    <Badge
+    <Chip
       variant={variant}
+      dot
       data-testid="runtime-activity"
       title={activity.warning || label}
       className="shrink-0 whitespace-nowrap"
     >
       {label}
-    </Badge>
+    </Chip>
   );
 }
 
@@ -1583,14 +1588,15 @@ function BlackboardConclusionBadge({ owner }: { owner: RuntimeOwnerView }) {
   const mode = runtimeOwnerBlackboardMode(owner);
   if (mode === "disabled") {
     return (
-      <Badge
-        variant="outline"
+      <Chip
+        variant="neutral"
+        dot
         data-testid="blackboard-conclusion-state"
         title="Blackboard: Disabled"
         className="min-w-0 shrink"
       >
         <span className="truncate whitespace-nowrap">Blackboard: Disabled</span>
-      </Badge>
+      </Chip>
     );
   }
   const state = owner.blackboardConclusion?.state ?? "clean";
@@ -1602,14 +1608,15 @@ function BlackboardConclusionBadge({ owner }: { owner: RuntimeOwnerView }) {
   if (sourceTurn) details.push(`source Turn ${sourceTurn}`);
   if (appliedRevision !== undefined) details.push(`applied revision ${appliedRevision}`);
   return (
-    <Badge
-      variant={state === "action_required" ? "destructive" : state === "pending" || state === "concluding" ? "warning" : "outline"}
+    <Chip
+      variant={state === "action_required" ? "danger" : state === "pending" || state === "concluding" ? "warning" : "signal"}
+      dot
       data-testid="blackboard-conclusion-state"
       title={details.join(" · ")}
       className="min-w-0 shrink"
     >
       <span className="truncate whitespace-nowrap">{label}</span>
-    </Badge>
+    </Chip>
   );
 }
 
@@ -1687,29 +1694,53 @@ function liveReasoningEntryID(entries: TaskTranscriptEntry[], runtimeBusy: boole
   return undefined;
 }
 
+type TranscriptLane = "user" | "runtime" | "system" | "divider";
+
+type TranscriptDisplayRow = {
+  entry: TaskTranscriptEntry;
+  result?: TaskTranscriptEntry;
+  lane: TranscriptLane;
+  laneStart: boolean;
+};
+
 function TranscriptList({
   entries,
   endRef,
   liveReasoningID,
+  runtimeLabel,
 }: {
   entries: TaskTranscriptEntry[];
   endRef: RefObject<HTMLDivElement | null>;
   liveReasoningID?: string;
+  runtimeLabel: string;
 }) {
+  const rows = buildTranscriptRows(entries);
   return (
     <div>
-      {entries.map((entry, index) => {
-        // A user message starts a new turn and gets breathing room above it.
-        // Everything inside an agent turn — assistant messages, tool calls,
-        // tool results — stays tight so the agent's reasoning reads as one block.
-        const spacing = index === 0 ? "" : isUserTurnStart(entry) ? "mt-4" : "mt-1";
+      {rows.map((row, index) => {
+        const spacing = index === 0 ? "" : row.lane === "user" && row.laneStart ? "mt-4" : "mt-1";
         return (
           <div
-            key={entry.id}
+            key={row.entry.id}
             data-testid="transcript-row"
             className={`[contain-intrinsic-size:72px] [content-visibility:auto] ${spacing}`}
           >
-            <TranscriptRow entry={entry} autoExpandReasoning={entry.id === liveReasoningID} />
+            {row.lane === "divider" ? (
+              <TranscriptRow entry={row.entry} />
+            ) : (
+              <TranscriptTurnGroup
+                lane={row.lane}
+                showMarker={row.laneStart}
+                entry={row.entry}
+                runtimeLabel={runtimeLabel}
+              >
+                <TranscriptRow
+                  entry={row.entry}
+                  pairedResult={row.result}
+                  autoExpandReasoning={row.entry.id === liveReasoningID}
+                />
+              </TranscriptTurnGroup>
+            )}
           </div>
         );
       })}
@@ -1724,17 +1755,91 @@ function TranscriptList({
   );
 }
 
-// isUserTurnStart identifies a row that begins a new operator turn. Only these
-// get the roomier spacing; agent reasoning (assistant text, tool calls, tool
-// results) stays tight so a single agent turn reads as one cohesive block.
-function isUserTurnStart(entry: TaskTranscriptEntry): boolean {
-  if (entry.kind === "continuation" || entry.kind === "tool_call" || entry.kind === "tool_result") {
-    return false;
+function buildTranscriptRows(entries: TaskTranscriptEntry[]): TranscriptDisplayRow[] {
+  const resultByCallID = new Map<string, TaskTranscriptEntry>();
+  for (const entry of entries) {
+    if (entry.kind === "tool_result" && entry.tool_call_id) resultByCallID.set(entry.tool_call_id, entry);
   }
-  return entry.role === "user";
+  const absorbedResults = new Set<string>();
+  const rows: TranscriptDisplayRow[] = [];
+  for (const entry of entries) {
+    if (absorbedResults.has(entry.id)) continue;
+    const result = entry.kind === "tool_call" && entry.tool_call_id ? resultByCallID.get(entry.tool_call_id) : undefined;
+    if (result) absorbedResults.add(result.id);
+    const lane = transcriptLane(entry);
+    rows.push({
+      entry,
+      result,
+      lane,
+      laneStart: lane === "divider" || rows.length === 0 || rows[rows.length - 1]!.lane !== lane,
+    });
+  }
+  return rows;
 }
 
-function TranscriptRow({ entry, autoExpandReasoning = false }: { entry: TaskTranscriptEntry; autoExpandReasoning?: boolean }) {
+function transcriptLane(entry: TaskTranscriptEntry): TranscriptLane {
+  if (entry.kind === "continuation") return "divider";
+  if (entry.role === "user") return "user";
+  if (entry.role === "system") return "system";
+  return "runtime";
+}
+
+function TranscriptTurnGroup({
+  lane,
+  showMarker,
+  entry,
+  runtimeLabel,
+  children,
+}: {
+  lane: Exclude<TranscriptLane, "divider">;
+  showMarker: boolean;
+  entry: TaskTranscriptEntry;
+  runtimeLabel: string;
+  children: ReactNode;
+}) {
+  const label = lane === "user" ? "你" : lane === "runtime" ? runtimeLabel : "System";
+  return (
+    <div className="relative pl-6">
+      {showMarker && (
+        <span
+          className={cn(
+            "absolute left-0 top-1 flex h-4 w-4 items-center justify-center rounded-full border",
+            lane === "user" && "border-border bg-card",
+            lane === "runtime" && "border-signal/40 bg-signal/10 text-signal",
+            lane === "system" && "border-border bg-muted",
+          )}
+        >
+          {lane === "user" && <User className="h-2.5 w-2.5" aria-hidden="true" />}
+          {lane === "runtime" && <Bot className="h-2.5 w-2.5" aria-hidden="true" />}
+          {lane === "system" && <GitBranch className="h-2.5 w-2.5" aria-hidden="true" />}
+        </span>
+      )}
+      <div className="border-l border-border pl-4">
+        {showMarker && (
+          <div data-testid="transcript-turn-header" className="mb-1 flex items-center gap-2 text-xs">
+            <span className={cn("font-medium", lane === "runtime" && "text-signal")}>{label}</span>
+            {entry.created_at && (
+              <span className="text-muted-foreground" title={formatDateTime(entry.created_at)}>
+                {formatRelativeTime(entry.created_at)}
+              </span>
+            )}
+          </div>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function TranscriptRow({
+  entry,
+  pairedResult,
+  autoExpandReasoning = false,
+}: {
+  entry: TaskTranscriptEntry;
+  pairedResult?: TaskTranscriptEntry;
+  autoExpandReasoning?: boolean;
+}) {
   if (entry.kind === "continuation") {
     return (
       <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground">
@@ -1752,41 +1857,61 @@ function TranscriptRow({ entry, autoExpandReasoning = false }: { entry: TaskTran
     return <AttachmentFileRow name={filename} size={size} prefix="Attached" />;
   }
 
-  if (isCollapsedTranscriptEntry(entry)) {
+  if (entry.kind === "tool_call" || entry.kind === "tool_result") {
+    return (
+      <ToolTranscriptRow
+        call={entry.kind === "tool_call" ? entry : undefined}
+        result={entry.kind === "tool_call" ? pairedResult : entry}
+      />
+    );
+  }
+
+  if (entry.kind === "reasoning" || entry.kind === "runtime_output") {
     return <CollapsedTranscriptRow entry={entry} autoExpand={autoExpandReasoning && entry.kind === "reasoning"} />;
   }
 
   const isUser = entry.role === "user";
-  const isAssistant = entry.role === "assistant";
-  const Icon = isUser ? User : MessageSquare;
-  const roleLabel = isUser ? "You" : isAssistant ? "Agent" : entry.role;
+  const isAssistant = entry.role === "assistant" || entry.role === "runtime";
   return (
-    <div className={`flex gap-3 text-sm ${isUser ? "justify-end pl-8 sm:pl-16" : "justify-start pr-2 sm:pr-8"}`}>
-      {!isUser && !isAssistant && (
-        <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/60 text-muted-foreground">
-          <Icon className="h-4 w-4" />
-        </span>
+    <div
+      data-testid="transcript-message-bubble"
+      className={cn(
+        "min-w-0 whitespace-pre-wrap break-words text-sm leading-6 text-foreground",
+        isUser && "rounded-lg border border-border bg-card px-3.5 py-3",
+        isAssistant && "border-l-2 border-signal/40 py-1 pl-4",
+        !isUser && !isAssistant && "rounded-md border border-border bg-muted/30 px-3 py-2",
       )}
-      <div
-        data-testid="transcript-message-bubble"
-        className={`min-w-0 max-w-[88%] rounded-lg px-3 py-2 sm:px-3.5 ${isUser ? "bg-primary/10 dark:bg-primary/15" : "bg-transparent px-0"}`}
-      >
-        {!isAssistant && (
-          <div className="mb-1 text-[11px] font-medium text-muted-foreground">
-            {roleLabel}
-            {entry.created_at && (
-              <span className="font-normal text-muted-foreground/70"> · {formatDateTime(entry.created_at)}</span>
-            )}
-          </div>
-        )}
-        <div className="whitespace-pre-wrap break-words leading-6 text-foreground">{entry.text}</div>
-      </div>
-      {isUser && (
-        <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-foreground/70 dark:bg-primary/15">
-          <Icon className="h-4 w-4" />
-        </span>
-      )}
+    >
+      {entry.text}
     </div>
+  );
+}
+
+function ToolTranscriptRow({ call, result }: { call?: TaskTranscriptEntry; result?: TaskTranscriptEntry }) {
+  const [manuallyOpen, setManuallyOpen] = useState(false);
+  const isError = Boolean((result?.details as { is_error?: boolean } | undefined)?.is_error) || result?.status === "failed";
+  const title = call ? collapsedTranscriptTitle(call) : result ? collapsedTranscriptTitle(result) : "Tool";
+  const duration = call?.created_at && result?.created_at ? formatTranscriptDuration(call.created_at, result.created_at) : "";
+  return (
+    <details
+      data-testid="transcript-tool-row"
+      open={manuallyOpen}
+      onToggle={(event) => setManuallyOpen(event.currentTarget.open)}
+      className="group"
+    >
+      <summary className="-mx-1 flex min-h-9 cursor-pointer list-none items-center gap-2 rounded-sm px-1 py-1.5 text-sm transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+        {isError ? <CircleX className="h-4 w-4 shrink-0 text-destructive" /> : <CheckCircle2 className="h-4 w-4 shrink-0 text-success" />}
+        <span className="min-w-0 flex-1 truncate font-mono text-[13px] text-muted-foreground transition-colors group-hover:text-foreground group-open:text-foreground">{title}</span>
+        {result?.text && <span className="max-w-[40%] truncate text-xs text-muted-foreground">{collapsedTranscriptTitle(result)}</span>}
+        {isError && <Chip variant="danger" className="h-4 px-1 text-[9px]">failed</Chip>}
+        {duration && <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">{duration}</span>}
+      </summary>
+      <div className="ml-[1.625rem] space-y-3 border-l border-border/60 pb-3 pl-4 pr-2 pt-2">
+        {call && <ToolCallDetails entry={call} />}
+        {result && <pre className="overflow-x-auto whitespace-pre-wrap break-words text-xs leading-5 text-foreground/80">{result.text || "(empty)"}</pre>}
+      </div>
+    </details>
   );
 }
 
@@ -1794,46 +1919,40 @@ function CollapsedTranscriptRow({ entry, autoExpand = false }: { entry: TaskTran
   const [manuallyOpen, setManuallyOpen] = useState(false);
   const wasAutoExpanded = useRef(false);
   useEffect(() => {
-    // A live reasoning row opens automatically. When streaming stops, close
-    // it once; completed rows remain manually expandable across later polls.
     if (wasAutoExpanded.current && !autoExpand) setManuallyOpen(false);
     wasAutoExpanded.current = autoExpand;
   }, [autoExpand]);
-  const isError = entry.kind === "tool_result" && (entry.details as { is_error?: boolean } | undefined)?.is_error === true;
-  const Icon =
-    entry.kind === "reasoning"
-      ? Brain
-      : entry.kind === "runtime_output"
-        ? Terminal
-      : entry.kind === "tool_result"
-        ? isError
-          ? CircleX
-          : CheckCircle2
-        : Wrench;
+  const isReasoning = entry.kind === "reasoning";
+  const Icon = isReasoning ? Brain : Terminal;
   return (
     <details
-      data-testid={entry.kind === "reasoning" ? "transcript-reasoning-row" : "transcript-tool-row"}
+      data-testid={isReasoning ? "transcript-reasoning-row" : "transcript-tool-row"}
       open={autoExpand || manuallyOpen}
       onToggle={(event) => {
         if (!autoExpand) setManuallyOpen(event.currentTarget.open);
       }}
-      className="group border-b border-border/50 last:border-b-0"
+      className="group"
     >
-      <summary className="-mx-1 flex min-h-9 cursor-pointer list-none items-center gap-2 rounded-sm px-1 py-1.5 text-sm transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+      <summary className={cn(
+        "-mx-1 flex min-h-9 cursor-pointer list-none items-center gap-2 rounded-sm px-1 py-1.5 text-sm transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden",
+        isReasoning && "italic text-muted-foreground",
+      )}>
         <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
-        <Icon className={`h-4 w-4 shrink-0 ${isError ? "text-destructive" : "text-muted-foreground"}`} />
-        <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground transition-colors group-hover:text-foreground group-open:text-foreground">{collapsedTranscriptTitle(entry)}</span>
-        {entry.created_at && <span className="ml-auto shrink-0 text-[11px] tabular-nums text-muted-foreground/70">{formatDateTime(entry.created_at)}</span>}
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-[13px] transition-colors group-hover:text-foreground group-open:text-foreground">{collapsedTranscriptTitle(entry)}</span>
       </summary>
       <div className="ml-[1.625rem] border-l border-border/60 pb-3 pl-4 pr-2 pt-2">
-        {entry.kind === "tool_call" ? (
-          <ToolCallDetails entry={entry} />
-        ) : (
-          <pre className="overflow-x-auto whitespace-pre-wrap break-words text-xs leading-5 text-foreground/80">{collapsedBody(entry)}</pre>
-        )}
+        <pre className="overflow-x-auto whitespace-pre-wrap break-words text-xs leading-5 text-foreground/80">{collapsedBody(entry)}</pre>
       </div>
     </details>
   );
+}
+
+function formatTranscriptDuration(start: string, end: string): string {
+  const milliseconds = Date.parse(end) - Date.parse(start);
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) return "";
+  if (milliseconds < 1000) return `${milliseconds}ms`;
+  return `${(milliseconds / 1000).toFixed(milliseconds < 10_000 ? 1 : 0)}s`;
 }
 
 function ToolCallDetails({ entry }: { entry: TaskTranscriptEntry }) {
@@ -1862,9 +1981,6 @@ function ToolCallDetails({ entry }: { entry: TaskTranscriptEntry }) {
   );
 }
 
-function isCollapsedTranscriptEntry(entry: TaskTranscriptEntry) {
-  return entry.kind === "reasoning" || entry.kind === "tool_call" || entry.kind === "tool_result" || entry.kind === "runtime_output";
-}
 
 function collapsedBody(entry: TaskTranscriptEntry) {
   if (entry.kind === "tool_result") return entry.text || "(empty)";

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, useRef, type KeyboardEvent, type ReactNode, type RefObject } from "react";
 import { flushSync } from "react-dom";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { Square, Send, Terminal, GitBranch, MessageSquare, Play, ChevronRight, ChevronsUpDown, Wrench, User, Bot, ArrowDown, ArrowUp, CheckCircle2, Trash2, CircleX, KeyRound, ListPlus, Loader2, Maximize2, Minimize2, Flag, RefreshCcw, TriangleAlert, Archive, ArchiveRestore, Pencil, Paperclip, Brain, PlugZap, Info } from "lucide-react";
+import { Square, Terminal, GitBranch, MessageSquare, Play, ChevronRight, ChevronsUpDown, Wrench, User, Bot, ArrowDown, ArrowUp, CheckCircle2, Trash2, CircleX, KeyRound, ListPlus, Loader2, Maximize2, Minimize2, Flag, RefreshCcw, TriangleAlert, Archive, ArchiveRestore, Pencil, Paperclip, Brain, PlugZap, Info } from "lucide-react";
 import { apiGet, type FinishReadiness, type ModelProvider, type ProviderPermissionRequest, type RuntimeActivity, type RuntimePlugin, type RuntimeProfile, type TaskTranscriptEntry } from "@/lib/api";
 import { Button, Badge, Chip, Input, Select, Textarea } from "@/components/ui";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -803,6 +803,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
       hideChrome={focusMode}
       data-testid="task-detail-shell"
       className={focusMode ? "h-[calc(100dvh-3.5rem)] max-w-none p-0 md:h-dvh lg:p-0" : "flex min-h-full flex-col"}
+      contentClassName={focusMode ? undefined : "max-w-none px-0 pb-0 lg:px-0 lg:pb-0"}
       bodyClassName={focusMode ? "flex h-full min-h-0 flex-col" : "flex min-h-[32rem] flex-1 flex-col pb-0 lg:min-h-0"}
     >
       <header data-testid="task-session-header" className="shrink-0 px-2 py-2 sm:px-3">
@@ -832,7 +833,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
               <div
                 data-testid="continuation-summary"
                 title={continuationTitle}
-                className="mt-1 hidden min-w-0 items-center gap-1 overflow-hidden whitespace-nowrap font-mono text-xs text-muted-foreground sm:flex"
+                className="mt-1 hidden min-w-0 items-center gap-1 overflow-hidden whitespace-nowrap font-mono text-[11px] text-muted-foreground sm:flex"
               >
                 <span>continuation #{currentContinuation.number}</span>
                 <span aria-hidden="true">·</span>
@@ -840,7 +841,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
                 <span aria-hidden="true">·</span>
                 <span>runner {owner.runner}</span>
                 <span aria-hidden="true">·</span>
-                <span>{formatRelativeTime(owner.updatedAt)} 更新</span>
+                <span>Updated {formatRelativeTime(owner.updatedAt)}</span>
               </div>
             )}
           </div>
@@ -904,7 +905,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
       {owner.kind === "session" && !focusMode && (
         <div role="note" className="flex shrink-0 items-center gap-2 border-b border-info/20 bg-info/5 px-3 py-2 text-xs text-muted-foreground">
           <Info className="h-4 w-4 shrink-0 text-info" aria-hidden="true" />
-          <span>Non-Project Mode — 无 Project Scope 约束，Runtime 执行不受 Scope 限制。</span>
+          <span>Non-Project Mode — no Project Scope is applied, so Runtime execution is not Scope-constrained.</span>
         </div>
       )}
 
@@ -1169,19 +1170,20 @@ type RuntimeOwnerShellProps = {
   hideChrome?: boolean;
   className?: string;
   bodyClassName?: string;
+  contentClassName?: string;
   "data-testid"?: string;
 };
 
-function RuntimeOwnerShell({ projectChrome, children, bodyClassName, ...props }: RuntimeOwnerShellProps) {
+function RuntimeOwnerShell({ projectChrome, children, bodyClassName, contentClassName, ...props }: RuntimeOwnerShellProps) {
   if (projectChrome) {
-    return <ProjectPageShell bodyClassName={bodyClassName} {...props}>{children}</ProjectPageShell>;
+    return <ProjectPageShell bodyClassName={bodyClassName} contentClassName={contentClassName} {...props}>{children}</ProjectPageShell>;
   }
   return (
     <PageContainer
       data-testid={props["data-testid"]}
-      className={`mx-auto w-full max-w-6xl ${props.className ?? ""}`}
+      className={cn("flex w-full max-w-none min-w-0 flex-col p-0 lg:p-0", props.className)}
     >
-      <div className={bodyClassName}>{children}</div>
+      <div className={cn("flex min-w-0 w-full flex-1 flex-col", contentClassName, bodyClassName)}>{children}</div>
     </PageContainer>
   );
 }
@@ -1394,7 +1396,7 @@ function RuntimeOwnerComposer({
         {runtimeOffline && (
           <div className="flex items-center gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-[hsl(28_90%_32%)]">
             <PlugZap className="h-3.5 w-3.5 flex-none" />
-            <span>Runtime 当前离线。发送消息将恢复此 Session 并启动新的 Runtime。</span>
+            <span>The Runtime is offline. Sending a message resumes this Session with a new Runtime.</span>
           </div>
         )}
         {steerState === "action_required" && (
@@ -1415,12 +1417,13 @@ function RuntimeOwnerComposer({
             onChange={(event) => onChange(event.target.value)}
             onKeyDown={onKeyDown}
             placeholder="Focus on admin.example.com next…"
+            title="Enter to send; Shift+Enter for a new line"
             rows={2}
             autoComplete="off"
             className="max-h-40 min-h-[60px] resize-y rounded-none border-0 bg-transparent px-3 py-2.5 shadow-none focus-visible:border-transparent focus-visible:ring-0"
           />
-          <div className="flex flex-wrap items-center gap-1.5 px-2 py-1.5">
-            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-1.5 px-2 py-1.5 md:flex-nowrap">
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 md:flex-nowrap">
               {onAttachmentsChange && (
                 <label className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md border-0 bg-transparent px-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
                   <Paperclip className="h-3.5 w-3.5" />
@@ -1470,10 +1473,10 @@ function RuntimeOwnerComposer({
                 </Select>
                 <ChevronsUpDown className="pointer-events-none absolute right-1 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
               </div>
-              <div className="relative max-w-full sm:max-w-[9rem]">
+              <div className="relative w-[5.25rem] shrink-0">
                 <Select
                   size="sm"
-                  className="h-7 min-w-0 w-auto max-w-full appearance-none border-0 bg-transparent px-1.5 pr-6 text-xs shadow-none focus-visible:ring-2"
+                  className="h-7 w-full appearance-none whitespace-nowrap border-0 bg-transparent px-1.5 pr-6 text-xs shadow-none focus-visible:ring-2"
                   name="continuation_reasoning_effort"
                   value={displayReasoningEffort(continuationReasoningEffort)}
                   onChange={(event) => onSelectReasoningEffort(event.target.value)}
@@ -1502,7 +1505,6 @@ function RuntimeOwnerComposer({
               )}
             </div>
             <div className="ml-auto flex shrink-0 items-center gap-1">
-              <span className="mr-1 hidden text-xs text-muted-foreground sm:inline">Enter 发送 · Shift+Enter 换行</span>
               {running && queueAvailable && sendMode !== "queue" && (
                 <Button
                   size="icon-xl"
@@ -1534,13 +1536,14 @@ function RuntimeOwnerComposer({
                 </Button>
               )}
               <Button
+                data-testid="composer-send"
                 size="icon-xl"
                 onClick={onSend}
                 disabled={!value.trim() || sending || sendMode === "unavailable" || (providerSwitchRequested && !providerSwitchAvailable)}
                 aria-label={sendActionLabel}
                 title={sendActionLabel}
               >
-                {sending ? <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" /> : sendMode === "resume" ? <Play className="h-4 w-4" /> : <Send className="h-4 w-4" />}
+                {sending ? <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" /> : <ArrowUp className="h-4 w-4" />}
               </Button>
             </div>
           </div>
@@ -1797,7 +1800,7 @@ function TranscriptTurnGroup({
   runtimeLabel: string;
   children: ReactNode;
 }) {
-  const label = lane === "user" ? "你" : lane === "runtime" ? runtimeLabel : "System";
+  const label = lane === "user" ? "You" : lane === "runtime" ? runtimeLabel : "System";
   return (
     <div className="relative pl-6">
       {showMarker && (

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -803,10 +803,10 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
       hideChrome={focusMode}
       data-testid="task-detail-shell"
       className={focusMode ? "h-[calc(100dvh-3.5rem)] max-w-none p-0 md:h-dvh lg:p-0" : "flex min-h-full flex-col"}
-      contentClassName={focusMode ? undefined : "max-w-none px-0 pb-0 lg:px-0 lg:pb-0"}
+      contentClassName={focusMode ? undefined : "mx-auto max-w-6xl px-0 pb-0 lg:px-0 lg:pb-0"}
       bodyClassName={focusMode ? "flex h-full min-h-0 flex-col" : "flex min-h-[32rem] flex-1 flex-col pb-0 lg:min-h-0"}
     >
-      <header data-testid="task-session-header" className="shrink-0 px-2 py-2 sm:px-3">
+      <header data-testid="task-session-header" className="shrink-0 rounded-t-xl border border-b-0 border-border bg-card px-2 py-2 sm:px-3">
         <div className="flex min-w-0 items-start gap-2">
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -947,7 +947,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
         />
       )}
 
-      <div className="flex h-10 shrink-0 items-center gap-1 px-2 sm:px-3">
+      <div className="flex h-10 shrink-0 items-center gap-1 border-x border-border bg-card px-2 sm:px-3">
         <button
           type="button"
           className={tabClass(activeView === "conversation")}
@@ -975,7 +975,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
 
       <div
         data-testid="task-workspace"
-        className="flex min-h-[28rem] min-w-0 flex-1 flex-col overflow-visible bg-card/30 md:overflow-hidden lg:min-h-0"
+        className="flex min-h-[28rem] min-w-0 flex-1 flex-col overflow-visible rounded-b-xl border border-border bg-card/30 md:overflow-hidden lg:min-h-0"
       >
         {activeView === "timeline" ? (
           <div className="min-h-0 flex-1 overflow-hidden p-2 pb-44 sm:p-3 md:pb-5">
@@ -1181,7 +1181,7 @@ function RuntimeOwnerShell({ projectChrome, children, bodyClassName, contentClas
   return (
     <PageContainer
       data-testid={props["data-testid"]}
-      className={cn("flex w-full max-w-none min-w-0 flex-col p-0 lg:p-0", props.className)}
+      className={cn("mx-auto flex w-full max-w-6xl min-w-0 flex-col p-0 lg:p-0", props.className)}
     >
       <div className={cn("flex min-w-0 w-full flex-1 flex-col", contentClassName, bodyClassName)}>{children}</div>
     </PageContainer>
@@ -1390,7 +1390,7 @@ function RuntimeOwnerComposer({
   // resume: explain the state and its consequence instead of a bare badge.
   const runtimeOffline = sendMode === "resume";
   return (
-    <div data-testid="task-composer" className="fixed inset-x-0 bottom-0 z-30 shrink-0 bg-background/95 px-3 py-2 shadow-[0_-8px_24px] shadow-black/15 backdrop-blur-sm sm:px-4 md:static md:z-10 md:shadow-none">
+    <div data-testid="task-composer" className="fixed inset-x-0 bottom-0 z-30 shrink-0 bg-background/95 px-3 py-2 shadow-[0_-8px_24px] shadow-black/15 backdrop-blur-sm sm:px-4 md:static md:z-10 md:shadow-none lg:px-0">
       <div className="mx-auto max-w-3xl space-y-2">
         {actionError && <p role="alert" className="text-xs text-destructive">{actionError}</p>}
         {runtimeOffline && (

--- a/web/src/pages/TaskLaunchPage.test.tsx
+++ b/web/src/pages/TaskLaunchPage.test.tsx
@@ -117,7 +117,7 @@ describe("TaskLaunchPage", () => {
 
     await screen.findByRole("option", { name: "MiMo" });
     await user.selectOptions(await screen.findByLabelText("Task type"), "pentest");
-    await user.type(screen.getByLabelText("你想探索什么？"), "Inspect the target");
+    await user.type(screen.getByLabelText("What do you want to explore?"), "Inspect the target");
     await user.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
     const disabledMode = screen.getByRole("radio", { name: /^Disabled/ });
     expect(disabledMode).toBeEnabled();
@@ -284,7 +284,7 @@ describe("TaskLaunchPage", () => {
     expect(screen.getByRole("radio", { name: /^Interactive/ })).toHaveAttribute("aria-checked", "true");
     await userEvent.click(screen.getByRole("radio", { name: /^Assisted/ }));
     expect(screen.getByText(/runs a bounded Conclude Turn and applies its validated Attempt result/i)).toBeInTheDocument();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await userEvent.clear(screen.getByLabelText("Maximum wrong submissions"));
     await userEvent.type(screen.getByLabelText("Maximum wrong submissions"), "3");
     await userEvent.clear(screen.getByLabelText("Maximum rating drawdown"));
@@ -403,7 +403,7 @@ describe("TaskLaunchPage", () => {
     expect(screen.getByRole("radio", { name: /^Assisted/ })).toBeDisabled();
     expect(screen.getByText(/does not expose the complete persistent Turn, normalized Tool\/Turn event, and closed AttemptResult contract/i)).toBeInTheDocument();
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
   });
 
@@ -488,7 +488,7 @@ describe("TaskLaunchPage", () => {
 
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /use a saved Runtime Profile/i }));
     await userEvent.selectOptions(await screen.findByLabelText("Runtime Profile"), "codex-preset");
     await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     expect(await screen.findByText(/selected runtime profile/i)).toBeInTheDocument();
@@ -728,7 +728,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
 
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /use a saved Runtime Profile/i }));
     await userEvent.selectOptions(await screen.findByLabelText("Runtime Profile"), "codex-preset");
     await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     expect(await screen.findByText("No skills enabled for this profile.")).toBeInTheDocument();
@@ -814,13 +814,13 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    await userEvent.click(screen.getByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.click(screen.getByRole("button", { name: /use a saved Runtime Profile/i }));
     expect(screen.getByLabelText("Runtime Profile")).toHaveValue("");
     expect(screen.getByLabelText("Runtime")).not.toBeDisabled();
     expect(screen.getByLabelText("Model provider")).not.toBeDisabled();
 
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
@@ -917,11 +917,11 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
 
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /use a saved Runtime Profile/i }));
     await userEvent.selectOptions(screen.getByLabelText("Runtime Profile"), "legacy-preset");
     expect(screen.getByLabelText("Runtime Profile")).toHaveValue("legacy-preset");
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run legacy recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run legacy recon");
 
     const launchButton = screen.getByRole("button", { name: /launch/i });
     expect(launchButton).not.toBeDisabled();
@@ -1022,7 +1022,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     renderPage();
 
     await selectPentestTaskType();
-    await userEvent.type(await screen.findByLabelText("你想探索什么？"), "Run with extension");
+    await userEvent.type(await screen.findByLabelText("What do you want to explore?"), "Run with extension");
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
@@ -1140,7 +1140,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
 
     renderPage();
     await selectPentestTaskType();
-    await userEvent.type(await screen.findByLabelText("你想探索什么？"), "Probe sandbox env");
+    await userEvent.type(await screen.findByLabelText("What do you want to explore?"), "Probe sandbox env");
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
@@ -1260,14 +1260,14 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
 
     renderPage();
 
-    const presetToggle = await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i });
+    const presetToggle = await screen.findByRole("button", { name: /use a saved Runtime Profile/i });
     expect(presetToggle).toHaveAttribute("aria-expanded", "false");
     await userEvent.click(presetToggle);
     expect(presetToggle).toHaveAttribute("aria-expanded", "true");
     await userEvent.selectOptions(screen.getByLabelText("Runtime Profile"), "");
 
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     const preview = await screen.findByText("Model provider", { selector: "p" });
@@ -1375,7 +1375,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     await screen.findByRole("option", { name: "mimo-v2-pro" });
     await userEvent.selectOptions(modelSelect, "mimo-v2-pro");
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     expect(await screen.findByText("Model provider", { selector: "p" })).toBeInTheDocument();
@@ -1463,7 +1463,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     renderPage();
 
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     expect(await screen.findByText("Codex multi-agent tools", { selector: "p" })).toBeInTheDocument();
@@ -1583,7 +1583,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     await userEvent.click(await screen.findByRole("button", { name: /runner/i }));
     await userEvent.selectOptions(await screen.findByLabelText("Docker network"), "host_proxy_only");
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
@@ -1708,7 +1708,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     await userEvent.click(await screen.findByRole("button", { name: /runner/i }));
     await userEvent.click(await screen.findByRole("checkbox", { name: /vpn tun/i }));
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Connect OpenVPN");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Connect OpenVPN");
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
@@ -1785,7 +1785,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     expect(screen.getByText(/Container engine/i)).toBeInTheDocument();
     expect(screen.getByLabelText("Podman network")).toBeInTheDocument();
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Use podman");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Use podman");
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
     await waitFor(() => {
@@ -1901,7 +1901,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     await userEvent.click(screen.getByLabelText(/explicitly activate the host runner/i));
     await userEvent.selectOptions(screen.getByLabelText("Runner"), "docker");
     await selectPentestTaskType();
-    await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(screen.getByLabelText("What do you want to explore?"), "Run recon");
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /launch/i }));
 
@@ -1969,7 +1969,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
 
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /use a saved Runtime Profile/i }));
     const presetSelect = screen.getByLabelText("Runtime Profile");
     await userEvent.selectOptions(presetSelect, "codex-preset");
     expect(presetSelect).toHaveValue("codex-preset");
@@ -2118,7 +2118,7 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     renderPage();
 
     await selectPentestTaskType();
-    await userEvent.type(await screen.findByLabelText("你想探索什么？"), "Run recon");
+    await userEvent.type(await screen.findByLabelText("What do you want to explore?"), "Run recon");
     const file = new File(["secret-notes"], "notes.txt", { type: "text/plain" });
     await userEvent.upload(screen.getByLabelText("Attachments"), file);
     expect(screen.getByText("notes.txt")).toBeInTheDocument();

--- a/web/src/pages/TaskLaunchPage.test.tsx
+++ b/web/src/pages/TaskLaunchPage.test.tsx
@@ -119,9 +119,9 @@ describe("TaskLaunchPage", () => {
     await user.selectOptions(await screen.findByLabelText("Task type"), "pentest");
     await user.type(screen.getByLabelText("你想探索什么？"), "Inspect the target");
     await user.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
-    const mode = screen.getByLabelText("Blackboard conclusions");
-    expect(screen.getByRole("option", { name: "Disabled" })).toBeEnabled();
-    await user.selectOptions(mode, "disabled");
+    const disabledMode = screen.getByRole("radio", { name: /^Disabled/ });
+    expect(disabledMode).toBeEnabled();
+    await user.click(disabledMode);
     expect(screen.getByText(/does not receive Blackboard state or Blackboard access/i)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /launch/i }));
 
@@ -176,8 +176,8 @@ describe("TaskLaunchPage", () => {
     expect(screen.queryByLabelText("Task type")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Reason Task goal")).toHaveAttribute("readonly");
     await userEvent.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
-    expect(screen.getByLabelText("Blackboard conclusions")).toHaveValue("interactive");
-    expect(screen.queryByRole("option", { name: "Disabled" })).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /^Interactive/ })).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByRole("radio", { name: /^Disabled/ })).not.toBeInTheDocument();
     await waitFor(() => expect(screen.getByRole("button", { name: /Launch Reason Task/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /Launch Reason Task/i }));
 
@@ -280,10 +280,9 @@ describe("TaskLaunchPage", () => {
     expect(screen.getByText(/must match this Project's kind/i)).toBeInTheDocument();
     await userEvent.selectOptions(taskType, "ctf_challenge");
 
-await userEvent.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
-    const mode = await screen.findByLabelText("Blackboard conclusions");
-    expect(mode).toHaveValue("interactive");
-    await userEvent.selectOptions(mode, "assisted");
+    await userEvent.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
+    expect(screen.getByRole("radio", { name: /^Interactive/ })).toHaveAttribute("aria-checked", "true");
+    await userEvent.click(screen.getByRole("radio", { name: /^Assisted/ }));
     expect(screen.getByText(/runs a bounded Conclude Turn and applies its validated Attempt result/i)).toBeInTheDocument();
     await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
     await userEvent.clear(screen.getByLabelText("Maximum wrong submissions"));
@@ -399,9 +398,9 @@ await userEvent.click(await screen.findByRole("button", { name: /blackboard conc
 
     renderPage();
 
-await userEvent.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
-    expect(await screen.findByLabelText("Blackboard conclusions")).toHaveValue("interactive");
-    expect(screen.getByRole("option", { name: "Assisted" })).toBeDisabled();
+    await userEvent.click(await screen.findByRole("button", { name: /blackboard conclusions/i }));
+    expect(screen.getByRole("radio", { name: /^Interactive/ })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: /^Assisted/ })).toBeDisabled();
     expect(screen.getByText(/does not expose the complete persistent Turn, normalized Tool\/Turn event, and closed AttemptResult contract/i)).toBeInTheDocument();
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
@@ -489,8 +488,8 @@ await userEvent.click(await screen.findByRole("button", { name: /blackboard conc
 
     renderPage();
 
-await userEvent.click(await screen.findByRole("button", { name: /use saved preset/i }));
-    await userEvent.selectOptions(await screen.findByLabelText("Runtime profile preset"), "codex-preset");
+    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.selectOptions(await screen.findByLabelText("Runtime Profile"), "codex-preset");
     await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     expect(await screen.findByText(/selected runtime profile/i)).toBeInTheDocument();
     expect(await screen.findByText("Recon Helper")).toBeInTheDocument();
@@ -729,8 +728,8 @@ await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
 
     renderPage();
 
-await userEvent.click(await screen.findByRole("button", { name: /use saved preset/i }));
-    await userEvent.selectOptions(await screen.findByLabelText("Runtime profile preset"), "codex-preset");
+    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.selectOptions(await screen.findByLabelText("Runtime Profile"), "codex-preset");
     await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
     expect(await screen.findByText("No skills enabled for this profile.")).toBeInTheDocument();
   });
@@ -815,8 +814,8 @@ await userEvent.click(await screen.findByRole("button", { name: /use saved prese
     renderPage();
 
     await screen.findByRole("option", { name: "MiMo" });
-    await userEvent.click(screen.getByRole("button", { name: /use saved preset/i }));
-    expect(screen.getByLabelText("Runtime profile preset")).toHaveValue("");
+    await userEvent.click(screen.getByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    expect(screen.getByLabelText("Runtime Profile")).toHaveValue("");
     expect(screen.getByLabelText("Runtime")).not.toBeDisabled();
     expect(screen.getByLabelText("Model provider")).not.toBeDisabled();
 
@@ -918,9 +917,9 @@ await userEvent.click(await screen.findByRole("button", { name: /use saved prese
 
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: /use saved preset/i }));
-    await userEvent.selectOptions(screen.getByLabelText("Runtime profile preset"), "legacy-preset");
-    expect(screen.getByLabelText("Runtime profile preset")).toHaveValue("legacy-preset");
+    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    await userEvent.selectOptions(screen.getByLabelText("Runtime Profile"), "legacy-preset");
+    expect(screen.getByLabelText("Runtime Profile")).toHaveValue("legacy-preset");
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run legacy recon");
 
@@ -1261,11 +1260,11 @@ await userEvent.click(await screen.findByRole("button", { name: /use saved prese
 
     renderPage();
 
-    const presetToggle = await screen.findByRole("button", { name: /use saved preset/i });
+    const presetToggle = await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i });
     expect(presetToggle).toHaveAttribute("aria-expanded", "false");
     await userEvent.click(presetToggle);
     expect(presetToggle).toHaveAttribute("aria-expanded", "true");
-    await userEvent.selectOptions(screen.getByLabelText("Runtime profile preset"), "");
+    await userEvent.selectOptions(screen.getByLabelText("Runtime Profile"), "");
 
     await selectPentestTaskType();
     await userEvent.type(screen.getByLabelText("你想探索什么？"), "Run recon");
@@ -1970,8 +1969,8 @@ await userEvent.click(await screen.findByRole("button", { name: /use saved prese
 
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: /use saved preset/i }));
-    const presetSelect = screen.getByLabelText("Runtime profile preset");
+    await userEvent.click(await screen.findByRole("button", { name: /使用已保存的 Runtime Profile/i }));
+    const presetSelect = screen.getByLabelText("Runtime Profile");
     await userEvent.selectOptions(presetSelect, "codex-preset");
     expect(presetSelect).toHaveValue("codex-preset");
     expect(screen.getByLabelText("Runtime")).toBeDisabled();

--- a/web/src/pages/TaskLaunchPage.tsx
+++ b/web/src/pages/TaskLaunchPage.tsx
@@ -106,14 +106,14 @@ export function TaskLaunchPage() {
         )}
         <section className="rounded-lg border border-border bg-card shadow-sm">
           <div className="p-4">
-            <Label htmlFor="goal" className="text-sm font-medium">{reasonTask ? "Reason Task goal" : "你想探索什么？"}</Label>
+            <Label htmlFor="goal" className="text-sm font-medium">{reasonTask ? "Reason Task goal" : "What do you want to explore?"}</Label>
             <Textarea
               id="goal"
               name="task_goal"
               rows={4}
               value={effectiveGoal}
               onChange={(event) => setGoal(event.target.value)}
-              placeholder="描述目标，例如：对 staging.example.com 做认证面枚举…"
+              placeholder="Describe the goal, for example: enumerate the authenticated surface of staging.example.com…"
               autoComplete="off"
               readOnly={reasonTask}
               className="mt-2 w-full resize-none rounded-lg border border-input bg-background px-3.5 py-3 text-sm leading-relaxed outline-none placeholder:text-muted-foreground focus:border-ring"

--- a/web/src/pages/TaskLaunchPage.tsx
+++ b/web/src/pages/TaskLaunchPage.tsx
@@ -2,11 +2,10 @@ import { useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Rocket } from "lucide-react";
 import { AttachmentPicker } from "@/components/AttachmentPicker";
-import { RuntimeLaunchControls, useRuntimeLaunchControls } from "@/components/RuntimeLaunchControls";
+import { LaunchSummaryRail, RuntimeLaunchControls, useRuntimeLaunchControls } from "@/components/RuntimeLaunchControls";
 import { ProjectPageShell } from "@/components/ProjectPageShell";
-import { Button, Card, CardHeader, CardTitle, Input, Label, Select, Textarea } from "@/components/ui";
+import { Card, CardHeader, CardTitle, Input, Label, Select, Textarea } from "@/components/ui";
 import { apiPost, apiPostForm } from "@/lib/api";
-import { displayReasoningEffort } from "@/pages/runtimeProfileForm";
 
 const REASON_TASK_GOAL = "Read the complete Runtime Blackboard Snapshot and prepare an approval-required proposal for next Task Goals, Exploration Objective changes, and a readiness judgment. Do not mutate Blackboard records directly.";
 
@@ -78,11 +77,6 @@ export function TaskLaunchPage() {
   const hostBlocked = launchControls.form.runner === "host" && !launchControls.hostActivated;
   const projectKind = launchControls.project?.kind === "ctf_challenge" ? "ctf_challenge" : "pentest";
   const taskTypeMatchesProject = reasonTask || (taskType !== "" && taskType === projectKind);
-  const runtimeDisplay = launchControls.plugins.find((plugin) => plugin.id === launchControls.form.runtime)?.name ?? (launchControls.form.runtime || "—");
-  const summaryProvider = launchControls.compatibleProviders.find((provider) => provider.id === launchControls.form.modelProviderId);
-  const modelDisplay = [summaryProvider?.name, launchControls.form.modelOverride || "Default model"].filter(Boolean).join(" · ") || "—";
-  const runnerDisplay = launchControls.form.runner === "host" ? "Host" : launchControls.containerCLI === "podman" ? "Podman" : "Docker";
-  const blackboardDisplay = launchControls.blackboardConclusionMode === "assisted" ? "Assisted" : launchControls.blackboardConclusionMode === "disabled" ? "Disabled" : "Interactive";
 
   return (
     <ProjectPageShell
@@ -128,6 +122,7 @@ export function TaskLaunchPage() {
             <div className="mt-3">
               <AttachmentPicker
                 id="attachments"
+                variant="compact"
                 files={attachments}
                 onFilesChange={setAttachments}
                 onError={launchControls.setError}
@@ -155,25 +150,13 @@ export function TaskLaunchPage() {
         </Card>
       </div>
 
-<aside className="lg:sticky lg:top-6 h-fit">
-        <div className="rounded-lg border border-border bg-card shadow-sm">
-          <div className="border-b border-border px-4 py-3"><span className="text-sm font-medium">Launch 摘要</span></div>
-          <dl className="space-y-2.5 px-4 py-3.5 text-xs">
-            <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Runtime</dt><dd className="min-w-0 truncate font-medium">{runtimeDisplay}</dd></div>
-            <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Model</dt><dd className="min-w-0 truncate font-mono">{modelDisplay}</dd></div>
-            <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Effort</dt><dd className="font-medium">{displayReasoningEffort(launchControls.form.reasoningEffort)}</dd></div>
-            <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Runner</dt><dd className="font-medium">{runnerDisplay}</dd></div>
-            <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Blackboard</dt><dd className="font-medium">{blackboardDisplay}</dd></div>
-            <div className="flex justify-between gap-3"><dt className="text-muted-foreground">Skills</dt><dd className="font-medium">{launchControls.enabledSkillsPreview.length} enabled</dd></div>
-          </dl>
-          <div className="border-t border-border p-3.5">
-            <Button onClick={launchTask} disabled={!taskTypeMatchesProject || !launchControls.launchReady(effectiveGoal) || launching || hostBlocked} className="w-full">
-              <Rocket className="h-4 w-4" /> {launching ? "Launching…" : reasonTask ? "Launch Reason Task" : "Launch"}
-            </Button>
-            <p className="mt-2 text-center text-xs text-muted-foreground">启动前会自动运行 Preflight 检查</p>
-          </div>
-        </div>
-      </aside>
+<LaunchSummaryRail
+        controller={launchControls}
+        disabled={!taskTypeMatchesProject || !launchControls.launchReady(effectiveGoal) || launching || hostBlocked}
+        busy={launching}
+        label={reasonTask ? "Launch Reason Task" : "Launch"}
+        onClick={launchTask}
+      />
     </ProjectPageShell>
   );
 }


### PR DESCRIPTION
## What

Applies the complete Direction A (refined minimal) design to the production web UI and unifies page shells:

- **Design tokens/components** (`40d1266`): Chip + SectionLabel primitives; Workspace sidebar (relative time · state lines, status dots, group counts); AgentTranscriptView Direction A treatment; Launch hero goal + 2×2 config; Dashboard, Profiles, Providers, Credentials, Skills pages restructured per mockups; composer status banner.
- **Layout corrections** (`44cbf10`): all visible copy in English; inputs/selects/textareas standardized to `rounded-lg` shadowless border-only focus; Workspace lifecycle metadata compacted; restored the pre-existing Timeline implementation that an earlier pass had replaced; compact project section tabs; corrected Dashboard header/metrics; Runtime Profiles split layout (fixed 320px list + full-width detail); custom accessible Skill archive picker; composer up-arrow send, single-line reasoning effort, keyboard hint moved to `title`.
- **Shell unification** (`542105d`): every standard page (Runtime Profiles, Overview, Task/Session Workspaces) now sits on `mx-auto max-w-6xl`, matching Skills/Credentials/Providers; Runtime Owner Workspace framed as one continuous card (header + view tabs + body share borders and rounding); Overview moved onto the shared `ProjectNav` chrome, which now renders dashboard count badges — removing the duplicate nav plane.

## Why

Follows the Direction A mockups (`mockups/a-minimal/*`) and the implementation plan (`docs/superpowers/plans/2026-08-31-direction-a-ui-refinement.md`) plus operator feedback rounds: full-bleed pages clashed with centered settings pages, the Workspace lacked its card frame, and Overview rendered a second nav plane out of alignment with the other tabs.

## Testing

- [x] `npx vitest run` — 47 files / 574 tests pass
- [x] `npm run build` (tsc -b + vite) passes
- [x] Browser-verified at 1920×1080 with mocked API: Overview/Tasks chrome pixel-identical (`chromeLeft=288`, `navTop=45`), no horizontal overflow on Overview, Session header spans the main pane, Skills switches default-on and disabled without a Runtime Profile, file picker shows chosen filename
