### PR TITLE
Add global skill opt-out and owner-local launch configuration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,7 +193,7 @@ Provider-native arguments required for a **Runtime** to operate without interact
 _Avoid_: permission grant, Scope authorization, **Host Runner Activation**, **Project Interface** authority, runner policy
 
 **Runtime Profile**:
-A global user-created reusable advanced configuration for a **Runtime**, including MCP, Skill opt-outs, Extensions, binary paths, custom configuration, or Runner defaults without storing secret values.
+A global user-created reusable advanced configuration for a **Runtime**, including MCP, **Profile Skill Opt-Outs**, Extensions, binary paths, custom configuration, or Runner defaults without storing secret values.
 _Avoid_: account, credential bundle, secret store, automatic profile, runtime profile preset
 
 **Runtime Custom Arguments**:
@@ -393,7 +393,7 @@ The file-backed content of a **Runtime Extension**, including its instructions, 
 _Avoid_: manifest-only skill, external path pointer, raw JSON config
 
 **Skill**:
-A runtime-agnostic **Runtime Extension Bundle** managed through the **Skills Page** and projected for any supported **Runtime** when enabled by a **Runtime Profile**.
+A runtime-agnostic **Runtime Extension Bundle** managed through the **Skills Page** and projected for any supported **Runtime** when allowed by **Default Skill Enablement**, **Global Skill Opt-Out**, and any selected **Profile Skill Opt-Out**.
 _Avoid_: runtime plugin, provider-specific extension, MCP server
 
 **Skill ID**:
@@ -457,16 +457,24 @@ The checks that gate **Skill Publication** for identity, bundle shape, path safe
 _Avoid_: runtime execution test, trust proof, full code audit
 
 **Runtime Extension Enablement**:
-A **Runtime Profile** choice that allows a compatible **Runtime Extension** from the **Runtime Extension Library** to be projected for tasks using that profile.
+The effective choice that allows a compatible **Runtime Extension** from the **Runtime Extension Library** to be projected for a new Runtime Owner. For **Skills**, it combines **Default Skill Enablement**, **Global Skill Opt-Out**, and any selected **Profile Skill Opt-Out**.
 _Avoid_: library membership, automatic global mount, project-wide default
 
 **Default Skill Enablement**:
-The default-on policy that enables newly uploaded or imported **Skills** for direct launches and all current and future **Runtime Profiles**, unless a selected Profile opts out.
+The default-on policy that enables newly uploaded or imported **Skills** for direct launches and all current and future **Runtime Profiles**, unless a **Global Skill Opt-Out** or selected **Profile Skill Opt-Out** disables the Skill.
 _Avoid_: runtime-specific plugin default, live task mutation, project-local default
 
 **Skill Opt-Out**:
-A **Runtime Profile** override that disables a default-enabled **Skill** by **Skill ID**.
+An enablement override that disables a default-enabled **Skill** by **Skill ID**. It is either a **Global Skill Opt-Out** or a **Profile Skill Opt-Out**.
 _Avoid_: Skill Deletion, Runtime-Specific Extension disablement, temporary task skip
+
+**Global Skill Opt-Out**:
+A **Skills Page** library-level override that disables one default-enabled **Skill** for direct launches and every current or future **Runtime Profile**. It overrides, but does not erase, **Profile Skill Opt-Outs**.
+_Avoid_: Skill Deletion, bulk Profile action, started Runtime Owner mutation
+
+**Profile Skill Opt-Out**:
+A **Runtime Profile** override that disables one default-enabled **Skill** when that Profile is selected for a new Runtime Owner.
+_Avoid_: Global Skill Opt-Out, direct launch default, temporary task skip
 
 **Skills Page**:
 The top-level product view named Skills for managing **Skills** in the **Runtime Extension Library**.
@@ -1071,13 +1079,15 @@ _Avoid_: transcript, export, source of truth
 - **Runtime-Specific Extensions** are managed through their owning runtime-specific surfaces rather than treated as universal **Skills**.
 - A **Runtime Extension Manifest** may declare compatibility, source paths, projection targets, and non-secret defaults but must not contain credential values.
 - A **Runtime Profile** manages **Runtime Extensions** through structured controls rather than raw manifest JSON.
-- **Runtime Extension Enablement** belongs to a **Runtime Profile** and is limited to compatible **Runtime Plugins**.
+- **Runtime Extension Enablement** for **Runtime-Specific Extensions** belongs to a **Runtime Profile** and is limited to compatible **Runtime Plugins**.
 - **Default Skill Enablement** applies to **Skills** but not **Runtime-Specific Extensions**.
-- A **Runtime Profile** may opt out of a **Skill** enabled by **Default Skill Enablement**.
-- A **Skill Opt-Out** is tied to **Skill ID** and survives ordinary imports or edits that update the same **Skill**.
-- The **Skills Page** bulk enablement actions apply to the selected **Runtime Profile** and the current **Skill** library: Disable all atomically creates a **Skill Opt-Out** for every current Skill, while Enable all atomically removes every Skill Opt-Out for that profile. Neither action changes started **Tasks**, and later imports still follow **Default Skill Enablement**.
-- **Skill Deletion** ends the enablement lifecycle for that **Skill ID**; re-importing the same **Skill ID** follows **Default Skill Enablement** instead of restoring old opt-outs.
-- The **Skills Page** may change **Runtime Extension Enablement**, but the enablement state still belongs to the affected **Runtime Profile**.
+- A **Global Skill Opt-Out** removes one Skill from direct launches and every current or future **Runtime Profile**.
+- A **Runtime Profile** may add a **Profile Skill Opt-Out** for a Skill enabled by **Default Skill Enablement**.
+- Every **Skill Opt-Out** is tied to **Skill ID** and survives ordinary imports or edits that update the same **Skill**.
+- A **Global Skill Opt-Out** overrides effective Profile enablement but does not erase existing **Profile Skill Opt-Outs**; removing the global override restores each Profile's own choice.
+- The **Skills Page** bulk Profile enablement actions apply to the selected **Runtime Profile** and the current **Skill** library: Disable all atomically creates a **Profile Skill Opt-Out** for every current Skill, while Enable all atomically removes every Profile Skill Opt-Out for that Profile. Neither action changes started **Tasks**, and later imports still follow **Default Skill Enablement**.
+- **Skill Deletion** ends the enablement lifecycle for that **Skill ID**; re-importing the same **Skill ID** follows **Default Skill Enablement** instead of restoring old Global or Profile Skill Opt-Outs.
+- The **Skills Page** is the source of truth for **Global Skill Opt-Outs** and updates **Profile Skill Opt-Outs** for the selected **Runtime Profile**.
 - A **Runtime Profile** may reference a manually entered **Runtime Extension** identifier, but task launch still requires the daemon **Runtime Extension Registry** to resolve it.
 - A new **Task** loads the current **Runtime Extensions** from the **Runtime Extension Library** when its runtime configuration is projected.
 - **Preflight** previews enabled **Skills** but resolves credentials only from **Runtime Profiles**, **Model Providers**, and launch requests.
@@ -1109,8 +1119,8 @@ _Avoid_: transcript, export, source of truth
 - **Requested Reasoning Effort** belongs to its **Runtime Turn** and does not edit the selected **Runtime Profile**.
 - Changing the selected **Runtime Plugin** family during launch clears an incompatible **Runtime Profile** selection.
 - **Launch Configuration Resolution** applies a **Runtime Profile** only when the launch explicitly selects that Profile.
