### PR TITLE
Add explicit global Skill bulk controls

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1085,7 +1085,10 @@ _Avoid_: transcript, export, source of truth
 - A **Runtime Profile** may add a **Profile Skill Opt-Out** for a Skill enabled by **Default Skill Enablement**.
 - Every **Skill Opt-Out** is tied to **Skill ID** and survives ordinary imports or edits that update the same **Skill**.
 - A **Global Skill Opt-Out** overrides effective Profile enablement but does not erase existing **Profile Skill Opt-Outs**; removing the global override restores each Profile's own choice.
-- The **Skills Page** bulk Profile enablement actions apply to the selected **Runtime Profile** and the current **Skill** library: Disable all atomically creates a **Profile Skill Opt-Out** for every current Skill, while Enable all atomically removes every Profile Skill Opt-Out for that Profile. Neither action changes started **Tasks**, and later imports still follow **Default Skill Enablement**.
+- The **Skills Page** exposes separate bulk Global and Profile enablement actions so the operation scope is explicit.
+- Bulk Global Disable all atomically creates a **Global Skill Opt-Out** for every current Skill, while Bulk Global Enable all atomically removes every Global Skill Opt-Out.
+- Bulk Profile Disable all atomically creates a **Profile Skill Opt-Out** for every current Skill in the selected **Runtime Profile**, while Bulk Profile Enable all atomically removes every Profile Skill Opt-Out for that Profile.
+- Bulk Skill enablement actions do not change started **Runtime Owners**, and later imports still follow **Default Skill Enablement**.
 - **Skill Deletion** ends the enablement lifecycle for that **Skill ID**; re-importing the same **Skill ID** follows **Default Skill Enablement** instead of restoring old Global or Profile Skill Opt-Outs.
 - The **Skills Page** is the source of truth for **Global Skill Opt-Outs** and updates **Profile Skill Opt-Outs** for the selected **Runtime Profile**.
 - A **Runtime Profile** may reference a manually entered **Runtime Extension** identifier, but task launch still requires the daemon **Runtime Extension Registry** to resolve it.

--- a/docs/adr/0032-add-global-skill-opt-out.md
+++ b/docs/adr/0032-add-global-skill-opt-out.md
@@ -16,6 +16,7 @@ This decision extends ADR-0001. Skills remain default-on, but Profile Skill Opt-
 - **Skill Deletion** removes both kinds of opt-out. Recreating the same Skill ID starts with **Default Skill Enablement**.
 - Started Runtime Owners keep their captured **Runtime Configuration Snapshot** and **Task Skills Root**. The change applies only to later launch resolution.
 - The **Skills Page** exposes separate Global and Profile controls. A Profile control is inactive while the Global Skill Opt-Out is active because it cannot change effective enablement.
+- The **Skills Page** exposes separate Global and Profile bulk controls. Disable all globally atomically creates a Global Skill Opt-Out for every current Skill, while Enable all globally removes every Global Skill Opt-Out. Later imports still follow Default Skill Enablement.
 
 ## Considered options
 

--- a/internal/daemon/assisted_conclusion_test.go
+++ b/internal/daemon/assisted_conclusion_test.go
@@ -531,9 +531,9 @@ func TestAssistedConclusionStartupReplaysCommittedValidatedApplyWithoutProviderT
 		}
 	}
 	waitForAssistedProviderRequests(t, session, 2)
