### PR TITLE
fix(web): keep Runtime Owner scroll stable with measured virtual rows

### DIFF
--- a/web/e2e/runtime-owner-workspace.spec.ts
+++ b/web/e2e/runtime-owner-workspace.spec.ts
@@ -249,3 +249,147 @@ test("a page-long final message stays at its beginning when a live Transcript en
   await expect(page.getByTestId("unseen-transcript-indicator")).toContainText("2 new messages", { timeout: 3000 });
   expect(await viewport.evaluate((element) => element.scrollTop)).toBeLessThanOrEqual(readingPosition + 2);
 });
+
+test("leaving the live tail keeps the viewport covered without a blank band", async ({ page }) => {
+  // Collapsed single-line rows sit far below the 72px virtual-window
+  // estimate, so the estimate-derived window used to end above the viewport
+  // bottom and expose the tail spacer as a large blank band.
+  const shortEntries: TranscriptEntry[] = Array.from({ length: 200 }, (_, index) => ({
+    id: `entry-${index + 1}`,
+    seq: index + 1,
+    continuation: 1,
+    kind: "message",
+    role: "assistant",
+    text: `History entry ${index + 1}`,
+    created_at: "2026-08-01T00:00:00Z",
+  }));
+  await routeRuntimeOwnerWorkspace(page, { transcript: shortEntries });
+
+  await page.goto("/projects/project-0/tasks/task-0");
+  await expect(page.getByText("History entry 200")).toBeVisible();
+
+  const viewport = page.getByTestId("conversation-workspace");
+  await viewport.hover();
+  await page.mouse.wheel(0, -600);
+  await expect(page.getByRole("button", { name: "Scroll to latest (auto-follow off)" })).toBeVisible();
+
+  await expect.poll(async () => {
+    const [viewportBox, rowsBox] = await Promise.all([
+      viewport.boundingBox(),
+      page.getByTestId("transcript-rows").boundingBox(),
+    ]);
+    if (viewportBox === null || rowsBox === null) return false;
+    // The rows cannot cover the container's bottom padding, so compare
+    // against the content-box bottom.
+    const paddingBottom = await viewport.evaluate(
+      (element) => parseFloat(getComputedStyle(element).paddingBottom) || 0,
+    );
+    return rowsBox.y + rowsBox.height >= viewportBox.y + viewportBox.height - paddingBottom - 4;
+  }).toBe(true);
+
+  // The coverage extension must stay bounded (#202).
+  expect(await page.getByTestId("transcript-row").count()).toBeLessThan(120);
+});
+
+test("scrolling up through mixed row heights never exceeds the React update depth", async ({ page }) => {
+  // Real transcripts mix collapsed single-line rows with tall messages. This
+  // sweep is a browser smoke pass over that mix; the deterministic guard for
+  // the covering/over-covering ping-pong (React error #185) lives in
+  // virtualWindow.test.ts, where the resonant geometry is exact.
+  const mixedEntries: TranscriptEntry[] = Array.from({ length: 200 }, (_, index) => ({
+    id: `entry-${index + 1}`,
+    seq: index + 1,
+    continuation: 1,
+    kind: "message",
+    role: "assistant",
+    text: index === 120
+      ? Array.from({ length: 180 }, (_, line) => `Tall message line ${line + 1}`).join("\n")
+      : `History entry ${index + 1}`,
+    created_at: "2026-08-01T00:00:00Z",
+  }));
+  await routeRuntimeOwnerWorkspace(page, { transcript: mixedEntries });
+
+  await page.goto("/projects/project-0/tasks/task-0");
+  await expect(page.getByText("History entry 200")).toBeVisible();
+
+  const viewport = page.getByTestId("conversation-workspace");
+  await viewport.hover();
+  await page.mouse.wheel(0, -600);
+  await expect(page.getByRole("button", { name: "Scroll to latest (auto-follow off)" })).toBeVisible();
+  // The reading position must move smoothly while rows above the viewport are
+  // measured: a fixed row may shift at most by the wheel step plus slack, not
+  // by the thousands of px a layout mis-anchor used to snap.
+  const tallMessage = page.getByText("Tall message line 1");
+  let previousY: number | null = null;
+  for (let step = 0; step < 24; step += 1) {
+    await page.mouse.wheel(0, -300);
+    await page.waitForTimeout(120);
+    await expect(page.getByRole("heading", { name: "Something went wrong" })).toHaveCount(0);
+    if (await tallMessage.count() > 0) {
+      const box = await tallMessage.boundingBox();
+      if (box) {
+        if (previousY !== null) {
+          expect(Math.abs(box.y - previousY)).toBeLessThanOrEqual(700);
+        }
+        previousY = box.y;
+      }
+    }
+  }
+
+  await expect.poll(async () => {
+    const [viewportBox, rowsBox] = await Promise.all([
+      viewport.boundingBox(),
+      page.getByTestId("transcript-rows").boundingBox(),
+    ]);
+    if (viewportBox === null || rowsBox === null) return false;
+    const paddingBottom = await viewport.evaluate(
+      (element) => parseFloat(getComputedStyle(element).paddingBottom) || 0,
+    );
+    return rowsBox.y + rowsBox.height >= viewportBox.y + viewportBox.height - paddingBottom - 4;
+  }).toBe(true);
+  expect(await page.getByTestId("transcript-row").count()).toBeLessThan(120);
+});
+
+test("a tall transcript scrolls from the live tail back to its oldest history", async ({ page }) => {
+  // Real transcript rows are far taller than the uniform estimate. Scrolling
+  // up must keep measuring rows and shifting the window instead of staying
+  // pinned on the same tail rows or snapping back.
+  const tallEntries: TranscriptEntry[] = Array.from({ length: 200 }, (_, index) => ({
+    id: `entry-${index + 1}`,
+    seq: index + 1,
+    continuation: 1,
+    kind: "message",
+    role: "assistant",
+    text: Array.from({ length: 20 }, (_, line) => `Entry ${index + 1} line ${line + 1}`).join("\n"),
+    created_at: "2026-08-01T00:00:00Z",
+  }));
+  await routeRuntimeOwnerWorkspace(page, { transcript: tallEntries });
+
+  await page.goto("/projects/project-0/tasks/task-0");
+  await expect(page.getByText("Entry 200 line 20")).toBeVisible();
+
+  const viewport = page.getByTestId("conversation-workspace");
+  await viewport.hover();
+  await page.mouse.wheel(0, -600);
+  await expect(page.getByRole("button", { name: "Scroll to latest (auto-follow off)" })).toBeVisible();
+
+  let scrollTop = await viewport.evaluate((element) => element.scrollTop);
+  for (let step = 0; step < 80 && scrollTop > 1500; step += 1) {
+    await page.mouse.wheel(0, -3000);
+    await page.waitForTimeout(50);
+    scrollTop = await viewport.evaluate((element) => element.scrollTop);
+  }
+  expect(scrollTop).toBeLessThan(1500);
+  await expect(page.getByRole("heading", { name: "Something went wrong" })).toHaveCount(0);
+
+  const [viewportBox, entryBox] = await Promise.all([
+    viewport.boundingBox(),
+    page.getByText("Entry 1 line 1").boundingBox(),
+  ]);
+  expect(viewportBox).not.toBeNull();
+  expect(entryBox).not.toBeNull();
+  // The oldest message intersects the viewport.
+  expect(entryBox!.y + entryBox!.height).toBeGreaterThanOrEqual(viewportBox!.y);
+  expect(entryBox!.y).toBeLessThanOrEqual(viewportBox!.y + viewportBox!.height);
+  expect(await page.getByTestId("transcript-row").count()).toBeLessThan(120);
+});