-- **Launch Configuration Resolution** otherwise builds the **Runtime Configuration Snapshot** directly from the selected **Runtime Plugin**, **Model Provider**, model, **Reasoning Effort**, **Runner**, Runtime Plugin standard configuration, and globally default-enabled **Skills**.
-- A direct **Launch Selection** does not receive **MCP Configuration**, **Custom Config File**, **Runtime Extension Enablement**, or **Skill Opt-Out** from any matching or default **Runtime Profile**.
+- **Launch Configuration Resolution** otherwise builds the **Runtime Configuration Snapshot** directly from the selected **Runtime Plugin**, **Model Provider**, model, **Reasoning Effort**, **Runner**, Runtime Plugin standard configuration, and globally default-enabled **Skills** after **Global Skill Opt-Outs** are applied.
+- A direct **Launch Selection** does not receive **MCP Configuration**, **Custom Config File**, **Runtime Extension Enablement**, or **Profile Skill Opt-Out** from any matching or default **Runtime Profile**.
 - A direct Runtime Owner is displayed by its **Runtime Plugin**, **Model Provider**, and model rather than a synthetic Profile name; an explicit Profile name is shown only when that Owner selected a **Runtime Profile** at creation.
 - **Save as Runtime Profile** requires a user-supplied name and explicit confirmation; CyberPenda never suggests, triggers, or completes it automatically.
 - Task, Reason Task, Session, Resume, Steering, and Runtime Turn model-selection paths never create or reuse a **Launch-Resolved Runtime Profile**.
@@ -1603,10 +1613,11 @@ _Avoid_: transcript, export, source of truth
 - **Task Skills Root** is not global skill installation; resolved: each task receives its own materialized enabled skills.
 - **Skills Page** is not provider-specific plugin management; resolved: runtime-specific plugins belong to their own runtime family.
 - **Skills Page** is not a project tab; resolved: it belongs in global navigation alongside runtime profile and credential management.
-- **Default Skill Enablement** is not runtime-specific plugin injection; resolved: skills are default-on for runtime profiles with per-profile opt-out, while runtime-specific extensions remain explicit.
-- **Skill Opt-Out** is not reset by a skill update; resolved: profile opt-outs follow the stable **Skill ID**.
-- Re-import after **Skill Deletion** is not a skill update; resolved: old opt-outs are not restored after deletion and recreation.
-- **Skills Page** enablement controls are not a second source of truth; resolved: they update **Runtime Profile** enablement.
+- **Default Skill Enablement** is not runtime-specific plugin injection; resolved: Skills are default-on for direct launches and Runtime Profiles, while Global and Profile Skill Opt-Outs can remove them and runtime-specific extensions remain explicit.
+- **Global Skill Opt-Out** is not a bulk Profile action; resolved: it disables one Skill for direct launches and every current or future Runtime Profile.
+- **Skill Opt-Out** is not reset by a Skill update; resolved: Global and Profile Skill Opt-Outs follow the stable **Skill ID**.
+- Re-import after **Skill Deletion** is not a Skill update; resolved: old Global and Profile Skill Opt-Outs are not restored after deletion and recreation.
+- **Skills Page** enablement controls are not a second source of truth; resolved: Global controls own library-level opt-outs, and Profile controls update the selected **Runtime Profile**.
 - **Runtime Extension Import** is not task startup installation; resolved: package-backed skills are imported or updated through management, while task launch projects already-managed extensions.
 - **Controlled Skill Import** is not arbitrary shell execution; resolved: package-backed skill import uses a fixed importer from structured input.
 - **Skill Publication** is not partial live update; resolved: failed imports or edits leave the current live skill unchanged.

--- a/docs/adr/0001-global-default-on-skills.md
+++ b/docs/adr/0001-global-default-on-skills.md
@@ -1,5 +1,7 @@
 # Global Skills are default-on with per-profile opt-out
 
+> Superseded in part by ADR-0032 on September 2, 2026: Global Skill Opt-Out is now also supported.
+
 Skills are global, runtime-agnostic bundles managed from the Skills page and projected into task-local runtime boundaries. We chose default-on Skill enablement for all current and future Runtime Profiles, with per-profile opt-out, because Skills are intended to be shared baseline agent capabilities rather than provider-specific plugins; provider-specific extensions remain explicit and runtime-owned.
 
 ## Considered Options

--- a/docs/adr/0031-resolve-launches-with-owner-local-runtime-configuration.md
+++ b/docs/adr/0031-resolve-launches-with-owner-local-runtime-configuration.md
@@ -12,7 +12,7 @@ Runtime Plugin, Model Provider, and model selection will resolve directly into a
 - Task, Reason Task, Session, Resume, Steering, and Runtime Turn model-selection paths never find, create, or reuse a Runtime Profile automatically.
 - A **Runtime Profile** is only a user-created reusable advanced configuration. It has no `manual` or `launch_resolve` Kind.
 - A Runtime Profile is optional and must be selected explicitly when a Task or Session is created. Project Defaults cannot select one, and an existing Runtime Owner cannot switch one.
-- A direct launch uses Runtime Plugin standard configuration, global default Skills, and explicit Run Controls. Profile-specific MCP, Custom Config, Extensions, and Skill Opt-Out apply only when the launch explicitly selects that Profile.
+- A direct launch uses Runtime Plugin standard configuration, global default Skills after Global Skill Opt-Outs, and explicit Run Controls. Profile-specific MCP, Custom Config, Extensions, and Profile Skill Opt-Out apply only when the launch explicitly selects that Profile.
 - Runtime Turn Selection may still change Model Provider, model, and Reasoning Effort. These changes create only Runtime Owner-local state when new Config Projection is required.
 - Resume uses the latest immutable Snapshot. Later global-default or Runtime Profile edits do not change it.
 - Direct Runtime Owners display Runtime Plugin, Model Provider, and model instead of a synthetic Profile name.

