### PR TITLE
fix(web): show durable continuation status in sidebar rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,48 @@ SANDBOX_IMAGE=pentest-sandbox:dev make build-sandbox-image
 
 Override the source-build tag with `SANDBOX_IMAGE=...`. The source-smoke Make targets use that tag; direct daemon and script invocations use the published GHCR image unless `PENTEST_SANDBOX_IMAGE=...` is set.
 
+## TSecBench Hosted evaluation
+
+CyberPenda also builds a self-contained `linux/amd64` image for [TSecBench Hosted Mode](https://tsecbench.zc.tencent.com). The image runs the isolated Hosted Controller (`pentest-tsecbench-hosted`) plus the challenge client and one of the bundled Codex / Claude Code runtimes. TSecBench supplies the VPN-isolated network, challenge lifecycle, and scorekeeping; the container only solves challenges and emits its JSONL transcript.
+
+### Build the image
+
+The build target always targets `linux/amd64`, regardless of the host architecture:
+
+```sh
+make build-tsecbench-hosted-image
+```
+
+The default tag is `cyberpenda-tsecbench-hosted:local`. Override it with `TSECBENCH_HOSTED_IMAGE=...`.
+
+After a build you can verify the image and inspect its bundled runtimes:
+
+```sh
+make smoke-tsecbench-hosted-image
+make tsecbench-hosted-runtime-inventory
+```
+
+For the TSecBench upload bundle, run the `Build TSecBench Hosted Bundle` GitHub Actions workflow (or `make build-tsecbench-hosted-bundle TSECBENCH_BUNDLE_VERSION=v1` after exporting the image). The bundle archives the image as one `.tar.gz` Docker file plus its checksum and component inventory. See [docs/tsecbench/README.md](docs/tsecbench/README.md) for upload, environment templates, and VPN-backed local validation.
+
+### Hosted environment variables
+
+TSecBench injects `BENCHMARK_BASE_URL` and the one-use `BENCHMARK_TOKEN` in Hosted Mode. The remaining `CYBERPENDA_*` values are entered on the TSecBench page (secrets are never stored in the repo):
+
+| Variable | Meaning |
+| --- | --- |
+| `CYBERPENDA_RUNTIME` | `codex` (default) or `claude_code` |
+| `CYBERPENDA_MODEL_PROTOCOL` | `openai_responses` for Codex; `anthropic_messages` for Claude Code |
+| `CYBERPENDA_MODEL_BASE_URL` | Gateway base URL ending in `.tsecbench.gw`; do not append an operation suffix |
+| `CYBERPENDA_MODEL` | Model ID served by the gateway |
+| `CYBERPENDA_MODEL_API_KEY` | Dedicated, revocable evaluation model API key |
+| `CYBERPENDA_REASONING_EFFORT` | Optional; `low`, `medium`, `high`, `xhigh`, or `max` |
+| `CYBERPENDA_TASK_GOAL_APPENDIX` | Optional text appended to the required Hosted Task Goal |
+| `CYBERPENDA_AUTO_COMPACT_THRESHOLD` | Optional Claude Code compaction threshold (1-100) |
+| `CYBERPENDA_AUTO_COMPACT_WINDOW` | Optional Claude Code compaction window (1-1048576) |
+| `CYBERPENDA_MAX_OUTPUT_TOKENS` | Optional max output tokens (1-1048576); DeepSeek hosted runs use `393216` |
+| `CYBERPENDA_CONTEXT_WINDOW` | Optional context window in tokens |
+| `CYBERPENDA_CHALLENGE_ADAPTER` | Optional challenge adapter id; defaults to `tsecbench` |
+
 ## Typical workflow
 
 1. Create a **Project** and define **Scope** (what is authorized).
@@ -132,6 +174,10 @@ Domain terms are defined in [CONTEXT.md](CONTEXT.md).
 | `make build-ui` | Build React UI into the local (gitignored) embed path |
 | `make build` | `build-ui` + compile `pentestd` with embedded UI |
 | `make build-sandbox-image` | Build local sandbox container image |
+| `make build-tsecbench-hosted-image` | Build the local TSecBench Hosted image (`linux/amd64`) |
+| `make smoke-tsecbench-hosted-image` | Run the no-capability smoke test against a built Hosted image |
+| `make tsecbench-hosted-runtime-inventory` | Print runtime versions bundled in a built Hosted image |
+| `make build-tsecbench-hosted-bundle TSECBENCH_BUNDLE_VERSION=v1` | Export a Hosted upload bundle from a built image |
 | `make test` / `make test-backend` | Go unit and integration tests |
 | `make test-ci` | CI-safe tests (no Docker, no LLM credentials) |
 | `make smoke-sandbox-mcp` | Live smoke: sandbox → daemon Blackboard v2 MCP change |

--- a/web/src/components/WorkspaceSidebar.test.tsx
+++ b/web/src/components/WorkspaceSidebar.test.tsx
@@ -132,6 +132,8 @@ describe("WorkspaceSidebar", () => {
           return response({
             ...session("session-archived", "Archived session", "2026-08-01T00:00:00Z"),
             lifecycle: "archived",
+            // A stale active continuation must not change archived presentation.
+            latest_continuation: { status: "running" },
           });
         }
         return response({});
@@ -518,6 +520,54 @@ describe("WorkspaceSidebar", () => {
     }
   });
 
+  // #268: the fast-poll heuristic must count owners with an active durable
+  // continuation, not only rows already rendered busy, so a turn that starts on
+  // a live idle owner surfaces within about 3 seconds.
+  it("polls fast while an owner has an active continuation even when no row is busy", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/workspace/navigation") return response({ projects: [] });
+        if (url === "/api/sessions?limit=5") {
+          return response({
+            sessions: [{
+              ...session("session-running", "Running session", "2026-08-01T00:00:00Z"),
+              runtime_activity: { liveness: "live", turn_activity: "idle" },
+              latest_continuation: { status: "running" },
+            }],
+          });
+        }
+        return response({});
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      render(
+        <ThemeProvider>
+          <MemoryRouter>
+            <WorkspaceSidebar />
+          </MemoryRouter>
+        </ThemeProvider>,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByRole("region", { name: /non-project/i })).toBeInTheDocument();
+      const callsAfterMount = fetchMock.mock.calls.length;
+
+      // The turn is idle, so no row renders busy — but the running
+      // continuation must keep the fast cadence (a poll inside the 2s window,
+      // well under the ~3s budget), not the 30s backoff.
+      await act(async () => {
+        vi.advanceTimersByTimeAsync(2500);
+      });
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("suspends polling entirely while the tab is hidden and resumes when it returns", async () => {
     vi.useFakeTimers();
     try {
@@ -876,6 +926,115 @@ describe("WorkspaceSidebar", () => {
     expect(nonProjectLink.parentElement).toHaveTextContent("Non-project2");
     const projectsLink = screen.getByRole("link", { name: /^projects$/i });
     expect(projectsLink.parentElement).toHaveTextContent("Projects3");
+  });
+
+  // #268: the sidebar status word is durable-first. While the owner's latest
+  // continuation is active the row shows the durable status word (matching the
+  // detail header's primary badge); the colored dot keeps encoding the Runtime
+  // Activity Indicator so no activity information is lost.
+  it("shows the durable status word for active continuations while the dot keeps encoding activity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/workspace/navigation") return response({ projects: [] });
+        if (url === "/api/sessions?limit=5") {
+          return response({
+            sessions: [
+              {
+                ...session("session-running-idle", "Quiet session", "2026-08-01T00:00:00Z"),
+                runtime_activity: { liveness: "live", turn_activity: "idle" },
+                latest_continuation: { status: "running" },
+              },
+              {
+                ...session("session-running-busy", "Working session", "2026-07-31T00:00:00Z"),
+                runtime_activity: { liveness: "live", turn_activity: "busy" },
+                latest_continuation: { status: "running" },
+              },
+              {
+                ...session("session-paused", "Paused session", "2026-07-30T00:00:00Z"),
+                runtime_activity: { liveness: "live", turn_activity: "idle" },
+                latest_continuation: { status: "paused" },
+              },
+              {
+                ...session("session-orphaned", "Orphaned session", "2026-07-29T00:00:00Z"),
+                runtime_activity: { liveness: "orphaned" },
+              },
+              {
+                ...session("session-unknown", "Undetermined session", "2026-07-28T00:00:00Z"),
+                runtime_activity: { liveness: "unknown" },
+              },
+            ],
+          });
+        }
+        return response({});
+      }),
+    );
+
+    render(
+      <ThemeProvider>
+        <MemoryRouter initialEntries={["/sessions"]}>
+          <WorkspaceSidebar />
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    const nonProject = await screen.findByRole("region", { name: /non-project/i });
+
+    // Active continuation + idle turn: the word is the durable status, the dot
+    // still shows the idle Runtime Activity Indicator.
+    const runningIdle = await within(nonProject).findByRole("link", { name: /quiet session session conversation\. running\./i });
+    expect(runningIdle).toHaveTextContent("· Running");
+    expect(runningIdle).not.toHaveTextContent("Idle");
+    expect(within(runningIdle).getByRole("img", { name: "Runtime live idle" }).firstElementChild).toHaveClass("bg-info");
+
+    // Active continuation + busy turn: same durable word, busy dot.
+    const runningBusy = within(nonProject).getByRole("link", { name: /working session session conversation\. running\./i });
+    expect(runningBusy).toHaveTextContent("· Running");
+    expect(within(runningBusy).getByRole("img", { name: "Runtime busy" }).firstElementChild).toHaveClass("bg-success", "animate-pulse");
+
+    // Paused is an active continuation too: durable word, activity dot kept.
+    const paused = within(nonProject).getByRole("link", { name: /paused session session conversation\. paused\./i });
+    expect(paused).toHaveTextContent("· Paused");
+    expect(within(paused).getByRole("img", { name: "Runtime live idle" }).firstElementChild).toHaveClass("bg-info");
+
+    // Without an active continuation the activity wording is unchanged
+    // (offline → "Stopped" is pinned by the activity-dots test below).
+    expect(within(nonProject).getByRole("link", { name: /orphaned session session conversation\./i })).toHaveTextContent("· Unknown");
+    expect(within(nonProject).getByRole("link", { name: /undetermined session session conversation\./i })).toHaveTextContent("· Unknown");
+  });
+
+  it("labels task rows with the durable status word while their continuation is active", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("/api/workspace/navigation")) {
+          return response({
+            projects: [
+              navigationSummary("project-active", "Active project", "2026-08-01T00:00:00Z", [
+                { ...task("task-running", "Probe task", "2026-08-01T00:00:00Z", { liveness: "live", turn_activity: "idle" }), status: "running" },
+              ]),
+            ],
+          });
+        }
+        if (url === "/api/sessions?limit=5") return response({ sessions: [] });
+        return response({});
+      }),
+    );
+
+    render(
+      <ThemeProvider>
+        <MemoryRouter initialEntries={["/projects/project-active/tasks/task-running"]}>
+          <WorkspaceSidebar />
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    const projectRegion = await screen.findByRole("region", { name: /active project/i });
+    expect(
+      await within(projectRegion).findByRole("link", { name: /probe task task conversation\. running\./i }),
+    ).toBeInTheDocument();
   });
 
   it("renders runtime activity as colored status dots with mockup state text", async () => {

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/api";
 import { ThemeToggle } from "@/components/ThemeProvider";
 import { PromptDialog } from "@/components/ConfirmDialog";
+import { activeStatusWord, isActiveStatus, sessionContinuationStatus } from "@/lib/runtimeOwner/status";
 import { useDocumentVisibility } from "@/lib/useDocumentVisibility";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format";
@@ -78,13 +79,16 @@ export function WorkspaceSidebar({ onNavigate }: WorkspaceSidebarProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const isVisible = useDocumentVisibility();
-  // Whether any tracked owner currently has a live, busy runtime. While true the
-  // sidebar polls fast (2s) to surface runtime progress; once idle it backs off
-  // to a slow cadence so an open-but-unused tab does not hammer the daemon.
+  // Whether any tracked owner currently has a live, busy runtime or an active
+  // durable continuation (#268). Counting active continuations — not only rows
+  // already rendered busy — keeps the fast cadence (2s) while a turn can start
+  // at any moment, so a busy/idle transition lands well within ~3s. Once
+  // nothing is active the sidebar backs off to a slow cadence so an
+  // open-but-unused tab does not hammer the daemon.
   const hasActive = useMemo(
     () =>
-      sessions.some(isSessionBusy) ||
-      navigation.some((summary) => summary.tasks.some(isTaskBusy)),
+      sessions.some(isSessionActive) ||
+      navigation.some((summary) => summary.tasks.some(isTaskActive)),
     [sessions, navigation],
   );
 
@@ -564,8 +568,9 @@ function SessionRow({
   onRename: (session: Session) => void;
   onArchive: (session: Session) => Promise<void>;
 }) {
-  const failed = session.latest_continuation?.status === "failed";
-  const state = runtimeActivityState(session.runtime_activity, failed);
+  const durableStatus = sessionContinuationStatus(session);
+  const failed = durableStatus === "failed";
+  const state = durableFirstRowState(runtimeActivityState(session.runtime_activity, failed), durableStatus);
   const time = formatRelativeTime(session.last_activity_at ?? session.updated_at);
   return (
     <div className="group flex items-start gap-1">
@@ -600,7 +605,7 @@ function TaskRow({ task, current, onNavigate }: { task: Task; current: boolean; 
     <NavLink
       to={`/projects/${encodeURIComponent(task.project_id)}/tasks/${encodeURIComponent(task.id)}`}
       end
-      aria-label={`Open ${task.goal || "Untitled task"} task conversation. ${runtimeActivityState(task.runtime_activity, task.status === "failed").label}.`}
+      aria-label={`Open ${task.goal || "Untitled task"} task conversation. ${durableFirstRowState(runtimeActivityState(task.runtime_activity, task.status === "failed"), task.status).label}.`}
       onClick={onNavigate}
       className={({ isActive }) => navItemClasses(isActive || current, "h-auto min-w-0 w-full py-1 pl-7 text-xs")}
     >
@@ -864,12 +869,35 @@ function runtimeActivityState(activity?: RuntimeActivity, failed = false) {
   return { label: "Runtime activity unavailable", text: "Stopped", dot: "bg-muted-foreground/40", busy: false };
 }
 
+// Sidebar rows are durable-first (#268): while the owner's continuation is
+// active, the visible word and row label are the durable status (from the
+// shared runtimeOwner status vocabulary, so they cannot drift from the detail
+// header's primary badge) instead of contradicting it with turn activity. The
+// dot always encodes the Runtime Activity Indicator, and owners without an
+// active continuation keep the activity wording above.
+function durableFirstRowState(activityState: ReturnType<typeof runtimeActivityState>, durableStatus: string | undefined) {
+  const word = activeStatusWord(durableStatus);
+  return word ? { ...activityState, label: word, text: word } : activityState;
+}
+
+function isRuntimeBusy(activity?: RuntimeActivity) {
+  return activity?.liveness === "live" && activity.turn_activity === "busy";
+}
+
 function isSessionBusy(session: Session) {
-  return session.runtime_activity?.liveness === "live" && session.runtime_activity.turn_activity === "busy";
+  return isRuntimeBusy(session.runtime_activity);
 }
 
 function isTaskBusy(task: Task) {
-  return task.runtime_activity?.liveness === "live" && task.runtime_activity.turn_activity === "busy";
+  return isRuntimeBusy(task.runtime_activity);
+}
+
+function isSessionActive(session: Session) {
+  return isSessionBusy(session) || isActiveStatus(sessionContinuationStatus(session));
+}
+
+function isTaskActive(task: Task) {
+  return isTaskBusy(task) || isActiveStatus(task.status);
 }
 
 function sessionActivity(session: Session) {

--- a/web/src/lib/runtimeOwner/adapter.ts
+++ b/web/src/lib/runtimeOwner/adapter.ts
@@ -11,6 +11,7 @@ import {
   type TaskTranscript,
 } from "@/lib/api";
 import { newPermissionRequestID } from "./ids";
+import { sessionContinuationStatus } from "./status";
 import type {
   ConversationSelection,
   OwnerHistory,
@@ -235,7 +236,7 @@ export function sessionAsRuntimeOwner(session: Session): RuntimeOwnerView {
   const active = session.active_continuation ? sessionContinuationAsRuntimeOwner(session.active_continuation) : undefined;
   const latest = session.latest_continuation ? sessionContinuationAsRuntimeOwner(session.latest_continuation) : active;
   const continuation = active ?? latest;
-  const status = session.lifecycle === "archived" ? "archived" : active?.status ?? latest?.status ?? "stopped";
+  const status = session.lifecycle === "archived" ? "archived" : sessionContinuationStatus(session) ?? "stopped";
   const controls = session.runtime_controls;
   return {
     kind: "session",

--- a/web/src/lib/runtimeOwner/status.ts
+++ b/web/src/lib/runtimeOwner/status.ts
@@ -1,0 +1,27 @@
+import type { Session } from "@/lib/api";
+
+// Durable owner-status vocabulary shared by the detail header and the sidebar
+// (#268) so the two surfaces cannot drift: the same active-status set, the same
+// capitalized status word, and the same Session continuation precedence.
+
+/** Durable statuses the UI treats as an active continuation; paused stays interactive. */
+export const ACTIVE_OWNER_STATUSES = new Set(["running", "paused"]);
+
+export function isActiveStatus(status: string | undefined): status is string {
+  return status !== undefined && ACTIVE_OWNER_STATUSES.has(status);
+}
+
+/** The capitalized durable status word, e.g. "Running". */
+export function statusWord(status: string) {
+  return status[0]!.toUpperCase() + status.slice(1);
+}
+
+/** The status word for an active continuation, e.g. "Running"; undefined otherwise. */
+export function activeStatusWord(status: string | undefined) {
+  return isActiveStatus(status) ? statusWord(status) : undefined;
+}
+
+/** Durable Session status precedence: the active continuation outranks the latest one. */
+export function sessionContinuationStatus(session: Session) {
+  return session.active_continuation?.status ?? session.latest_continuation?.status;
+}

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -18,10 +18,9 @@ import { useDocumentVisibility } from "@/lib/useDocumentVisibility";
 import { useVirtualWindow } from "@/lib/virtualWindow";
 import { taskRuntimeOwnerAdapter, sessionRuntimeOwnerAdapter, type RuntimeOwnerAdapter } from "@/lib/runtimeOwner/adapter";
 import { canPiNativeCrossProvider, conversationModeText, conversationQueueUnavailable, conversationSendLabel, newSteerRequestID, resolveConversationAction, resolveConversationSendMode, steerPendingState } from "@/lib/runtimeOwner/conversationKernel";
+import { ACTIVE_OWNER_STATUSES, statusWord } from "@/lib/runtimeOwner/status";
 import { cn } from "@/lib/utils";
 import { emptyHistory, type ConversationSendMode, type OwnerHistory, type RuntimeOwnerKind, type RuntimeOwnerView } from "@/lib/runtimeOwner/types";
-
-const ACTIVE = new Set(["running", "paused"]);
 
 // Uniform row-height estimates used by the virtualized Runtime Owner history
 // lists. The virtual window bounds DOM size, and its measured coverage pass
@@ -405,7 +404,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
   // loadAll/owner are intentionally omitted.
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
-    if (!isVisible || !owner || !ACTIVE.has(owner.status)) return;
+    if (!isVisible || !owner || !ACTIVE_OWNER_STATUSES.has(owner.status)) return;
     const id = setInterval(() => void loadAll("poll"), 1000);
     return () => clearInterval(id);
   }, [owner?.status, isVisible]);
@@ -581,11 +580,11 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
     try {
       const modelPayload = continuationModelPayload();
       const action = resolveConversationAction(owner, {
-        running: ACTIVE.has(owner.status),
+        running: ACTIVE_OWNER_STATUSES.has(owner.status),
         nativeSteerAvailable: owner.runtimeControls?.native_steer_available ?? false,
         interruptSteerAvailable: owner.runtimeControls?.interrupt_steer_available ?? false,
         queueSteerAvailable: owner.runtimeControls?.queue_steer_available ?? true,
-        resumeAvailable: owner.runtimeControls?.resume_available ?? !ACTIVE.has(owner.status),
+        resumeAvailable: owner.runtimeControls?.resume_available ?? !ACTIVE_OWNER_STATUSES.has(owner.status),
         nativeResumeAvailable: owner.runtimeControls?.native_resume_available ?? false,
         precedingProviderID: owner.runtimeControls?.turn_selection?.model_provider_id?.trim() ?? "",
         selectedProviderID: continuationModelProvider.trim(),
@@ -718,13 +717,13 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
   const currentContinuation = owner.activeContinuation ?? owner.latestContinuation;
   const controls = owner.runtimeControls;
   const nativeResumeAvailable = controls?.native_resume_available ?? Boolean(currentContinuation?.nativeSessionID);
-  const resumeAvailable = !ACTIVE.has(owner.status) || controls?.resume_available === true;
+  const resumeAvailable = !ACTIVE_OWNER_STATUSES.has(owner.status) || controls?.resume_available === true;
   const queueSteerAvailable = controls?.queue_steer_available ?? true;
   const interruptSteerAvailable = controls?.interrupt_steer_available ?? nativeResumeAvailable;
   const nativeSteerAvailable = controls?.native_steer_available ?? false;
   const nativeSteerMode = controls?.native_steer_mode;
   const providerPermissions = controls?.provider_permissions ?? [];
-  const running = ACTIVE.has(owner.status);
+  const running = ACTIVE_OWNER_STATUSES.has(owner.status);
   // Finish gate trusts server RuntimeControls only (live+idle already applied).
   const finishAvailable = controls?.finish_available === true;
   const sendMode: ConversationSendMode = owner.kind === "session" && owner.lifecycle !== "open"
@@ -961,7 +960,7 @@ export function RuntimeOwnerDetailPage({ ownerKind }: { ownerKind: RuntimeOwnerK
               owner={owner}
               items={history.timeline}
               profileName={profiles.find((p) => p.id === owner.runtimeProfileID)?.name}
-              isLive={ACTIVE.has(owner.status)}
+              isLive={ACTIVE_OWNER_STATUSES.has(owner.status)}
               scrollRef={timelineViewport}
               onAtTailChange={handleTimelineAtTail}
               onSortDirectionChange={handleTimelineSortDirection}
@@ -1537,7 +1536,7 @@ function StatusBadge({ status }: { status: string }) {
     status === "running" ? "success" :
     status === "failed" ? "danger" :
     status === "paused" || status === "interrupted" ? "warning" : "neutral";
-  const label = status ? status[0]!.toUpperCase() + status.slice(1) : "Unknown";
+  const label = status ? statusWord(status) : "Unknown";
   return <Chip variant={variant} dot className="shrink-0 whitespace-nowrap">{label}</Chip>;
 }
 


### PR DESCRIPTION
## Summary

The sidebar status word was derived only from runtime activity, so a session whose latest continuation was `running` but whose current turn was idle read **Idle** in the sidebar while the detail header showed a durable **Running** badge for the same owner (#268).

- **Durable-first row text:** while an owner's continuation is active (`running`/`paused` — the same set the detail header treats as active), the sidebar row shows the durable status word, matching the header's primary badge. The colored dot still encodes the Runtime Activity Indicator (busy/idle/offline/orphaned/unknown); owners without an active continuation keep today's activity wording (`Stopped`/`Unknown`). Task rows apply the same rule to their accessible label.
- **Poll heuristic:** the fast 2s poll now counts owners with an active continuation, not only rows already rendered busy, so busy/idle transitions on a live idle owner appear within ~3s while the tab is visible.
- **Shared vocabulary:** the active-status set, capitalized status word, and session continuation precedence moved to `web/src/lib/runtimeOwner/status.ts`, used by the sidebar, detail header, and owner adapter so the surfaces cannot drift.

Out of scope per the issue: header badges, Runtime Activity Indicator semantics, and backend payloads are unchanged.

## Test plan

- [x] New Vitest cases (written first, red→green): durable word for active continuation + idle and + busy (dot unchanged), `paused`, fallback wording for offline/orphaned/unknown without a continuation, task-row label, and fast polling with no busy row.
- [x] Existing archived-session test strengthened with a stale `running` continuation.
- [x] `npm test` in `web/`: 577/577 pass; `tsc -b` and eslint clean.
- [x] Backend Go suite unaffected (frontend-only change).

Fixes #268