--- a/web/src/components/task-transcript/AgentTranscriptView.test.tsx
+++ b/web/src/components/task-transcript/AgentTranscriptView.test.tsx
@@ -82,7 +82,7 @@ describe("AgentTranscriptView", () => {
     expect(screen.queryByTestId("timeline-event-detail")).not.toBeInTheDocument();
   });
 
-  it("labels timeline segment buttons and gives rows a content-visibility boundary", () => {
+  it("labels timeline segment buttons and keeps rows on real layout for coverage measurement", () => {
     render(
       <AgentTranscriptView
         owner={owner}
@@ -95,7 +95,10 @@ describe("AgentTranscriptView", () => {
 
     expect(screen.getByRole("button", { name: /Jump to shell event/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Jump to Error event/i })).toBeInTheDocument();
-    expect(screen.getAllByTestId("transcript-event-row")[0]).toHaveClass("[content-visibility:auto]");
+    // The virtual window's measured coverage pass needs real row heights, so
+    // rows must not carry content-visibility size hints that report phantom
+    // heights for offscreen rows.
+    expect(screen.getAllByTestId("transcript-event-row")[0]).not.toHaveClass("[content-visibility:auto]");
   });
 
   it("exposes disclosure state and visible focus styles on transcript controls", () => {

--- a/web/src/components/task-transcript/AgentTranscriptView.tsx
+++ b/web/src/components/task-transcript/AgentTranscriptView.tsx
@@ -31,9 +31,9 @@ import {
   itemFilterKey,
 } from "./timeline-utils";
 
-// Uniform row-height estimate matching the contain-intrinsic-size hint on the
-// rendered rows; the virtualized window uses it to bound DOM size while older
-// pages accumulate (#202).
+// Uniform row-height estimate used by the virtualized window to bound DOM
+// size while older pages accumulate (#202). Rows render with real layout so
+// the window's measured coverage pass sees true heights.
 const TIMELINE_ROW_ESTIMATE = 48;
 // Distance from the tail (in px) below which the operator is "at the tail".
 const TAIL_THRESHOLD = 48;
@@ -72,6 +72,9 @@ export function AgentTranscriptView({ owner, items, profileName, isLive = false,
   const [sortDirection, setSortDirection] = useState<TranscriptSortDirection>("newest_first");
   const [filterOpen, setFilterOpen] = useState(false);
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+  // The element wrapping exactly the rendered rows; the virtual window
+  // measures it so the rows always cover the viewport (#blank band).
+  const [rowsElement, setRowsElement] = useState<HTMLDivElement | null>(null);
   const eventRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const filterRef = useRef<HTMLDivElement>(null);
   const atTailRef = useRef(true);
@@ -101,6 +104,11 @@ export function AgentTranscriptView({ owner, items, profileName, isLive = false,
     itemCount: displayItems.length,
     viewport: scrollContainer,
     estimateHeight: TIMELINE_ROW_ESTIMATE,
+    windowElement: rowsElement,
+    rowKey: (index) => {
+      const item = displayItems[index];
+      return item === undefined ? "" : item.id ?? `seq-${item.seq}`;
+    },
   });
   const visibleItems = displayWindow.virtualized
     ? displayItems.slice(displayWindow.startIndex, displayWindow.endIndex)
@@ -256,7 +264,7 @@ export function AgentTranscriptView({ owner, items, profileName, isLive = false,
     <div
       ref={setScrollContainer}
       data-testid="timeline-workspace"
-      className="flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain rounded-lg border border-border bg-card"
+      className="flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain rounded-lg border border-border bg-card [overflow-anchor:none]"
     >
       <div className="shrink-0 space-y-2 border-b px-4 py-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
@@ -374,22 +382,25 @@ export function AgentTranscriptView({ owner, items, profileName, isLive = false,
             )}
           </div>
         ) : (
-          <div className="divide-y">
+          <div>
             {sortDirection === "chronological" && footer}
             {displayWindow.spacerBefore > 0 && (
               <div aria-hidden="true" style={{ height: displayWindow.spacerBefore }} />
             )}
-            {visibleItems.map((item, visibleIndex) => (
-              <TranscriptEventRow
-                key={`${item.id ?? `${item.seq}-${visibleIndex}`}-${item.type === "reasoning" ? item.status ?? "" : ""}`}
-                ref={(el) => {
-                  if (el) eventRefs.current.set(item.seq, el);
-                  else eventRefs.current.delete(item.seq);
-                }}
-                item={item}
-                isSelected={selectedSeq === item.seq}
-              />
-            ))}
+            <div ref={setRowsElement} data-testid="timeline-rows" className="divide-y">
+              {visibleItems.map((item, visibleIndex) => (
+                <TranscriptEventRow
+                  key={`${item.id ?? `${item.seq}-${visibleIndex}`}-${item.type === "reasoning" ? item.status ?? "" : ""}`}
+                  vwKey={item.id ?? `seq-${item.seq}`}
+                  ref={(el) => {
+                    if (el) eventRefs.current.set(item.seq, el);
+                    else eventRefs.current.delete(item.seq);
+                  }}
+                  item={item}
+                  isSelected={selectedSeq === item.seq}
+                />
+              ))}
+            </div>
             {displayWindow.spacerAfter > 0 && (
               <div aria-hidden="true" style={{ height: displayWindow.spacerAfter }} />
             )}
@@ -551,10 +562,12 @@ function TimelineBar({
 
 function TranscriptEventRow({
   ref,
+  vwKey,
   item,
   isSelected,
 }: {
   ref?: React.Ref<HTMLDivElement>;
+  vwKey: string;
   item: TimelineItem;
   isSelected: boolean;
 }) {
@@ -575,9 +588,10 @@ function TranscriptEventRow({
   return (
     <div
       ref={ref}
+      data-vw-key={vwKey}
       data-testid="transcript-event-row"
       className={cn(
-        "group [contain-intrinsic-size:48px] [content-visibility:auto] transition-colors",
+        "group transition-colors",
         isSelected && "bg-accent/50",
       )}
     >

--- a/web/src/lib/virtualWindow.test.ts
+++ b/web/src/lib/virtualWindow.test.ts
@@ -16,6 +16,40 @@ function scrollViewportTo(el: HTMLDivElement, scrollTop: number) {
   el.dispatchEvent(new Event("scroll"));
 }
 
+function rect(top: number, bottom: number) {
+  const height = bottom - top;
+  return { top, bottom, height, width: 100, left: 0, right: 100, x: 0, y: top, toJSON: () => ({}) };
+}
+
+// Populates the rows wrapper with one row per list index whose measured
+// height and viewport-relative rect follow the given content offsets, so the
+// hook's measurement and DOM-anchor passes see deterministic layout in jsdom.
+function attachRows(wrapper: HTMLElement, viewport: HTMLElement, offsets: number[], heights: number[]) {
+  for (let i = 0; i < offsets.length; i += 1) {
+    const row = document.createElement("div");
+    const key = `k${i}`;
+    row.setAttribute("data-vw-key", key);
+    let height = heights[i] ?? 72;
+    const extra = 0;
+    Object.defineProperty(row, "offsetHeight", {
+      get: () => height,
+      configurable: true,
+    });
+    Object.defineProperty(row, "getBoundingClientRect", {
+      value: () => {
+        const top = offsets[i]! + extra - viewport.scrollTop;
+        return rect(top, top + height);
+      },
+      configurable: true,
+    });
+    wrapper.appendChild(row);
+    // Handle for tests to grow a row's measured height like real layout.
+    (row as unknown as { vwHeight: (heightPx: number) => void }).vwHeight = (heightPx: number) => {
+      height = heightPx;
+    };
+  }
+}
+
 describe("useVirtualWindow", () => {
   it("renders every row while the viewport cannot be measured", () => {
     const viewport = fakeViewport(0);
@@ -44,7 +78,7 @@ describe("useVirtualWindow", () => {
     );
     // A long final transcript entry is far taller than the 72px estimate, so
     // the real bottom scrollTop exceeds the estimated total height
-    // (100*72=7200). The estimated-ratio window must not detach from the tail.
+    // (100*72=7200). The window must not detach from the tail.
     act(() => scrollViewportTo(viewport, 10328));
     const window = result.current;
     expect(window.startIndex).toBeLessThan(100);
@@ -60,5 +94,123 @@ describe("useVirtualWindow", () => {
     expect(result.current.endIndex).toBe(100);
     expect(result.current.startIndex).toBeLessThan(100);
     expect(result.current.spacerAfter).toBe(0);
+  });
+
+  it("sizes spacers from measured row heights instead of the uniform estimate", () => {
+    const viewport = fakeViewport(600);
+    const rowsWrapper = document.createElement("div");
+    attachRows(
+      rowsWrapper,
+      viewport,
+      Array.from({ length: 100 }, (_, i) => i * 24),
+      Array.from({ length: 100 }, () => 24),
+    );
+    const { result } = renderHook(() =>
+      useVirtualWindow({
+        itemCount: 100,
+        viewport,
+        estimateHeight: 72,
+        windowElement: rowsWrapper,
+        rowKey: (index) => `k${index}`,
+      }),
+    );
+    act(() => scrollViewportTo(viewport, 1200));
+
+    // offsets[42] = 42 * 24 measured, not the 42 * 72 estimate grid.
+    expect(result.current.startIndex).toBe(42);
+    expect(result.current.spacerBefore).toBe(42 * 24);
+    expect(result.current.spacerAfter).toBe((100 - result.current.endIndex) * 24);
+  });
+
+  it("keeps the reading position when a layout shift above the viewport changes", () => {
+    const viewport = fakeViewport(600);
+    const rowsWrapper = document.createElement("div");
+    const offsets = Array.from({ length: 100 }, (_, i) => i * 72);
+    const heights = Array.from({ length: 100 }, () => 72);
+    attachRows(rowsWrapper, viewport, offsets, heights);
+    const { result } = renderHook(() =>
+      useVirtualWindow({
+        itemCount: 100,
+        viewport,
+        estimateHeight: 72,
+        windowElement: rowsWrapper,
+        rowKey: (index) => `k${index}`,
+      }),
+    );
+    act(() => scrollViewportTo(viewport, 3672));
+    expect(viewport.scrollTop).toBe(3672);
+
+    // Row 45 sits above the viewport top (row 51 at scrollTop 3672). It grows
+    // by 128px, so every row at or below it shifts down 128px in real layout.
+    (rowsWrapper.children[45] as HTMLElement & { vwHeight: (h: number) => void }).vwHeight(200);
+    for (let i = 45; i < 100; i += 1) {
+      offsets[i] += 128;
+    }
+    act(() => scrollViewportTo(viewport, 3680));
+
+    // The reading position is held: the container follows the +128px shift.
+    expect(viewport.scrollTop).toBe(3680 + 128);
+    expect(result.current.startIndex).toBeGreaterThan(0);
+  });
+
+  it("does not move the reading position when auto-follow owns the scroll", () => {
+    const viewport = fakeViewport(600);
+    const rowsWrapper = document.createElement("div");
+    const offsets = Array.from({ length: 100 }, (_, i) => i * 72);
+    const heights = Array.from({ length: 100 }, () => 72);
+    attachRows(rowsWrapper, viewport, offsets, heights);
+    const { result } = renderHook(() =>
+      useVirtualWindow({
+        itemCount: 100,
+        viewport,
+        estimateHeight: 72,
+        anchorEnd: true,
+        windowElement: rowsWrapper,
+        rowKey: (index) => `k${index}`,
+      }),
+    );
+    act(() => scrollViewportTo(viewport, 3600));
+
+    (rowsWrapper.children[10] as HTMLElement & { vwHeight: (h: number) => void }).vwHeight(200);
+    for (let i = 10; i < 100; i += 1) {
+      offsets[i] += 128;
+    }
+    act(() => scrollViewportTo(viewport, 3620));
+
+    expect(viewport.scrollTop).toBe(3620);
+    expect(result.current.endIndex).toBe(100);
+  });
+
+  // A tall row near the window end makes the measured coverage flip between
+  // "uncovered without it" and "over-covered with it". The extension must
+  // converge instead of ping-ponging between the two states (React #185).
+  it("does not oscillate when covering the viewport repeatedly swallows a tall row", () => {
+    const viewport = fakeViewport(700);
+    const rowsWrapper = document.createElement("div");
+    const offsets: number[] = [];
+    const heights = Array.from({ length: 200 }, (_, i) => (i === 120 ? 800 : 24));
+    let acc = 0;
+    for (let i = 0; i < 200; i += 1) {
+      offsets.push(acc);
+      acc += heights[i]!;
+    }
+    attachRows(rowsWrapper, viewport, offsets, heights);
+    const { result } = renderHook(() =>
+      useVirtualWindow({
+        itemCount: 200,
+        viewport,
+        estimateHeight: 72,
+        windowElement: rowsWrapper,
+        rowKey: (index) => `k${index}`,
+      }),
+    );
+    act(() => scrollViewportTo(viewport, 7056));
+    const first = result.current.endIndex - result.current.startIndex;
+    act(() => scrollViewportTo(viewport, 7200));
+    const second = result.current.endIndex - result.current.startIndex;
+
+    expect(first).toBeGreaterThan(0);
+    expect(second).toBeGreaterThan(0);
+    expect(second).toBeLessThan(200);
   });
 });

--- a/web/src/lib/virtualWindow.ts
+++ b/web/src/lib/virtualWindow.ts
@@ -1,16 +1,27 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * Virtualized row window (#202). The Runtime Owner Workspace keeps older
  * history pages in state, so rendered DOM rows must stay bounded while pages
  * accumulate. useVirtualWindow windows the list around the scroll position
- * using a uniform per-row height estimate and two spacer elements.
+ * and bounds the DOM with two spacer elements.
  *
- * The caller passes the scroll container element as a value (`viewport`),
- * typically by storing the element in state through a ref callback on the
- * container. The container may mount after the hook (the workspace renders
- * only once the owner loads, and the Timeline view mounts on demand), so the
- * scroll listener attaches whenever the element actually appears.
+ * Spacer sizes come from a prefix-offset table. Rows carried in the table by
+ * stable key (`rowKey`, mirrored on the row element as `data-vw-key`) are
+ * measured after every commit, so visited history uses real heights;
+ * never-rendered rows fall back to the uniform estimate until first rendered.
+ * Exact offsets are what keep scrolling stable: the spacers a sliding window
+ * leaves behind match the rows that were really there, and when new
+ * measurements change the layout above the viewport the hook shifts
+ * `scrollTop` by the same delta so the reading position never moves.
+ *
+ * The window end also extends, monotonically, until the rendered rows cover
+ * the viewport: collapsed rows sit far below the estimate, and an
+ * estimate-derived window can otherwise end above the viewport bottom and
+ * expose the tail spacer as a blank band once the operator leaves the live
+ * tail. The extension never hands rows back — dropping a tall row would
+ * re-uncover the viewport and ping-pong forever (React #185) — and is
+ * bounded by the end of the list.
  *
  * When the viewport cannot be measured (clientHeight is 0, for example in
  * jsdom), every row renders so tests observe the full list; in real browsers
@@ -32,6 +43,18 @@ export interface VirtualWindow {
   virtualized: boolean;
 }
 
+/** Largest row index whose prefix offset is at or below the given pixel. */
+function indexAt(offsets: number[], pixel: number): number {
+  let low = 0;
+  let high = offsets.length - 1;
+  while (low < high) {
+    const mid = (low + high + 1) >> 1;
+    if (offsets[mid]! <= pixel) low = mid;
+    else high = mid - 1;
+  }
+  return low;
+}
+
 export function useVirtualWindow(options: {
   itemCount: number;
   /** The scroll container element, passed as a state value. */
@@ -39,11 +62,27 @@ export function useVirtualWindow(options: {
   estimateHeight: number;
   /** Keep the rendered window on the final items while the view follows its live tail. */
   anchorEnd?: boolean;
+  /** Element wrapping exactly the rendered rows, measured to keep offsets exact. */
+  windowElement?: HTMLElement | null;
+  /** Stable per-row identity; must match the rows' data-vw-key attribute. */
+  rowKey?: (index: number) => string;
 }): VirtualWindow {
-  const { itemCount, viewport, estimateHeight, anchorEnd = false } = options;
+  const { itemCount, viewport, estimateHeight, anchorEnd = false, windowElement, rowKey } = options;
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
   const [measured, setMeasured] = useState(false);
+  // Measured height per stable row key; only rows rendered at least once have
+  // an entry, everything else uses the uniform estimate.
+  const [rowHeights, setRowHeights] = useState<ReadonlyMap<string, number>>(() => new Map());
+  // Extra rows rendered past the estimate-derived end so the rows actually
+  // cover the viewport when they are shorter than the estimate.
+  const [extension, setExtension] = useState(0);
+  // The DOM reading anchor recorded on the previous pass: a stable row key
+  // plus its content offset, used to cancel layout shifts above it.
+  const anchorRef = useRef<{ key: string; contentOffset: number } | null>(null);
+  // Change signal for re-measuring rows whose height changed without any
+  // scroll (for example an expanded tool row).
+  const [contentVersion, setContentVersion] = useState(0);
 
   useEffect(() => {
     if (!viewport) return;
@@ -71,33 +110,141 @@ export function useVirtualWindow(options: {
     return () => viewport.removeEventListener("scroll", handleScroll);
   }, [viewport]);
 
+  // Row heights also change without a scroll event whenever a rendered row
+  // expands or collapses, so the measurement pass below re-runs then too.
+  useEffect(() => {
+    if (!windowElement || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => setContentVersion((version) => version + 1));
+    observer.observe(windowElement);
+    return () => observer.disconnect();
+  }, [windowElement]);
+
+  // Reset the extension during render while the list is empty so a reloaded
+  // owner starts again from the estimate-derived window.
+  if (itemCount === 0 && extension !== 0) {
+    setExtension(0);
+  }
+
+  const buildOffsets = useCallback((heights: ReadonlyMap<string, number>) => {
+    const offsets = new Array<number>(itemCount + 1);
+    offsets[0] = 0;
+    for (let i = 0; i < itemCount; i += 1) {
+      const key = rowKey?.(i);
+      const measuredHeight = key === undefined ? undefined : heights.get(key);
+      offsets[i + 1] = offsets[i]! + (measuredHeight !== undefined && measuredHeight > 0 ? measuredHeight : estimateHeight);
+    }
+    return offsets;
+  }, [itemCount, rowKey, estimateHeight]);
+  const offsets = buildOffsets(rowHeights);
+  const totalHeight = offsets[itemCount]!;
+
+  const height = viewportHeight > 0 ? viewportHeight : estimateHeight * 10;
+  const topIndex = indexAt(offsets, scrollTop);
+  const derivedStart = Math.max(0, topIndex - OVERSCAN);
+  const windowSize = Math.ceil(height / estimateHeight) + OVERSCAN * 2;
+  // A tall tail row (a long final output) can push the real bottom scrollTop
+  // past the estimated total, so the derived start can reach the end of the
+  // list; once it does, anchor the window to the final items instead.
+  const anchorTail = anchorEnd || derivedStart + windowSize >= itemCount;
+  const startIndex = anchorTail ? Math.max(0, itemCount - windowSize) : derivedStart;
+  const baseEnd = Math.min(itemCount, indexAt(offsets, scrollTop + height) + 1 + OVERSCAN);
+  const endIndex = anchorTail ? itemCount : Math.min(itemCount, baseEnd + extension);
+
+  // Measurement, reading-position compensation, and coverage pass, after the
+  // rows have committed and real layout exists. The state updates must live
+  // in this effect: the measured layout only exists after commit, exactly
+  // like the scroll-position sync above.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useLayoutEffect(() => {
+    if (!measured || !viewport || itemCount === 0) return;
+    const viewportTop = viewport.getBoundingClientRect().top;
+
+    // 1) Keep the reading position with a DOM anchor: a row near the viewport
+    // top recorded on the previous pass. The difference between its recorded
+    // and current content offset is exactly the layout shift this commit
+    // caused above it (window slide, spacer corrections, measurements), so
+    // shifting the container by that difference holds the visible content
+    // still. The offset table cannot be used here: in regions not yet
+    // measured it disagrees with the real DOM layout. Auto-follow is skipped,
+    // where the tail settlement owns the scroll position.
+    if (!anchorEnd && anchorRef.current && windowElement) {
+      const anchorElement = windowElement.querySelector(
+        `[data-vw-key="${CSS.escape(anchorRef.current.key)}"]`,
+      ) as HTMLElement | null;
+      if (anchorElement) {
+        const anchorRect = anchorElement.getBoundingClientRect();
+        const contentOffset = anchorRect.top - viewportTop + viewport.scrollTop;
+        const shift = contentOffset - anchorRef.current.contentOffset;
+        if (Math.abs(shift) >= 1) {
+          viewport.scrollTop += shift;
+        }
+      }
+    }
+
+    // 2) Measure the rendered rows by their stable keys.
+    let nextHeights: Map<string, number> | null = null;
+    if (windowElement && rowKey) {
+      for (const child of windowElement.children) {
+        const element = child as HTMLElement;
+        const key = element.getAttribute("data-vw-key");
+        const rowHeight = element.offsetHeight;
+        if (!key || rowHeight <= 0) continue;
+        if (rowHeights.get(key) !== rowHeight) {
+          (nextHeights ??= new Map(rowHeights)).set(key, rowHeight);
+        }
+      }
+    }
+    if (nextHeights) {
+      setRowHeights(nextHeights);
+    }
+
+    // 3) Record the anchor for the next pass: the first row at or below the
+    // viewport top. Rows keep stable keys, so the next pass can find this
+    // same content again even after the window slides.
+    if (windowElement) {
+      for (const child of windowElement.children) {
+        const element = child as HTMLElement;
+        const key = element.getAttribute("data-vw-key");
+        if (!key) continue;
+        const rect = element.getBoundingClientRect();
+        if (rect.bottom > viewportTop) {
+          anchorRef.current = {
+            key,
+            contentOffset: rect.top - viewportTop + viewport.scrollTop,
+          };
+          break;
+        }
+      }
+    }
+
+    // 4) Coverage: extend the window end, monotonically, until the rendered
+    // rows reach the content-box bottom of the viewport. Rows can never cover
+    // the container's bottom padding, so the target is not the padding edge.
+    if (!anchorTail && endIndex < itemCount) {
+      const paddingBottom = parseFloat(getComputedStyle(viewport).paddingBottom) || 0;
+      const viewportBottom = viewport.scrollTop + viewport.clientHeight - paddingBottom;
+      const deficit = viewportBottom - (offsets[endIndex] ?? totalHeight);
+      if (deficit > 0) {
+        const coveredEnd = Math.min(itemCount, indexAt(offsets, viewportBottom) + 1);
+        const nextExtension = coveredEnd - endIndex + extension;
+        if (nextExtension > extension) setExtension(nextExtension);
+      }
+    }
+  }, [
+    measured, viewport, windowElement, rowKey, itemCount, anchorEnd, anchorTail,
+    endIndex, scrollTop, viewportHeight, contentVersion, extension,
+    estimateHeight, totalHeight, rowHeights, offsets, buildOffsets,
+  ]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
   if (!measured || itemCount === 0) {
     return { startIndex: 0, endIndex: itemCount, spacerBefore: 0, spacerAfter: 0, virtualized: false };
   }
-  const height = viewportHeight > 0 ? viewportHeight : estimateHeight * 10;
-  const windowSize = Math.ceil(height / estimateHeight) + OVERSCAN * 2;
-  const derivedStart = Math.max(0, Math.floor(scrollTop / estimateHeight) - OVERSCAN);
-  // Transcript rows have variable heights. A tall tail row (a long final
-  // output) makes the real bottom scrollTop far larger than the estimated
-  // total, so the ratio-derived start can reach or pass the end and the slice
-  // would render nothing while the layout collapses onto bare spacers. Once
-  // the derived window reaches the end, anchor it to the final items instead.
-  if (anchorEnd || derivedStart + windowSize >= itemCount) {
-    const startIndex = Math.max(0, itemCount - windowSize);
-    return {
-      startIndex,
-      endIndex: itemCount,
-      spacerBefore: startIndex * estimateHeight,
-      spacerAfter: 0,
-      virtualized: true,
-    };
-  }
-  const endIndex = Math.min(itemCount, Math.ceil((scrollTop + height) / estimateHeight) + OVERSCAN);
   return {
-    startIndex: derivedStart,
+    startIndex,
     endIndex,
-    spacerBefore: derivedStart * estimateHeight,
-    spacerAfter: (itemCount - endIndex) * estimateHeight,
+    spacerBefore: offsets[startIndex]!,
+    spacerAfter: totalHeight - offsets[endIndex]!,
     virtualized: true,
   };
 }

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -441,7 +441,9 @@ describe("TaskDetailPage", () => {
 
     expect(await screen.findByText("Conversation should be hidden by default")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Conversation" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByTestId("transcript-row")).toHaveClass("[content-visibility:auto]");
+    // The virtual window's measured coverage pass needs real row heights, so
+    // rows must not carry content-visibility size hints.
+    expect(screen.getByTestId("transcript-row")).not.toHaveClass("[content-visibility:auto]");
 
     await user.click(screen.getByRole("button", { name: "Timeline" }));
     expect(searches.at(-1)).toBe("?view=timeline");
@@ -2235,8 +2237,11 @@ describe("TaskDetailPage Runtime Owner History Window (#202)", () => {
     expect(await screen.findByText("Oldest message")).toBeInTheDocument();
     const calls = fetchMock.mock.calls.map(([input]) => String(input));
     expect(calls.some((url) => url.includes("/transcript?before=51"))).toBe(true);
-    // The prepended page pushed the visible rows down by 2 × 72px.
-    expect(viewport.scrollTop).toBe(720 + 2 * 72);
+    // Prepending must not move the reading position. Rows carry no measurable
+    // height in jsdom, so no compensation fires here; in a real browser the
+    // virtual window shifts scrollTop by the measured height of the prepended
+    // rows (see virtualWindow.test.ts).
+    expect(viewport.scrollTop).toBe(720);
     // The boundary page reached the beginning: the affordance disappears.
     expect(screen.queryByTestId("load-older-transcript")).not.toBeInTheDocument();
     expect(screen.getAllByTestId("transcript-row")).toHaveLength(4);

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -24,7 +24,9 @@ import { emptyHistory, type ConversationSendMode, type OwnerHistory, type Runtim
 const ACTIVE = new Set(["running", "paused"]);
 
 // Uniform row-height estimates used by the virtualized Runtime Owner history
-// lists; they match the contain-intrinsic-size hints on the rendered rows.
+// lists. The virtual window bounds DOM size, and its measured coverage pass
+// needs real row layout, so rows carry no content-visibility size hints that
+// would report phantom heights for offscreen rows.
 const TRANSCRIPT_ROW_ESTIMATE = 72;
 const TIMELINE_ROW_ESTIMATE = 48;
 
@@ -205,25 +207,19 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
     commitHistory(next);
   }
 
-  // loadOlderConversation prepends one backward Transcript page and preserves
-  // the visible anchor by shifting the container by the prepended height.
+  // loadOlderConversation prepends one backward Transcript page. The virtual
+  // window measures the new rows and compensates scrollTop, so the reading
+  // position survives without a manual estimate-based shift.
   async function loadOlderConversation() {
     const current = historyRef.current;
     if (current.loadingOlder !== null || current.transcript.length === 0 || !current.transcriptHasOlder) return;
     const before = current.transcript[0]!.seq;
-    const anchor = conversationViewport.current?.scrollTop ?? 0;
     commitHistory({ ...current, loadingOlder: "transcript" });
     try {
       const page = await ownerAdapter.loadOlderTranscript(before);
       const latest = historyRef.current;
       const merged = prependTranscriptEntries(latest.transcript, page.entries ?? []);
-      const prepended = merged.length - latest.transcript.length;
-      const next: OwnerHistory = { ...latest, transcript: merged, transcriptHasOlder: page.has_older === true, loadingOlder: null };
-      flushSync(() => commitHistory(next));
-      const viewport = conversationViewport.current;
-      if (viewport && prepended > 0) {
-        viewport.scrollTop = anchor + prepended * TRANSCRIPT_ROW_ESTIMATE;
-      }
+      commitHistory({ ...latest, transcript: merged, transcriptHasOlder: page.has_older === true, loadingOlder: null });
     } catch (e) {
       commitHistory({ ...historyRef.current, loadingOlder: null });
       setActionError((e as Error).message);
@@ -431,11 +427,19 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
   // container element is stored in state so the hook attaches its scroll
   // listener once the workspace renders after the owner loads.
   const [transcriptViewport, setTranscriptViewport] = useState<HTMLDivElement | null>(null);
+  // The element wrapping exactly the rendered transcript rows; the virtual
+  // window measures it so the rows always cover the viewport (#blank band).
+  const [transcriptRowsElement, setTranscriptRowsElement] = useState<HTMLDivElement | null>(null);
+  // The window slices display rows (tool results already paired with their
+  // calls), so row keys and measured heights match the rendered DOM 1:1.
+  const transcriptDisplayRows = buildTranscriptRows(history.transcript);
   const transcriptWindow = useVirtualWindow({
-    itemCount: history.transcript.length,
+    itemCount: transcriptDisplayRows.length,
     viewport: transcriptViewport,
     estimateHeight: TRANSCRIPT_ROW_ESTIMATE,
     anchorEnd: autoFollow,
+    windowElement: transcriptRowsElement,
+    rowKey: (index) => transcriptDisplayRows[index]!.entry.id,
   });
   const bindTranscriptViewport = useCallback((node: HTMLDivElement | null) => {
     conversationViewport.current = node;
@@ -443,6 +447,9 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
       node.scrollTop = conversationScrollTop.current;
     }
     setTranscriptViewport(node);
+  }, []);
+  const bindTranscriptRows = useCallback((node: HTMLDivElement | null) => {
+    setTranscriptRowsElement(node);
   }, []);
 
   const currentProfileRuntimeProvider = owner?.runtimeConfiguration?.runtime_plugin_id ?? profiles.find((profile) => profile.id === owner?.runtimeProfileID)?.provider;
@@ -1022,7 +1029,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
           <div
             ref={bindTranscriptViewport}
             data-testid="conversation-workspace"
-            className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain bg-background px-3 pt-3 pb-44 sm:px-6 md:pb-5"
+            className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain bg-background px-3 pt-3 pb-44 sm:px-6 md:pb-5 [overflow-anchor:none]"
           >
             <div className="mx-auto max-w-[860px]">
               {history.transcriptHasOlder && (
@@ -1047,7 +1054,8 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
                 <div aria-hidden="true" data-testid="transcript-spacer-before" style={{ height: transcriptWindow.spacerBefore }} />
               )}
               <TranscriptList
-                entries={history.transcript.slice(transcriptWindow.startIndex, transcriptWindow.endIndex)}
+                rows={transcriptDisplayRows.slice(transcriptWindow.startIndex, transcriptWindow.endIndex)}
+                rowsRef={bindTranscriptRows}
                 endRef={conversationEnd}
                 liveReasoningID={liveReasoningEntryID(
                   history.transcript,
@@ -1707,26 +1715,28 @@ type TranscriptDisplayRow = {
 };
 
 function TranscriptList({
-  entries,
+  rows,
+  rowsRef,
   endRef,
   liveReasoningID,
   runtimeLabel,
 }: {
-  entries: TaskTranscriptEntry[];
+  rows: TranscriptDisplayRow[];
+  rowsRef: (node: HTMLDivElement | null) => void;
   endRef: RefObject<HTMLDivElement | null>;
   liveReasoningID?: string;
   runtimeLabel: string;
 }) {
-  const rows = buildTranscriptRows(entries);
   return (
-    <div>
+    <div ref={rowsRef} data-testid="transcript-rows">
       {rows.map((row, index) => {
         const spacing = index === 0 ? "" : row.lane === "user" && row.laneStart ? "mt-4" : "mt-1";
         return (
           <div
             key={row.entry.id}
+            data-vw-key={row.entry.id}
             data-testid="transcript-row"
-            className={`[contain-intrinsic-size:72px] [content-visibility:auto] ${spacing}`}
+            className={`${spacing}`}
           >
             {row.lane === "divider" ? (
               <TranscriptRow entry={row.entry} />
@@ -1747,7 +1757,7 @@ function TranscriptList({
           </div>
         );
       })}
-      {entries.length === 0 && (
+      {rows.length === 0 && (
         <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-sm text-muted-foreground">
           <MessageSquare className="size-5 opacity-50" aria-hidden="true" />
           <p>No transcript yet. Send a message below to start.</p>


### PR DESCRIPTION
## Problem

Scrolling up in the Runtime Owner Conversation/Timeline was broken:

- Leaving the live tail (贴底模式) exposed a large blank band below the rendered rows.
- Scrolling up repeatedly snapped the reading position back to the same rows; a very tall transcript could never be scrolled back to its oldest history.
- A mixed-height transcript (collapsed ~32px rows + multi-thousand-px output rows) could oscillate the virtual window into **React error #185** (Maximum update depth exceeded).

Root cause: the virtual window sized every spacer from a uniform 72px/row estimate while real transcript rows range from ~32px collapsed rows to multi-thousand-px outputs. Estimates disagreed with real layout everywhere except the live tail, and the measurement feedback could ping-pong.

## Fix

`useVirtualWindow` now builds spacers from **per-row measured offsets**:

- Rows carry a stable `data-vw-key` (entry.id / item.id). After each commit the hook measures rendered rows; visited history uses exact heights, never-rendered rows fall back to the estimate until first rendered.
- A **DOM reading anchor** (a row near the viewport top, looked up by key on the next frame) cancels every layout shift above it by the exact DOM-measured delta — covering window slides, spacer corrections, and new measurements at once, instead of table-based arithmetic that disagreed with real layout.
- The **coverage extension is monotone** (never hands rows back) to eliminate the #185 ping-pong; growth is clamped by the end of the list.
- Rows no longer use `content-visibility`/`contain-intrinsic-size` size hints so measurement sees true layout.
- Both scroll containers set `overflow-anchor: none` so the browser's native scroll anchoring cannot double-compensate.

## Verification

- Unit tests: measured-offset spacers, DOM-anchor compensation (+128px shift follows exactly), auto-follow scroll ownership, tall-row oscillation convergence.
- e2e (Playwright + routed API mocks): blank band on leaving the tail, smooth reading position through mixed heights, a 200-entry tall transcript scrolling from the live tail back to entry 1, DOM row bound, no React error boundary.
- Full: 579 vitest tests, `tsc -b`, `eslint`, 8 Playwright e2e, `npm run build`.