--- a/docs/adr/0032-add-global-skill-opt-out.md
+++ b/docs/adr/0032-add-global-skill-opt-out.md
@@ -1,0 +1,30 @@
+---
+status: accepted
+date: 2026-09-02
+---
+
+# Add Global Skill Opt-Out
+
+This decision extends ADR-0001. Skills remain default-on, but Profile Skill Opt-Out alone cannot stop one Skill from entering direct launches or every current and future Runtime Profile.
+
+## Decision
+
+- A **Global Skill Opt-Out** disables one Skill by stable **Skill ID** for direct launches and every current or future **Runtime Profile**.
+- A Global Skill Opt-Out overrides effective Profile enablement. It does not delete or rewrite existing **Profile Skill Opt-Outs**.
+- Removing a Global Skill Opt-Out restores each Runtime Profile's existing Profile Skill Opt-Out choice.
+- Updating or re-importing the same live Skill ID preserves both Global and Profile Skill Opt-Outs.
+- **Skill Deletion** removes both kinds of opt-out. Recreating the same Skill ID starts with **Default Skill Enablement**.
+- Started Runtime Owners keep their captured **Runtime Configuration Snapshot** and **Task Skills Root**. The change applies only to later launch resolution.
+- The **Skills Page** exposes separate Global and Profile controls. A Profile control is inactive while the Global Skill Opt-Out is active because it cannot change effective enablement.
+
+## Considered options
+
+- Require an opt-out on every Runtime Profile. This does not cover direct launches or future Profiles and requires repeated work.
+- Convert Skills to default-off. This removes the shared baseline behavior chosen in ADR-0001.
+- Delete a Skill to disable it globally. This loses the managed bundle and source provenance and makes later re-enablement an import operation.
+
+## Consequences
+
+- Enabled Skill resolution is the live Skill library minus Global Skill Opt-Outs and then minus the selected Profile Skill Opt-Outs.
+- Preflight, direct launch, Task launch, and Session launch use the same effective resolution.
+- Skill list responses must distinguish effective enablement, Global Skill Opt-Out state, and Profile Skill Opt-Out state so the UI can show both controls without losing either choice.

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -954,6 +954,8 @@ func (server *Server) routes() {
 	server.mux.HandleFunc("GET /api/skills/{skill_id}", server.handleGetSkill)
 	server.mux.HandleFunc("PUT /api/skills/{skill_id}", server.handlePutSkill)
 	server.mux.HandleFunc("DELETE /api/skills/{skill_id}", server.handleDeleteSkill)
+	server.mux.HandleFunc("PUT /api/skills/{skill_id}/opt-out", server.handlePutGlobalSkillOptOut)
+	server.mux.HandleFunc("DELETE /api/skills/{skill_id}/opt-out", server.handleDeleteGlobalSkillOptOut)
 	server.mux.HandleFunc("PUT /api/skills/profiles/{profile_id}/opt-out", server.handlePutAllSkillProfileOptOuts)
 	server.mux.HandleFunc("DELETE /api/skills/profiles/{profile_id}/opt-out", server.handleDeleteAllSkillProfileOptOuts)
 	server.mux.HandleFunc("PUT /api/skills/{skill_id}/profiles/{profile_id}/opt-out", server.handlePutSkillProfileOptOut)

--- a/internal/daemon/skill_handlers.go
+++ b/internal/daemon/skill_handlers.go
@@ -20,14 +20,16 @@ type skillWriteRequest struct {
 }
 
 type skillResponse struct {
-	ID          string                 `json:"id"`
-	Name        string                 `json:"name"`
-	Description string                 `json:"description,omitempty"`
-	Source      skill.SourceProvenance `json:"source_provenance,omitempty"`
-	Files       map[string]string      `json:"files,omitempty"`
-	Enabled     bool                   `json:"enabled"`
-	CreatedAt   any                    `json:"created_at"`
-	UpdatedAt   any                    `json:"updated_at"`
+	ID               string                 `json:"id"`
+	Name             string                 `json:"name"`
+	Description      string                 `json:"description,omitempty"`
+	Source           skill.SourceProvenance `json:"source_provenance,omitempty"`
+	Files            map[string]string      `json:"files,omitempty"`
+	Enabled          bool                   `json:"enabled"`
+	GloballyOptedOut bool                   `json:"globally_opted_out"`
+	ProfileOptedOut  bool                   `json:"profile_opted_out"`
+	CreatedAt        any                    `json:"created_at"`
+	UpdatedAt        any                    `json:"updated_at"`
 }
 
 func (server *Server) handleListSkills(response http.ResponseWriter, request *http.Request) {
@@ -37,24 +39,22 @@ func (server *Server) handleListSkills(response http.ResponseWriter, request *ht
 		writeError(response, http.StatusInternalServerError, "list skills")
 		return
 	}
-	enabled := map[string]bool{}
+	profileOptedOut := map[string]bool{}
 	if profileID != "" {
-		enabledSkills, err := server.skills.EnabledSkills(profileID)
+		ids, err := server.skills.ProfileOptedOutSkillIDs(profileID)
 		if err != nil {
-			writeError(response, http.StatusInternalServerError, "resolve enabled skills")
+			writeError(response, http.StatusInternalServerError, "resolve Profile Skill Opt-Outs")
 			return
 		}
-		for _, got := range enabledSkills {
-			enabled[got.ID] = true
+		for _, id := range ids {
+			profileOptedOut[id] = true
 		}
 	}
 	out := make([]skillResponse, 0, len(skills))
 	for _, got := range skills {
-		isEnabled := true
-		if profileID != "" {
-			isEnabled = enabled[got.ID]
-		}
-		out = append(out, newSkillResponse(got, isEnabled))
+		isProfileOptedOut := profileOptedOut[got.ID]
+		isEnabled := !got.GloballyOptedOut && !isProfileOptedOut
+		out = append(out, newSkillResponse(got, isEnabled, isProfileOptedOut))
 	}
 	writeJSON(response, http.StatusOK, struct {
 		Skills []skillResponse `json:"skills"`
@@ -72,7 +72,7 @@ func (server *Server) handleGetSkill(response http.ResponseWriter, request *http
 		writeSkillError(response, err)
 		return
 	}
-	out := newSkillResponse(got, true)
+	out := newSkillResponse(got, !got.GloballyOptedOut, false)
 	out.Files = publicSkillFiles(got, files)
 	writeJSON(response, http.StatusOK, out)
 }
@@ -107,7 +107,7 @@ func (server *Server) handlePutSkill(response http.ResponseWriter, request *http
 	if existed {
 		status = http.StatusOK
 	}
-	writeJSON(response, status, newSkillResponse(published, true))
+	writeJSON(response, status, newSkillResponse(published, !published.GloballyOptedOut, false))
 }
 
 func (server *Server) handleImportSkill(response http.ResponseWriter, request *http.Request) {
@@ -139,7 +139,7 @@ func (server *Server) handleImportSkill(response http.ResponseWriter, request *h
 		writeSkillError(response, err)
 		return
 	}
-	writeJSON(response, http.StatusCreated, newSkillResponse(imported, true))
+	writeJSON(response, http.StatusCreated, newSkillResponse(imported, !imported.GloballyOptedOut, false))
 }
 
 func (server *Server) handleImportSkillArchive(response http.ResponseWriter, request *http.Request) {
@@ -159,7 +159,7 @@ func (server *Server) handleImportSkillArchive(response http.ResponseWriter, req
 		writeSkillError(response, err)
 		return
 	}
-	writeJSON(response, http.StatusCreated, newSkillResponse(imported, true))
+	writeJSON(response, http.StatusCreated, newSkillResponse(imported, !imported.GloballyOptedOut, false))
 }
 
 func (server *Server) importSkillArchive(request *http.Request, header *multipart.FileHeader) (skill.Skill, error) {
@@ -182,6 +182,23 @@ func (server *Server) handleDeleteSkill(response http.ResponseWriter, request *h
 	id := strings.TrimSpace(request.PathValue("skill_id"))
 	forceDisable := parseBoolQuery(request.URL.Query().Get("force_disable"))
 	if err := server.skills.Delete(request.Context(), id, forceDisable); err != nil {
+		writeSkillError(response, err)
+		return
+	}
+	response.WriteHeader(http.StatusNoContent)
+}
+
+func (server *Server) handlePutGlobalSkillOptOut(response http.ResponseWriter, request *http.Request) {
+	server.handleGlobalSkillOptOut(response, request, true)
+}
+
+func (server *Server) handleDeleteGlobalSkillOptOut(response http.ResponseWriter, request *http.Request) {
+	server.handleGlobalSkillOptOut(response, request, false)
+}
+
+func (server *Server) handleGlobalSkillOptOut(response http.ResponseWriter, request *http.Request, optedOut bool) {
+	skillID := strings.TrimSpace(request.PathValue("skill_id"))
+	if err := server.skills.SetGlobalOptOut(skillID, optedOut); err != nil {
 		writeSkillError(response, err)
 		return
 	}
@@ -223,15 +240,17 @@ func (server *Server) handleSkillProfileOptOut(response http.ResponseWriter, req
 	response.WriteHeader(http.StatusNoContent)
 }
 
-func newSkillResponse(got skill.Skill, enabled bool) skillResponse {
+func newSkillResponse(got skill.Skill, enabled, profileOptedOut bool) skillResponse {
 	return skillResponse{
-		ID:          got.ID,
-		Name:        got.Name,
-		Description: got.Description,
-		Source:      publicSkillSource(got.Source),
-		Enabled:     enabled,
-		CreatedAt:   got.CreatedAt,
-		UpdatedAt:   got.UpdatedAt,
+		ID:               got.ID,
+		Name:             got.Name,
+		Description:      got.Description,
+		Source:           publicSkillSource(got.Source),
+		Enabled:          enabled,
+		GloballyOptedOut: got.GloballyOptedOut,
+		ProfileOptedOut:  profileOptedOut,
+		CreatedAt:        got.CreatedAt,
+		UpdatedAt:        got.UpdatedAt,
 	}
 }
 

--- a/internal/daemon/skill_test.go
+++ b/internal/daemon/skill_test.go
@@ -136,6 +136,76 @@ func TestSkillsBulkOptOutAndEnableForRuntimeProfileHTTP(t *testing.T) {
 	})
 }
 
+func TestSkillGlobalOptOutHTTP(t *testing.T) {
+	server := newDaemon(t)
+	profileID := createRuntimeProfile(t, server, `{"name":"Codex","provider":"codex"}`)
+
+	putSkill(t, server, "recon-helper", `{
+		"name":"Recon Helper",
+		"files":{"SKILL.md":"# Recon Helper"}
+	}`)
+
+	profileOptOutReq := httptest.NewRequest(http.MethodPut, "/api/skills/recon-helper/profiles/"+profileID+"/opt-out", nil)
+	profileOptOutResp := httptest.NewRecorder()
+	server.ServeHTTP(profileOptOutResp, profileOptOutReq)
+	if profileOptOutResp.Code != http.StatusNoContent {
+		t.Fatalf("expected Profile Skill Opt-Out status 204, got %d with body %s", profileOptOutResp.Code, profileOptOutResp.Body.String())
+	}
+
+	optOutReq := httptest.NewRequest(http.MethodPut, "/api/skills/recon-helper/opt-out", nil)
+	optOutResp := httptest.NewRecorder()
+	server.ServeHTTP(optOutResp, optOutReq)
+	if optOutResp.Code != http.StatusNoContent {
+		t.Fatalf("expected global opt-out status 204, got %d with body %s", optOutResp.Code, optOutResp.Body.String())
+	}
+
+	for _, item := range []struct {
+		path            string
+		profileOptedOut bool
+	}{
+		{path: "/api/skills", profileOptedOut: false},
+		{path: "/api/skills?runtime_profile_id=" + profileID, profileOptedOut: true},
+	} {
+		path := item.path
+		listReq := httptest.NewRequest(http.MethodGet, path, nil)
+		listResp := httptest.NewRecorder()
+		server.ServeHTTP(listResp, listReq)
+		if listResp.Code != http.StatusOK {
+			t.Fatalf("expected list status 200 for %s, got %d with body %s", path, listResp.Code, listResp.Body.String())
+		}
+		var listed struct {
+			Skills []struct {
+				ID               string `json:"id"`
+				Enabled          bool   `json:"enabled"`
+				GloballyOptedOut bool   `json:"globally_opted_out"`
+				ProfileOptedOut  bool   `json:"profile_opted_out"`
+			} `json:"skills"`
+		}
+		if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+			t.Fatalf("decode skills list for %s: %v", path, err)
+		}
+		if len(listed.Skills) != 1 || listed.Skills[0].ID != "recon-helper" || listed.Skills[0].Enabled || !listed.Skills[0].GloballyOptedOut || listed.Skills[0].ProfileOptedOut != item.profileOptedOut {
+			t.Fatalf("unexpected globally opted-out list for %s: %#v", path, listed.Skills)
+		}
+	}
+
+	enableReq := httptest.NewRequest(http.MethodDelete, "/api/skills/recon-helper/opt-out", nil)
+	enableResp := httptest.NewRecorder()
+	server.ServeHTTP(enableResp, enableReq)
+	if enableResp.Code != http.StatusNoContent {
+		t.Fatalf("expected global enable status 204, got %d with body %s", enableResp.Code, enableResp.Body.String())
+	}
+	assertListedSkillEnablement(t, server, profileID, map[string]bool{"recon-helper": false})
+
+	profileEnableReq := httptest.NewRequest(http.MethodDelete, "/api/skills/recon-helper/profiles/"+profileID+"/opt-out", nil)
+	profileEnableResp := httptest.NewRecorder()
+	server.ServeHTTP(profileEnableResp, profileEnableReq)
+	if profileEnableResp.Code != http.StatusNoContent {
+		t.Fatalf("expected Profile Skill enable status 204, got %d with body %s", profileEnableResp.Code, profileEnableResp.Body.String())
+	}
+	assertListedSkillEnablement(t, server, profileID, map[string]bool{"recon-helper": true})
+}
+
 func assertListedSkillEnablement(t *testing.T, server http.Handler, profileID string, want map[string]bool) {
 	t.Helper()
 	request := httptest.NewRequest(http.MethodGet, "/api/skills?runtime_profile_id="+profileID, nil)

--- a/internal/skill/builtin.go
+++ b/internal/skill/builtin.go
@@ -124,7 +124,11 @@ func (s *Service) migrateLegacyBuiltinSkillID(newID string) (Skill, error) {
 		}
 		if _, err := tx.Exec(`UPDATE skill_profile_opt_outs SET skill_id = ? WHERE skill_id = ?`, newID, legacyID); err != nil {
 			_ = tx.Rollback()
-			return Skill{}, fmt.Errorf("migrate builtin skill opt-outs: %w", err)
+			return Skill{}, fmt.Errorf("migrate builtin Profile Skill Opt-Outs: %w", err)
+		}
+		if _, err := tx.Exec(`UPDATE skill_global_opt_outs SET skill_id = ? WHERE skill_id = ?`, newID, legacyID); err != nil {
+			_ = tx.Rollback()
+			return Skill{}, fmt.Errorf("migrate builtin Global Skill Opt-Out: %w", err)
 		}
 		if err := tx.Commit(); err != nil {
 			return Skill{}, fmt.Errorf("commit builtin skill id migration: %w", err)
@@ -213,7 +217,16 @@ func (s *Service) purgeLegacyBuiltinIfPresent(ctx context.Context, legacyID, suc
 			 ON CONFLICT(profile_id, skill_id) DO NOTHING`,
 			successorID, now, legacyID,
 		); err != nil {
-			return fmt.Errorf("migrate legacy skill opt-outs %q -> %q: %w", legacyID, successorID, err)
+			return fmt.Errorf("migrate legacy Profile Skill Opt-Outs %q -> %q: %w", legacyID, successorID, err)
+		}
+		if _, err := s.db.Exec(
+			`INSERT INTO skill_global_opt_outs (skill_id, created_at)
+			 SELECT ?, ?
+			 WHERE EXISTS (SELECT 1 FROM skill_global_opt_outs WHERE skill_id = ?)
+			 ON CONFLICT(skill_id) DO NOTHING`,
+			successorID, now, legacyID,
+		); err != nil {
+			return fmt.Errorf("migrate legacy Global Skill Opt-Out %q -> %q: %w", legacyID, successorID, err)
 		}
 	}
 	return s.Delete(ctx, legacyID, true)

--- a/internal/skill/builtin_test.go
+++ b/internal/skill/builtin_test.go
@@ -323,7 +323,10 @@ func TestInstallBuiltinSkillsPurgesSupersededPrunedLegacyIDs(t *testing.T) {
 		t.Fatalf("publish legacy builtin: %v", err)
 	}
 	if err := svc.SetOptOut(profile.ID, "cyberstrikeai-business-logic-testing", true); err != nil {
-		t.Fatalf("set legacy opt-out: %v", err)
+		t.Fatalf("set legacy Profile Skill Opt-Out: %v", err)
+	}
+	if err := svc.SetGlobalOptOut("cyberstrikeai-business-logic-testing", true); err != nil {
+		t.Fatalf("set legacy Global Skill Opt-Out: %v", err)
 	}
 	if err := svc.InstallBuiltinSkills(ctx); err != nil {
 		t.Fatalf("install builtins: %v", err)
@@ -337,6 +340,12 @@ func TestInstallBuiltinSkillsPurgesSupersededPrunedLegacyIDs(t *testing.T) {
 	}
 	if got.Source.Kind != "builtin" {
 		t.Fatalf("unexpected successor provenance: %#v", got.Source)
+	}
+	if !got.GloballyOptedOut {
+		t.Fatal("expected successor builtin to preserve the legacy Global Skill Opt-Out")
+	}
+	if err := svc.SetGlobalOptOut("vulnerabilities-business-logic", false); err != nil {
+		t.Fatalf("remove successor Global Skill Opt-Out: %v", err)
 	}
 	enabled, err := svc.EnabledSkills(profile.ID)
 	if err != nil {

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -196,13 +196,21 @@ func (s *Service) Get(id string) (Skill, error) {
 		return Skill{}, ErrNotFound
 	}
 	return s.scanSkill(s.db.QueryRow(
-		`SELECT id, name, description, source_provenance_json, created_at, updated_at FROM skills WHERE id = ?`,
+		`SELECT s.id, s.name, s.description, s.source_provenance_json, s.created_at, s.updated_at,
+		        EXISTS (SELECT 1 FROM skill_global_opt_outs g WHERE g.skill_id = s.id)
+		 FROM skills s
+		 WHERE s.id = ?`,
 		id,
 	))
 }
 
 func (s *Service) List() ([]Skill, error) {
-	rows, err := s.db.Query(`SELECT id, name, description, source_provenance_json, created_at, updated_at FROM skills ORDER BY id ASC`)
+	rows, err := s.db.Query(
+		`SELECT s.id, s.name, s.description, s.source_provenance_json, s.created_at, s.updated_at,
+		        EXISTS (SELECT 1 FROM skill_global_opt_outs g WHERE g.skill_id = s.id)
+		 FROM skills s
+		 ORDER BY s.id ASC`,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("list skills: %w", err)
 	}
@@ -262,6 +270,58 @@ func (s *Service) Files(id string) (map[string]string, error) {
 		return nil, err
 	}
 	return files, nil
+}
+
+func (s *Service) ProfileOptedOutSkillIDs(profileID string) ([]string, error) {
+	profileID = strings.TrimSpace(profileID)
+	if profileID == "" {
+		return []string{}, nil
+	}
+	rows, err := s.db.Query(
+		`SELECT skill_id FROM skill_profile_opt_outs WHERE profile_id = ? ORDER BY skill_id ASC`,
+		profileID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list Profile Skill Opt-Outs: %w", err)
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var skillID string
+		if err := rows.Scan(&skillID); err != nil {
+			return nil, fmt.Errorf("scan Profile Skill Opt-Out: %w", err)
+		}
+		out = append(out, skillID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate Profile Skill Opt-Outs: %w", err)
+	}
+	return out, nil
+}
+
+func (s *Service) SetGlobalOptOut(skillID string, optedOut bool) error {
+	skillID = strings.TrimSpace(skillID)
+	if skillID == "" {
+		return ErrNotFound
+	}
+	if _, err := s.Get(skillID); err != nil {
+		return err
+	}
+	if optedOut {
+		_, err := s.db.Exec(
+			`INSERT INTO skill_global_opt_outs (skill_id, created_at) VALUES (?, ?)
+			 ON CONFLICT(skill_id) DO NOTHING`,
+			skillID, time.Now().UTC().Format(time.RFC3339Nano),
+		)
+		if err != nil {
+			return fmt.Errorf("store global Skill Opt-Out: %w", err)
+		}
+		return nil
+	}
+	if _, err := s.db.Exec(`DELETE FROM skill_global_opt_outs WHERE skill_id = ?`, skillID); err != nil {
+		return fmt.Errorf("delete global Skill Opt-Out: %w", err)
+	}
+	return nil
 }
 
 func (s *Service) SetOptOut(profileID, skillID string, optedOut bool) error {
@@ -336,12 +396,16 @@ func (s *Service) SetAllOptOut(profileID string, optedOut bool) error {
 func (s *Service) EnabledSkills(profileID string) ([]Skill, error) {
 	profileID = strings.TrimSpace(profileID)
 	rows, err := s.db.Query(
-		`SELECT id, name, description, source_provenance_json, created_at, updated_at
-		 FROM skills
+		`SELECT s.id, s.name, s.description, s.source_provenance_json, s.created_at, s.updated_at,
+		        EXISTS (SELECT 1 FROM skill_global_opt_outs g WHERE g.skill_id = s.id)
+		 FROM skills s
 		 WHERE NOT EXISTS (
-			 SELECT 1 FROM skill_profile_opt_outs WHERE profile_id = ? AND skill_id = skills.id
+			 SELECT 1 FROM skill_global_opt_outs g WHERE g.skill_id = s.id
 		 )
-		 ORDER BY id ASC`,
+		 AND NOT EXISTS (
+			 SELECT 1 FROM skill_profile_opt_outs o WHERE o.profile_id = ? AND o.skill_id = s.id
+		 )
+		 ORDER BY s.id ASC`,
 		profileID,
 	)
 	if err != nil {
@@ -398,9 +462,12 @@ func (s *Service) Delete(ctx context.Context, id string, forceDisable bool) erro
 		if err := s.db.QueryRow(
 			`SELECT COUNT(*) FROM runtime_profiles
 			 WHERE NOT EXISTS (
+				 SELECT 1 FROM skill_global_opt_outs WHERE skill_id = ?
+			 )
+			 AND NOT EXISTS (
 				 SELECT 1 FROM skill_profile_opt_outs WHERE profile_id = runtime_profiles.id AND skill_id = ?
 			 )`,
-			id,
+			id, id,
 		).Scan(&enabledProfiles); err != nil {
 			return fmt.Errorf("check skill enablement: %w", err)
 		}
@@ -414,7 +481,11 @@ func (s *Service) Delete(ctx context.Context, id string, forceDisable bool) erro
 	}
 	if _, err := tx.Exec(`DELETE FROM skill_profile_opt_outs WHERE skill_id = ?`, id); err != nil {
 		_ = tx.Rollback()
-		return fmt.Errorf("delete skill opt-outs: %w", err)
+		return fmt.Errorf("delete Profile Skill Opt-Outs: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM skill_global_opt_outs WHERE skill_id = ?`, id); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("delete Global Skill Opt-Out: %w", err)
 	}
 	result, err := tx.Exec(`DELETE FROM skills WHERE id = ?`, id)
 	if err != nil {
@@ -489,7 +560,8 @@ func (s *Service) upsertMetadata(meta Metadata) (Skill, error) {
 func (s *Service) scanSkill(row rowScanner) (Skill, error) {
 	var got Skill
 	var sourceJSON, createdAt, updatedAt string
-	err := row.Scan(&got.ID, &got.Name, &got.Description, &sourceJSON, &createdAt, &updatedAt)
+	var globallyOptedOut int
+	err := row.Scan(&got.ID, &got.Name, &got.Description, &sourceJSON, &createdAt, &updatedAt, &globallyOptedOut)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Skill{}, ErrNotFound
 	}
@@ -509,6 +581,7 @@ func (s *Service) scanSkill(row rowScanner) (Skill, error) {
 	}
 	got.CreatedAt = created
 	got.UpdatedAt = updated
+	got.GloballyOptedOut = globallyOptedOut != 0
 	got.BundlePath = s.bundlePath(got.ID)
 	return got, nil
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -23,13 +23,14 @@ type SourceProvenance struct {
 }
 
 type Skill struct {
-	ID          string           `json:"id"`
-	Name        string           `json:"name"`
-	Description string           `json:"description,omitempty"`
-	Source      SourceProvenance `json:"source_provenance,omitempty"`
-	BundlePath  string           `json:"-"`
-	CreatedAt   time.Time        `json:"created_at"`
-	UpdatedAt   time.Time        `json:"updated_at"`
+	ID               string           `json:"id"`
+	Name             string           `json:"name"`
+	Description      string           `json:"description,omitempty"`
+	Source           SourceProvenance `json:"source_provenance,omitempty"`
+	GloballyOptedOut bool             `json:"globally_opted_out"`
+	BundlePath       string           `json:"-"`
+	CreatedAt        time.Time        `json:"created_at"`
+	UpdatedAt        time.Time        `json:"updated_at"`
 }
 
 type Bundle struct {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -150,6 +150,88 @@ func TestDefaultEnablementOptOutAndDeletionLifecycle(t *testing.T) {
 	assertEnabledSkillIDs(t, svc, profileB.ID, []string{"recon-helper"})
 }
 
+func TestGlobalSkillOptOutOverridesProfilesAndDirectLaunches(t *testing.T) {
+	db := openTestStore(t)
+	profiles := runtimeprofile.NewService(db)
+	profileA, err := profiles.Create("Codex", runtimeprofile.ProviderCodex, runtimeprofile.Fields{})
+	if err != nil {
+		t.Fatalf("create profile A: %v", err)
+	}
+	profileB, err := profiles.Create("Claude", runtimeprofile.ProviderClaudeCode, runtimeprofile.Fields{})
+	if err != nil {
+		t.Fatalf("create profile B: %v", err)
+	}
+	svc := skill.NewService(db, filepath.Join(t.TempDir(), "skills"))
+	ctx := context.Background()
+
+	if _, err := svc.Publish(ctx, skill.PublishRequest{
+		Metadata: skill.Metadata{ID: "recon-helper", Name: "Recon Helper"},
+		Files:    map[string]string{"SKILL.md": "version one"},
+	}); err != nil {
+		t.Fatalf("publish skill: %v", err)
+	}
+	if err := svc.SetOptOut(profileA.ID, "recon-helper", true); err != nil {
+		t.Fatalf("set profile opt-out: %v", err)
+	}
+	if err := svc.SetGlobalOptOut("recon-helper", true); err != nil {
+		t.Fatalf("set global opt-out: %v", err)
+	}
+
+	globallyOptedOut, err := svc.Get("recon-helper")
+	if err != nil {
+		t.Fatalf("get globally opted-out skill: %v", err)
+	}
+	if !globallyOptedOut.GloballyOptedOut {
+		t.Fatalf("expected global opt-out to be stored, got %#v", globallyOptedOut)
+	}
+	assertEnabledSkillIDs(t, svc, "", []string{})
+	assertEnabledSkillIDs(t, svc, profileA.ID, []string{})
+	assertEnabledSkillIDs(t, svc, profileB.ID, []string{})
+
+	if _, err := svc.Publish(ctx, skill.PublishRequest{
+		Metadata: skill.Metadata{ID: "recon-helper", Name: "Recon Helper Updated"},
+		Files:    map[string]string{"SKILL.md": "version two"},
+	}); err != nil {
+		t.Fatalf("update skill: %v", err)
+	}
+	updated, err := svc.Get("recon-helper")
+	if err != nil {
+		t.Fatalf("get updated skill: %v", err)
+	}
+	if !updated.GloballyOptedOut {
+		t.Fatal("skill update must preserve the global opt-out")
+	}
+
+	if err := svc.SetGlobalOptOut("recon-helper", false); err != nil {
+		t.Fatalf("remove global opt-out: %v", err)
+	}
+	assertEnabledSkillIDs(t, svc, "", []string{"recon-helper"})
+	assertEnabledSkillIDs(t, svc, profileA.ID, []string{})
+	assertEnabledSkillIDs(t, svc, profileB.ID, []string{"recon-helper"})
+
+	if err := svc.SetGlobalOptOut("recon-helper", true); err != nil {
+		t.Fatalf("restore global opt-out: %v", err)
+	}
+	if err := svc.Delete(ctx, "recon-helper", false); err != nil {
+		t.Fatalf("delete globally opted-out skill: %v", err)
+	}
+	if _, err := svc.Publish(ctx, skill.PublishRequest{
+		Metadata: skill.Metadata{ID: "recon-helper", Name: "Recon Helper Reimported"},
+		Files:    map[string]string{"SKILL.md": "version three"},
+	}); err != nil {
+		t.Fatalf("reimport skill: %v", err)
+	}
+	reimported, err := svc.Get("recon-helper")
+	if err != nil {
+		t.Fatalf("get reimported skill: %v", err)
+	}
+	if reimported.GloballyOptedOut {
+		t.Fatal("Skill Deletion and recreation must not restore the old global opt-out")
+	}
+	assertEnabledSkillIDs(t, svc, profileA.ID, []string{"recon-helper"})
+	assertEnabledSkillIDs(t, svc, profileB.ID, []string{"recon-helper"})
+}
+
 func openTestStore(t *testing.T) *store.DB {
 	t.Helper()
 	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))

--- a/internal/store/migration70_test.go
+++ b/internal/store/migration70_test.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestMigration70AddsGlobalSkillOptOutStorage(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "migration70.db"))
+	if err != nil {
+		t.Fatalf("open migrated store: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(
+		`INSERT INTO skills (id, name, description, source_provenance_json, created_at, updated_at)
+		 VALUES ('recon-helper', 'Recon Helper', '', '{}', 'now', 'now')`,
+	); err != nil {
+		t.Fatalf("insert skill: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO skill_global_opt_outs (skill_id, created_at) VALUES ('recon-helper', 'now')`,
+	); err != nil {
+		t.Fatalf("insert global Skill Opt-Out: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM skill_global_opt_outs WHERE skill_id = 'recon-helper'`,
+	).Scan(&count); err != nil {
+		t.Fatalf("read global Skill Opt-Out: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("global Skill Opt-Out count = %d, want 1", count)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -955,8 +955,18 @@ func migrations() []migration {
 		newMigration(67, "operator_disabled_output_origins", migration67SQL, migration67Up),
 		newMigration(68, "operator_evidence_request_sources", migration68SQL, migration68Up),
 		newMigration(69, "owner_local_runtime_configuration_snapshots", migration69SQL, migration69Up),
+		newMigration(70, "global_skill_opt_outs", migration70SQL, migration70Up),
 	}
 }
+
+const migration70SQL = `
+CREATE TABLE IF NOT EXISTS skill_global_opt_outs (
+	skill_id TEXT PRIMARY KEY,
+	created_at TEXT NOT NULL
+);
+`
+
+func migration70Up(tx *sql.Tx) error { return execStatements(tx, migration70SQL) }
 
 const migration69SQL = `runtime configuration snapshot v1; remove automatic Runtime Profiles and runtime_profiles.kind`
 

--- a/internal/store/store_v2_test.go
+++ b/internal/store/store_v2_test.go
@@ -135,7 +135,7 @@ func TestOrdinaryOpenRefusesUnknownEpochWithoutTouchingSQLiteState(t *testing.T)
 			prepare: func(t *testing.T, path string) func() {
 				return holdStoreEpochUpdateInWAL(t, path, "future_v3")
 			},
-			wantMigrationCount: 69,
+			wantMigrationCount: 70,
 			wantSidecars:       true,
 		},
 	}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -617,6 +617,8 @@ export interface Skill {
   };
   files?: Record<string, string>;
   enabled: boolean;
+  globally_opted_out?: boolean;
+  profile_opted_out?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/pages/SkillsPage.test.tsx
+++ b/web/src/pages/SkillsPage.test.tsx
@@ -132,6 +132,75 @@ describe("SkillsPage", () => {
     );
   });
 
+  it("supports global Skill Opt-Out independently of the selected Runtime Profile", async () => {
+    const fetchMock = mockApi({
+      "/api/runtime-profiles": {
+        profiles: [
+          {
+            id: "profile-1",
+            name: "Codex Default",
+            provider: "codex",
+            fields: {},
+            created_at: "",
+            updated_at: "",
+          },
+        ],
+      },
+      "/api/skills?runtime_profile_id=profile-1": {
+        skills: [
+          {
+            id: "recon-helper",
+            name: "Recon Helper",
+            enabled: true,
+            globally_opted_out: false,
+            created_at: "",
+            updated_at: "",
+          },
+          {
+            id: "report-helper",
+            name: "Report Helper",
+            enabled: false,
+            globally_opted_out: true,
+            profile_opted_out: false,
+            created_at: "",
+            updated_at: "",
+          },
+        ],
+      },
+      "/api/skills/recon-helper/opt-out": {},
+      "/api/skills/report-helper/opt-out": {},
+    });
+
+    renderPage();
+
+    const reconRow = await screen.findByTestId("skill-card-recon-helper");
+    await userEvent.click(
+      within(reconRow).getByRole("switch", { name: "Opt out globally for Recon Helper" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/skills/recon-helper/opt-out",
+      expect.objectContaining({ method: "PUT" }),
+    );
+
+    const reportRow = screen.getByTestId("skill-card-report-helper");
+    expect(
+      within(reportRow).getByRole("switch", { name: "Enable globally for Report Helper" }),
+    ).toBeInTheDocument();
+    const preservedProfileSwitch = within(reportRow).getByRole("switch", {
+      name: /Opt out for Codex Default/i,
+    });
+    expect(preservedProfileSwitch).toBeChecked();
+    expect(preservedProfileSwitch).toBeDisabled();
+
+    await userEvent.click(
+      within(reportRow).getByRole("switch", { name: "Enable globally for Report Helper" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/skills/report-helper/opt-out",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
   it("disables and enables all current skills for the selected Runtime Profile", async () => {
     const fetchMock = mockApi({
       "/api/runtime-profiles": {
@@ -263,8 +332,9 @@ describe("SkillsPage", () => {
     renderPage();
 
     expect(
-      await screen.findByText(/Skill opt-outs apply to this Runtime Profile/i),
+      await screen.findByText(/Global Skill Opt-Outs affect direct launches and every Runtime Profile/i),
     ).toBeInTheDocument();
+    expect(screen.getByText(/Profile Skill Opt-Outs apply only when this Runtime Profile/i)).toBeInTheDocument();
     expect(screen.getByText(/new Task or Session/i)).toBeInTheDocument();
   });
 

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -191,14 +191,29 @@ export function SkillsPage() {
   }
 
   async function toggleOptOut(skill: Skill) {
-    if (!selectedProfile) return;
+    if (!selectedProfile || skill.globally_opted_out) return;
     setError(null);
     try {
       const path = `/api/skills/${encodeURIComponent(skill.id)}/profiles/${encodeURIComponent(selectedProfile.id)}/opt-out`;
-      if (skill.enabled) {
+      if (profileSkillEnabled(skill)) {
         await apiPut(path);
       } else {
         await apiDelete(path);
+      }
+      await loadSkills();
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }
+
+  async function toggleGlobalOptOut(skill: Skill) {
+    setError(null);
+    try {
+      const path = `/api/skills/${encodeURIComponent(skill.id)}/opt-out`;
+      if (skill.globally_opted_out) {
+        await apiDelete(path);
+      } else {
+        await apiPut(path);
       }
       await loadSkills();
     } catch (e) {
@@ -261,6 +276,11 @@ export function SkillsPage() {
 
   const enabledCount = useMemo(() => skills.filter((skill) => skill.enabled).length, [skills]);
   const optedOutCount = skills.length - enabledCount;
+  const profileEnabledCount = useMemo(
+    () => skills.filter((skill) => profileSkillEnabled(skill)).length,
+    [skills],
+  );
+  const profileOptedOutCount = skills.length - profileEnabledCount;
 
   const filteredSkills = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -315,11 +335,12 @@ export function SkillsPage() {
               <Label htmlFor="skills-runtime-profile" className="text-xs font-medium">
                 Runtime profile view
               </Label>
-              {selectedProfile && profileId && (
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  Skill opt-outs apply to this Runtime Profile when it is selected for a new Task or Session.
-                </p>
-              )}
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Global Skill Opt-Outs affect direct launches and every Runtime Profile.
+                {selectedProfile && profileId
+                  ? " Profile Skill Opt-Outs apply only when this Runtime Profile is selected for a new Task or Session."
+                  : ""}
+              </p>
             </div>
             <Select
               id="skills-runtime-profile"
@@ -349,7 +370,7 @@ export function SkillsPage() {
                 size="sm"
                 variant="outline"
                 aria-label="Enable all skills"
-                disabled={!selectedProfile || optedOutCount === 0 || bulkUpdating || skillsLoading}
+                disabled={!selectedProfile || profileOptedOutCount === 0 || bulkUpdating || skillsLoading}
                 onClick={() => {
                   if (selectedProfile) void setAllSkillsOptOut(selectedProfile, false);
                 }}
@@ -360,7 +381,7 @@ export function SkillsPage() {
                 size="sm"
                 variant="outline"
                 aria-label="Disable all skills"
-                disabled={!selectedProfile || enabledCount === 0 || bulkUpdating || skillsLoading}
+                disabled={!selectedProfile || profileEnabledCount === 0 || bulkUpdating || skillsLoading}
                 onClick={() => {
                   if (selectedProfile) setConfirmDisableAllProfile(selectedProfile);
                 }}
@@ -443,7 +464,8 @@ export function SkillsPage() {
                     <th className="px-4 py-2.5 font-medium">Skill</th>
                     <th className="px-4 py-2.5 font-medium">Description</th>
                     <th className="px-4 py-2.5 font-medium w-[70px]">Source</th>
-                    <th className="px-4 py-2.5 font-medium w-[60px]">Enabled</th>
+                    <th className="px-4 py-2.5 font-medium w-[60px]">Global</th>
+                    <th className="px-4 py-2.5 font-medium w-[60px]">Profile</th>
                     <th className="px-4 py-2.5 font-medium w-[70px]"></th>
                   </tr>
                 </thead>
@@ -469,12 +491,24 @@ export function SkillsPage() {
                         </td>
                         <td className="px-4 py-2.5 text-xs text-muted-foreground">{source}</td>
                         <td className="px-4 py-2.5">
+                          <EnableSwitch
+                            enabled={!skill.globally_opted_out}
+                            onClick={() => toggleGlobalOptOut(skill)}
+                            ariaLabel={
+                              skill.globally_opted_out
+                                ? `Enable globally for ${name}`
+                                : `Opt out globally for ${name}`
+                            }
+                          />
+                        </td>
+                        <td className="px-4 py-2.5">
                           {selectedProfile ? (
                             <EnableSwitch
-                              enabled={skill.enabled}
+                              enabled={profileSkillEnabled(skill)}
+                              disabled={Boolean(skill.globally_opted_out)}
                               onClick={() => toggleOptOut(skill)}
                               ariaLabel={
-                                skill.enabled
+                                profileSkillEnabled(skill)
                                   ? `Opt out for ${selectedProfile.name}`
                                   : `Enable for ${selectedProfile.name}`
                               }
@@ -688,7 +722,7 @@ export function SkillsPage() {
             ? `Disable all skills for ${confirmDisableAllProfile.name}?`
             : "Disable all skills?"
         }
-        description="This adds Skill Opt-Outs for all current Skills in this Runtime Profile. Started Tasks do not change, and future imported Skills remain default-on."
+        description="This adds Profile Skill Opt-Outs for all current Skills in this Runtime Profile. Started Tasks do not change, and future imported Skills remain default-on."
         confirmLabel="Disable all"
         destructive
         onConfirm={() => {
@@ -701,7 +735,7 @@ export function SkillsPage() {
       <ConfirmDialog
         open={confirmDeleteSkill !== null}
         title={confirmDeleteSkill ? `Delete skill ${displaySkillName(confirmDeleteSkill)}?` : "Delete skill?"}
-        description="The skill is force-disabled and removed from this runtime profile view."
+        description="The Skill is removed from the global library and future launches. Started Runtime Owners do not change."
         confirmLabel="Delete"
         destructive
         onConfirm={() => {
@@ -752,10 +786,12 @@ function ImportForm({
 
 function EnableSwitch({
   enabled,
+  disabled = false,
   onClick,
   ariaLabel,
 }: {
   enabled: boolean;
+  disabled?: boolean;
   onClick: () => void;
   ariaLabel: string;
 }) {
@@ -765,9 +801,10 @@ function EnableSwitch({
       role="switch"
       aria-checked={enabled}
       aria-label={ariaLabel}
+      disabled={disabled}
       onClick={onClick}
       className={cn(
-        "relative h-6 w-10 shrink-0 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "relative h-6 w-10 shrink-0 rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         enabled
           ? "border-success/30 bg-success"
           : "border-border bg-muted",
@@ -781,6 +818,11 @@ function EnableSwitch({
       />
     </button>
   );
+}
+
+function profileSkillEnabled(skill: Skill) {
+  if (typeof skill.profile_opted_out === "boolean") return !skill.profile_opted_out;
+  return skill.enabled;
 }
 
 function sourceLabel(skill: Skill) {

--- a/web/src/pages/TaskLaunchPage.test.tsx
+++ b/web/src/pages/TaskLaunchPage.test.tsx
@@ -576,8 +576,8 @@ await userEvent.click(await screen.findByRole("button", { name: /use saved prese
 
     renderPage();
 
-await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
-    expect(await screen.findByText(/globally default-enabled/i)).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole("button", { name: /skills/i }));
+    expect(await screen.findByText(/after Global Skill Opt-Outs/i)).toBeInTheDocument();
     expect(await screen.findByText("Recon Helper")).toBeInTheDocument();
     expect(screen.queryByText(/^Profile:/)).not.toBeInTheDocument();
   });

--- a/web/src/pages/taskLaunchSkills.test.ts
+++ b/web/src/pages/taskLaunchSkills.test.ts
@@ -56,8 +56,10 @@ describe("taskLaunchSkills", () => {
     expect(enabledLaunchSkills(skills).map((skill) => skill.id)).toEqual(["recon-helper"]);
   });
 
-  it("explains Profile vs direct configuration semantics", () => {
-    expect(launchSkillsPreviewDetail(true)).toMatch(/Runtime Profile/i);
+  it("explains Global and Profile Skill Opt-Out semantics", () => {
+    expect(launchSkillsPreviewDetail(true)).toMatch(/Global Skill Opt-Outs/i);
+    expect(launchSkillsPreviewDetail(true)).toMatch(/Profile Skill Opt-Outs/i);
     expect(launchSkillsPreviewDetail(false)).toMatch(/Direct configuration/i);
+    expect(launchSkillsPreviewDetail(false)).toMatch(/Global Skill Opt-Outs/i);
   });
 });

--- a/web/src/pages/taskLaunchSkills.ts
+++ b/web/src/pages/taskLaunchSkills.ts
@@ -16,7 +16,7 @@ export function enabledLaunchSkills(skills: Skill[]): Skill[] {
 
 export function launchSkillsPreviewDetail(presetMode: boolean): string {
   if (presetMode) {
-    return "Skills follow the selected Runtime Profile. Library Skills are enabled by default unless this Profile has Opt-Outs.";
+    return "Global Skill Opt-Outs apply first. Other library Skills follow the selected Runtime Profile and its Profile Skill Opt-Outs.";
   }
-  return "Direct configuration captures the current globally default-enabled Skills. Later library changes do not change this Runtime Owner.";
+  return "Direct configuration captures the current Skills after Global Skill Opt-Outs. Later library changes do not change this Runtime Owner.";
 }


### PR DESCRIPTION
## Summary

- Add global skill opt-out support with persisted store state and migration coverage.
- Apply owner-local runtime configuration when resolving task launches.
- Update daemon handlers and APIs for skill preference management.
- Update Skills and task launch pages to display and manage skill settings.
- Add ADRs and context documentation for the new behavior.

## Testing

- Added and updated Go unit tests for skill services, built-in skills, daemon handlers, store migrations, and store behavior.
- Added and updated frontend tests for Skills and task launch flows.