-	receipt, err := server.tasks.LatestBlackboardConclusion(created.ID)
-	if err != nil || receipt == nil || receipt.BaseRevision == nil {
-		t.Fatalf("load awaiting receipt: %#v, %v", receipt, err)
+	receipt := waitForBlackboardConclusionReceiptState(t, server, created.ID, task.BlackboardConclusionReceiptAwaitingResult)
+	if receipt.BaseRevision == nil {
+		t.Fatalf("awaiting receipt has no base revision: %#v", receipt)
 	}
 	decoded, err := blackboardconclusion.Decode([]byte(assistedAttemptResultJSON(*receipt.BaseRevision, "attempt:startup-replay", "objective:startup-replay")))
 	if err != nil {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -954,6 +954,8 @@ func (server *Server) routes() {
 	server.mux.HandleFunc("GET /api/skills/{skill_id}", server.handleGetSkill)
 	server.mux.HandleFunc("PUT /api/skills/{skill_id}", server.handlePutSkill)
 	server.mux.HandleFunc("DELETE /api/skills/{skill_id}", server.handleDeleteSkill)
+	server.mux.HandleFunc("PUT /api/skills/opt-outs/global", server.handlePutAllGlobalSkillOptOuts)
+	server.mux.HandleFunc("DELETE /api/skills/opt-outs/global", server.handleDeleteAllGlobalSkillOptOuts)
 	server.mux.HandleFunc("PUT /api/skills/{skill_id}/opt-out", server.handlePutGlobalSkillOptOut)
 	server.mux.HandleFunc("DELETE /api/skills/{skill_id}/opt-out", server.handleDeleteGlobalSkillOptOut)
 	server.mux.HandleFunc("PUT /api/skills/profiles/{profile_id}/opt-out", server.handlePutAllSkillProfileOptOuts)

--- a/internal/daemon/skill_handlers.go
+++ b/internal/daemon/skill_handlers.go
@@ -196,6 +196,22 @@ func (server *Server) handleDeleteGlobalSkillOptOut(response http.ResponseWriter
 	server.handleGlobalSkillOptOut(response, request, false)
 }
 
+func (server *Server) handlePutAllGlobalSkillOptOuts(response http.ResponseWriter, request *http.Request) {
+	server.handleAllGlobalSkillOptOuts(response, request, true)
+}
+
+func (server *Server) handleDeleteAllGlobalSkillOptOuts(response http.ResponseWriter, request *http.Request) {
+	server.handleAllGlobalSkillOptOuts(response, request, false)
+}
+
+func (server *Server) handleAllGlobalSkillOptOuts(response http.ResponseWriter, _ *http.Request, optedOut bool) {
+	if err := server.skills.SetAllGlobalOptOut(optedOut); err != nil {
+		writeSkillError(response, err)
+		return
+	}
+	response.WriteHeader(http.StatusNoContent)
+}
+
 func (server *Server) handleGlobalSkillOptOut(response http.ResponseWriter, request *http.Request, optedOut bool) {
 	skillID := strings.TrimSpace(request.PathValue("skill_id"))
 	if err := server.skills.SetGlobalOptOut(skillID, optedOut); err != nil {

--- a/internal/daemon/skill_test.go
+++ b/internal/daemon/skill_test.go
@@ -206,6 +206,58 @@ func TestSkillGlobalOptOutHTTP(t *testing.T) {
 	assertListedSkillEnablement(t, server, profileID, map[string]bool{"recon-helper": true})
 }
 
+func TestSkillsBulkGlobalOptOutAndEnableHTTP(t *testing.T) {
+	server := newDaemon(t)
+	profileID := createRuntimeProfile(t, server, `{"name":"Codex","provider":"codex"}`)
+
+	putSkill(t, server, "recon-helper", `{
+		"name":"Recon Helper",
+		"files":{"SKILL.md":"# Recon Helper"}
+	}`)
+	putSkill(t, server, "report-helper", `{
+		"name":"Report Helper",
+		"files":{"SKILL.md":"# Report Helper"}
+	}`)
+
+	profileOptOutReq := httptest.NewRequest(http.MethodPut, "/api/skills/recon-helper/profiles/"+profileID+"/opt-out", nil)
+	profileOptOutResp := httptest.NewRecorder()
+	server.ServeHTTP(profileOptOutResp, profileOptOutReq)
+	if profileOptOutResp.Code != http.StatusNoContent {
+		t.Fatalf("expected Profile Skill Opt-Out status 204, got %d with body %s", profileOptOutResp.Code, profileOptOutResp.Body.String())
+	}
+
+	bulkPath := "/api/skills/opt-outs/global"
+	disableReq := httptest.NewRequest(http.MethodPut, bulkPath, nil)
+	disableResp := httptest.NewRecorder()
+	server.ServeHTTP(disableResp, disableReq)
+	if disableResp.Code != http.StatusNoContent {
+		t.Fatalf("expected global bulk opt-out status 204, got %d with body %s", disableResp.Code, disableResp.Body.String())
+	}
+	assertListedSkillEnablement(t, server, "", map[string]bool{
+		"recon-helper":  false,
+		"report-helper": false,
+	})
+	assertListedSkillEnablement(t, server, profileID, map[string]bool{
+		"recon-helper":  false,
+		"report-helper": false,
+	})
+
+	enableReq := httptest.NewRequest(http.MethodDelete, bulkPath, nil)
+	enableResp := httptest.NewRecorder()
+	server.ServeHTTP(enableResp, enableReq)
+	if enableResp.Code != http.StatusNoContent {
+		t.Fatalf("expected global bulk enable status 204, got %d with body %s", enableResp.Code, enableResp.Body.String())
+	}
+	assertListedSkillEnablement(t, server, "", map[string]bool{
+		"recon-helper":  true,
+		"report-helper": true,
+	})
+	assertListedSkillEnablement(t, server, profileID, map[string]bool{
+		"recon-helper":  false,
+		"report-helper": true,
+	})
+}
+
 func assertListedSkillEnablement(t *testing.T, server http.Handler, profileID string, want map[string]bool) {
 	t.Helper()
 	request := httptest.NewRequest(http.MethodGet, "/api/skills?runtime_profile_id="+profileID, nil)

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -324,6 +324,30 @@ func (s *Service) SetGlobalOptOut(skillID string, optedOut bool) error {
 	return nil
 }
 
+func (s *Service) SetAllGlobalOptOut(optedOut bool) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin bulk global Skill Opt-Out: %w", err)
+	}
+	defer tx.Rollback()
+
+	if optedOut {
+		if _, err := tx.Exec(
+			`INSERT OR IGNORE INTO skill_global_opt_outs (skill_id, created_at)
+			 SELECT id, ? FROM skills`,
+			time.Now().UTC().Format(time.RFC3339Nano),
+		); err != nil {
+			return fmt.Errorf("store bulk Global Skill Opt-Outs: %w", err)
+		}
+	} else if _, err := tx.Exec(`DELETE FROM skill_global_opt_outs`); err != nil {
+		return fmt.Errorf("delete bulk Global Skill Opt-Outs: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit bulk Global Skill Opt-Out: %w", err)
+	}
+	return nil
+}
+
 func (s *Service) SetOptOut(profileID, skillID string, optedOut bool) error {
 	profileID = strings.TrimSpace(profileID)
 	skillID = strings.TrimSpace(skillID)

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -232,6 +232,59 @@ func TestGlobalSkillOptOutOverridesProfilesAndDirectLaunches(t *testing.T) {
 	assertEnabledSkillIDs(t, svc, profileB.ID, []string{"recon-helper"})
 }
 
+func TestAllGlobalSkillOptOutsPreserveProfileChoicesAndKeepFutureSkillsDefaultOn(t *testing.T) {
+	db := openTestStore(t)
+	profiles := runtimeprofile.NewService(db)
+	profile, err := profiles.Create("Codex", runtimeprofile.ProviderCodex, runtimeprofile.Fields{})
+	if err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	svc := skill.NewService(db, filepath.Join(t.TempDir(), "skills"))
+	ctx := context.Background()
+
+	for _, id := range []string{"recon-helper", "report-helper"} {
+		if _, err := svc.Publish(ctx, skill.PublishRequest{
+			Metadata: skill.Metadata{ID: id, Name: id},
+			Files:    map[string]string{"SKILL.md": "# " + id},
+		}); err != nil {
+			t.Fatalf("publish %s: %v", id, err)
+		}
+	}
+	if err := svc.SetOptOut(profile.ID, "recon-helper", true); err != nil {
+		t.Fatalf("set Profile Skill Opt-Out: %v", err)
+	}
+
+	if err := svc.SetAllGlobalOptOut(true); err != nil {
+		t.Fatalf("disable all Skills globally: %v", err)
+	}
+	assertEnabledSkillIDs(t, svc, "", []string{})
+	assertEnabledSkillIDs(t, svc, profile.ID, []string{})
+	for _, id := range []string{"recon-helper", "report-helper"} {
+		got, err := svc.Get(id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if !got.GloballyOptedOut {
+			t.Fatalf("expected %s to have a Global Skill Opt-Out", id)
+		}
+	}
+
+	if _, err := svc.Publish(ctx, skill.PublishRequest{
+		Metadata: skill.Metadata{ID: "future-helper", Name: "Future Helper"},
+		Files:    map[string]string{"SKILL.md": "# Future Helper"},
+	}); err != nil {
+		t.Fatalf("publish future Skill: %v", err)
+	}
+	assertEnabledSkillIDs(t, svc, "", []string{"future-helper"})
+	assertEnabledSkillIDs(t, svc, profile.ID, []string{"future-helper"})
+
+	if err := svc.SetAllGlobalOptOut(false); err != nil {
+		t.Fatalf("enable all Skills globally: %v", err)
+	}
+	assertEnabledSkillIDs(t, svc, "", []string{"future-helper", "recon-helper", "report-helper"})
+	assertEnabledSkillIDs(t, svc, profile.ID, []string{"future-helper", "report-helper"})
+}
+
 func openTestStore(t *testing.T) *store.DB {
 	t.Helper()
 	db, err := store.Open(filepath.Join(t.TempDir(), "pentest.db"))

--- a/web/src/pages/SkillsPage.test.tsx
+++ b/web/src/pages/SkillsPage.test.tsx
@@ -201,7 +201,7 @@ describe("SkillsPage", () => {
     );
   });
 
-  it("disables and enables all current skills for the selected Runtime Profile", async () => {
+  it("offers separate bulk controls for Global and Profile Skill Opt-Outs", async () => {
     const fetchMock = mockApi({
       "/api/runtime-profiles": {
         profiles: [
@@ -215,12 +215,16 @@ describe("SkillsPage", () => {
           },
         ],
       },
+      "/api/skills/opt-outs/global": {},
+      "/api/skills/profiles/profile-1/opt-out": {},
       "/api/skills?runtime_profile_id=profile-1": {
         skills: [
           {
             id: "recon-helper",
             name: "Recon Helper",
             enabled: true,
+            globally_opted_out: false,
+            profile_opted_out: false,
             created_at: "",
             updated_at: "",
           },
@@ -228,31 +232,64 @@ describe("SkillsPage", () => {
             id: "report-helper",
             name: "Report Helper",
             enabled: false,
+            globally_opted_out: true,
+            profile_opted_out: true,
             created_at: "",
             updated_at: "",
           },
         ],
       },
-      "/api/skills/profiles/profile-1/opt-out": {},
     });
 
     renderPage();
 
     await screen.findByText("Recon Helper");
-    await userEvent.click(screen.getByRole("button", { name: "Disable all skills" }));
+
+    expect(screen.getByRole("group", { name: "Global Skill bulk actions" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Codex Default Profile Skill bulk actions" }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Disable all skills globally" }));
+
+    const globalDialog = screen.getByRole("alertdialog", {
+      name: "Disable all skills globally?",
+    });
+    expect(globalDialog).toBeInTheDocument();
+    expect(
+      within(globalDialog).getByText(/direct launches and every Runtime Profile/i),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Disable globally" }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/skills/opt-outs/global",
+      expect.objectContaining({ method: "PUT" }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Enable all skills globally" }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/skills/opt-outs/global",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Disable all skills for Codex Default" }),
+    );
 
     expect(
       screen.getByRole("alertdialog", { name: "Disable all skills for Codex Default?" }),
     ).toBeInTheDocument();
     expect(screen.getByText(/future imported Skills remain default-on/i)).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Disable all" }));
+    await userEvent.click(screen.getByRole("button", { name: "Disable for profile" }));
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/skills/profiles/profile-1/opt-out",
       expect.objectContaining({ method: "PUT" }),
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "Enable all skills" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Enable all skills for Codex Default" }),
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/skills/profiles/profile-1/opt-out",
       expect.objectContaining({ method: "DELETE" }),
@@ -399,6 +436,7 @@ describe("SkillsPage", () => {
   it("keeps the Global Skill control active when no Runtime Profile exists", async () => {
     const fetchMock = mockApi({
       "/api/runtime-profiles": { profiles: [] },
+      "/api/skills/opt-outs/global": {},
       "/api/skills/api-security/opt-out": {},
       "/api/skills": {
         skills: [
@@ -433,6 +471,21 @@ describe("SkillsPage", () => {
     expect(profileSwitch).toBeDisabled();
     expect(profileSwitch).toHaveAttribute("aria-checked", "true");
     expect(within(screen.getByTestId("skill-card-api-security")).queryByText("—")).not.toBeInTheDocument();
+
+    const globalBulkButton = screen.getByRole("button", {
+      name: "Disable all skills globally",
+    });
+    expect(globalBulkButton).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Disable all skills for a Runtime Profile" }),
+    ).toBeDisabled();
+
+    await userEvent.click(globalBulkButton);
+    await userEvent.click(screen.getByRole("button", { name: "Disable globally" }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/skills/opt-outs/global",
+      expect.objectContaining({ method: "PUT" }),
+    );
   });
 
   it("keeps the create form collapsed until New skill is chosen", async () => {

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -40,6 +40,9 @@ type SkillForm = {
 
 type FormMode = "idle" | "create" | "edit";
 type StatusFilter = "all" | "enabled" | "opted_out";
+type DisableAllTarget =
+  | { scope: "global" }
+  | { scope: "profile"; profile: RuntimeProfile };
 
 const emptySkillForm: SkillForm = {
   id: "",
@@ -63,7 +66,7 @@ export function SkillsPage() {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [confirmDeleteSkill, setConfirmDeleteSkill] = useState<Skill | null>(null);
-  const [confirmDisableAllProfile, setConfirmDisableAllProfile] = useState<RuntimeProfile | null>(null);
+  const [confirmDisableAllTarget, setConfirmDisableAllTarget] = useState<DisableAllTarget | null>(null);
   const [bulkUpdating, setBulkUpdating] = useState(false);
   const [skillsLoading, setSkillsLoading] = useState(true);
 
@@ -239,6 +242,24 @@ export function SkillsPage() {
     }
   }
 
+  async function setAllGlobalSkillsOptOut(optedOut: boolean) {
+    setBulkUpdating(true);
+    setError(null);
+    try {
+      const path = "/api/skills/opt-outs/global";
+      if (optedOut) {
+        await apiPut(path);
+      } else {
+        await apiDelete(path);
+      }
+      await loadSkills();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBulkUpdating(false);
+    }
+  }
+
   async function editSkill(skill: Skill) {
     setError(null);
     try {
@@ -276,6 +297,11 @@ export function SkillsPage() {
 
   const enabledCount = useMemo(() => skills.filter((skill) => skill.enabled).length, [skills]);
   const optedOutCount = skills.length - enabledCount;
+  const globalEnabledCount = useMemo(
+    () => skills.filter((skill) => !skill.globally_opted_out).length,
+    [skills],
+  );
+  const globalOptedOutCount = skills.length - globalEnabledCount;
   const profileEnabledCount = useMemo(
     () => skills.filter((skill) => profileSkillEnabled(skill)).length,
     [skills],
@@ -358,6 +384,112 @@ export function SkillsPage() {
             </Select>
           </div>
 
+          <div className="grid gap-2 rounded-lg border border-border bg-card p-3 shadow-sm sm:grid-cols-2 lg:shrink-0">
+            <div
+              role="group"
+              aria-label="Global Skill bulk actions"
+              className="rounded-md border border-border bg-muted/20 p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold">Global</p>
+                  <p className="mt-0.5 text-[11px] leading-4 text-muted-foreground">
+                    Direct launches and every Runtime Profile
+                  </p>
+                </div>
+                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                  {globalEnabledCount}/{skills.length} enabled
+                </span>
+              </div>
+              <div className="mt-3 flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label="Enable all skills globally"
+                  disabled={globalOptedOutCount === 0 || bulkUpdating || skillsLoading}
+                  onClick={() => void setAllGlobalSkillsOptOut(false)}
+                  className="flex-1"
+                >
+                  <CheckCheck className="h-3.5 w-3.5" /> Enable all
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label="Disable all skills globally"
+                  disabled={globalEnabledCount === 0 || bulkUpdating || skillsLoading}
+                  onClick={() => setConfirmDisableAllTarget({ scope: "global" })}
+                  className="flex-1 text-destructive hover:text-destructive"
+                >
+                  <Ban className="h-3.5 w-3.5" /> Disable all
+                </Button>
+              </div>
+            </div>
+
+            <div
+              role="group"
+              aria-label={
+                selectedProfile
+                  ? `${selectedProfile.name} Profile Skill bulk actions`
+                  : "Profile Skill bulk actions"
+              }
+              className="rounded-md border border-border bg-muted/20 p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-semibold">
+                    Profile{selectedProfile ? ` · ${selectedProfile.name}` : ""}
+                  </p>
+                  <p className="mt-0.5 text-[11px] leading-4 text-muted-foreground">
+                    {selectedProfile
+                      ? "Only this Profile; Global Opt-Outs still override"
+                      : "Create a Runtime Profile to use these controls"}
+                  </p>
+                </div>
+                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                  {selectedProfile
+                    ? `${profileEnabledCount}/${skills.length} allowed`
+                    : "Unavailable"}
+                </span>
+              </div>
+              <div className="mt-3 flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={
+                    selectedProfile
+                      ? `Enable all skills for ${selectedProfile.name}`
+                      : "Enable all skills for a Runtime Profile"
+                  }
+                  disabled={!selectedProfile || profileOptedOutCount === 0 || bulkUpdating || skillsLoading}
+                  onClick={() => {
+                    if (selectedProfile) void setAllSkillsOptOut(selectedProfile, false);
+                  }}
+                  className="flex-1"
+                >
+                  <CheckCheck className="h-3.5 w-3.5" /> Enable all
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={
+                    selectedProfile
+                      ? `Disable all skills for ${selectedProfile.name}`
+                      : "Disable all skills for a Runtime Profile"
+                  }
+                  disabled={!selectedProfile || profileEnabledCount === 0 || bulkUpdating || skillsLoading}
+                  onClick={() => {
+                    if (selectedProfile) {
+                      setConfirmDisableAllTarget({ scope: "profile", profile: selectedProfile });
+                    }
+                  }}
+                  className="flex-1 text-destructive hover:text-destructive"
+                >
+                  <Ban className="h-3.5 w-3.5" /> Disable all
+                </Button>
+              </div>
+            </div>
+          </div>
+
           <div className="flex flex-wrap items-center justify-between gap-2 lg:shrink-0">
             <span className="text-base font-semibold">
               {enabledCount}{" "}
@@ -366,29 +498,6 @@ export function SkillsPage() {
               </span>
             </span>
             <div className="flex flex-wrap items-center gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                aria-label="Enable all skills"
-                disabled={!selectedProfile || profileOptedOutCount === 0 || bulkUpdating || skillsLoading}
-                onClick={() => {
-                  if (selectedProfile) void setAllSkillsOptOut(selectedProfile, false);
-                }}
-              >
-                <CheckCheck className="h-3.5 w-3.5" /> Enable all
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                aria-label="Disable all skills"
-                disabled={!selectedProfile || profileEnabledCount === 0 || bulkUpdating || skillsLoading}
-                onClick={() => {
-                  if (selectedProfile) setConfirmDisableAllProfile(selectedProfile);
-                }}
-                className="text-destructive hover:text-destructive"
-              >
-                <Ban className="h-3.5 w-3.5" /> Disable all
-              </Button>
               <SettingsSegmentedFilter
                 aria-label="Filter by status"
                 value={statusFilter}
@@ -729,21 +838,31 @@ export function SkillsPage() {
         </aside>
       </SettingsSplitLayout>
       <ConfirmDialog
-        open={confirmDisableAllProfile !== null}
+        open={confirmDisableAllTarget !== null}
         title={
-          confirmDisableAllProfile
-            ? `Disable all skills for ${confirmDisableAllProfile.name}?`
+          confirmDisableAllTarget?.scope === "global"
+            ? "Disable all skills globally?"
+            : confirmDisableAllTarget?.scope === "profile"
+              ? `Disable all skills for ${confirmDisableAllTarget.profile.name}?`
             : "Disable all skills?"
         }
-        description="This adds Profile Skill Opt-Outs for all current Skills in this Runtime Profile. Started Tasks do not change, and future imported Skills remain default-on."
-        confirmLabel="Disable all"
+        description={
+          confirmDisableAllTarget?.scope === "global"
+            ? "This adds Global Skill Opt-Outs for all current Skills. Direct launches and every Runtime Profile stop receiving them. Started Runtime Owners do not change, and future imported Skills remain default-on."
+            : "This adds Profile Skill Opt-Outs for all current Skills in this Runtime Profile. Started Runtime Owners do not change, and future imported Skills remain default-on."
+        }
+        confirmLabel={confirmDisableAllTarget?.scope === "global" ? "Disable globally" : "Disable for profile"}
         destructive
         onConfirm={() => {
-          const profile = confirmDisableAllProfile;
-          setConfirmDisableAllProfile(null);
-          if (profile) void setAllSkillsOptOut(profile, true);
+          const target = confirmDisableAllTarget;
+          setConfirmDisableAllTarget(null);
+          if (target?.scope === "global") {
+            void setAllGlobalSkillsOptOut(true);
+          } else if (target?.scope === "profile") {
+            void setAllSkillsOptOut(target.profile, true);
+          }
         }}
-        onCancel={() => setConfirmDisableAllProfile(null)}
+        onCancel={() => setConfirmDisableAllTarget(null)}
       />
       <ConfirmDialog
         open={confirmDeleteSkill !== null}


### PR DESCRIPTION
## Summary

- Add separate, explicit Global and Profile bulk action panels on the Skills Page.
- Add atomic Global Disable all and Enable all operations through `PUT` and `DELETE /api/skills/opt-outs/global`.
- Preserve Profile Skill Opt-Out choices when Global Skill Opt-Outs are removed.
- Keep Skills imported after a bulk disable default-on.
- Update the accepted Skill enablement decision and domain context.

This is a follow-up to #261, which was merged on September 2, 2026 while this UX change was being implemented.

## Testing

- `go test -count=1 ./internal/skill ./internal/daemon`
- `npm test -- --run` — 47 files, 575 tests
- `npm run lint`
- `npm run build`
- `make build-ui`