### PR TITLE
fix: define implicit working graph decide

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -617,7 +617,7 @@ The single system Skill projected and explicitly invoked for one Blackboard Mode
 _Avoid_: ordinary Skill toggle, mixed-mode instructions, Runtime Profile capability
 
 **Working Graph**:
-The Harness-defined file graph used in `working_graph` mode. It contains `state.md`, fact and data directories, goals, steps, a continuation-scoped Outbox, and continuation-scoped Receipts. It is Runtime working state, while the Blackboard remains the durable semantic source of truth.
+The Harness-defined file graph used in `working_graph` mode. It contains `state.md`, fact and data directories, goals, steps, a continuation-scoped Outbox, and continuation-scoped Receipts. The main Runtime is its implicit Decide process unless a selected orchestration Skill provides that role. It is Runtime working state, while the Blackboard remains the durable semantic source of truth.
 _Avoid_: Assisted Blackboard, transcript parser, direct Blackboard storage
 
 **Working Graph Intent**:

--- a/internal/modeskill/bundles/cyberpenda-blackboard-working-graph/SKILL.md
+++ b/internal/modeskill/bundles/cyberpenda-blackboard-working-graph/SKILL.md
@@ -7,10 +7,12 @@ description: System instructions for FGS Working Graph coordination.
 
 Use the filesystem graph as the only coordination blackboard. Read `$PENTEST_WORKING_GRAPH_ROOT/state.md`, `graph/steps.yaml`, `graph/goals.yaml`, and immutable facts under `graph/facts/`.
 
+The main Runtime is the implicit Decide process unless a selected orchestration Skill provides that role. Before substantive task work, initialize any empty or missing `state.md`, `graph/goals.yaml`, and `graph/steps.yaml` with the current objective and the next executable step.
+
 Use `pentestctl blackboard read` and `pentestctl blackboard history` only for durable Blackboard lookup. Direct Blackboard writes, checkpoints, evidence retention, and Finish are not authorized.
 
-Publish semantic intent without waiting for settlement:
+For every durable result, append its immutable fact or data file, update the Decide-owned graph state, and publish semantic intent without waiting for settlement:
 
 `pentestctl working-graph emit --input <file|->`
 
-Execute agents append facts and data only. The Decide agent owns state, steps, goals, and intent emission. Do not implement an all-agent completion barrier.
+Publish before starting the next task step. Execute agents append facts and data only. The Decide process owns state, steps, goals, and intent emission. Do not implement an all-agent completion barrier.


### PR DESCRIPTION
## Summary
- make the main Runtime the implicit Decide process when no orchestration Skill provides that role
- require Working Graph bootstrap before substantive work
- require fact/data append, graph update, and intent emission for every durable result

## Testing
- go test ./internal/modeskill -count=1