### PR TITLE
Share Task and Session permission validation and owner operations

### DIFF
--- a/internal/daemon/permission_ladder.go
+++ b/internal/daemon/permission_ladder.go
@@ -8,6 +8,7 @@ import (
 
 	"pentest/internal/runtime"
 	"pentest/internal/task"
+	"pentest/internal/timeline"
 )
 
 // The provider permission-response ladder is one owner-neutral protocol
@@ -128,4 +129,43 @@ func permissionResponseErrorCode(operationErr error) string {
 	default:
 		return "provider_rejected"
 	}
+}
+
+// readPermissionResponse shares validation while each route keeps its body contract.
+func readPermissionResponse(response http.ResponseWriter, request *http.Request, decode func(any) error) (providerPermissionResponseRequest, string, bool) {
+	var input providerPermissionResponseRequest
+	permissionID := strings.TrimSpace(request.PathValue("permission_id"))
+	if permissionID == "" {
+		writeError(response, http.StatusBadRequest, "permission request id is required")
+		return input, permissionID, false
+	}
+	if err := decode(&input); err != nil {
+		writeError(response, http.StatusBadRequest, "invalid JSON body")
+		return input, permissionID, false
+	}
+	input.Decision = normalizePermissionDecision(input.Decision)
+	if input.Decision == "" {
+		writeError(response, http.StatusBadRequest, "permission decision must be allow or deny")
+		return input, permissionID, false
+	}
+	derivePermissionResponseRequestID(request, &input)
+	return input, permissionID, true
+}
+
+// permissionResponsePending replays prior outcomes before owner lifecycle gates.
+func permissionResponsePending(response http.ResponseWriter, input providerPermissionResponseRequest, permissionID, providerSessionID string, events []timeline.Event) bool {
+	pending, priorOutcome, priorDecision := providerPermissionStatus(events, permissionID, input.RequestID)
+	if priorDecision != "" && priorDecision != input.Decision {
+		writeError(response, http.StatusConflict, "permission request id already belongs to a different decision")
+		return false
+	}
+	if priorOutcome != "" {
+		writePermissionResponseAccepted(response, input, permissionID, providerSessionID, priorOutcome)
+		return false
+	}
+	if !pending {
+		writeError(response, http.StatusNotFound, "provider permission request is no longer pending")
+		return false
+	}
+	return true
 }

--- a/internal/daemon/session_permission_test.go
+++ b/internal/daemon/session_permission_test.go
@@ -1,0 +1,60 @@
+package daemon
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pentest/internal/runtime"
+	"pentest/internal/session"
+)
+
+func TestSessionPermissionResponseValidationAndReplay(t *testing.T) {
+	server, err := NewServer(Config{DBPath: filepath.Join(t.TempDir(), "pentest.db"), RuntimeRoot: t.TempDir(), DisableBuiltinSkills: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+	created, err := server.sessions.Create(session.CreateRequest{Input: "inspect", BlackboardMode: session.BlackboardModeDisabled})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := runtime.NewFakeProviderSession(runtime.FakeProviderSessionConfig{SessionID: "permission-provider"})
+	if err := server.BindSessionProviderSession(created.ID, provider); err != nil {
+		t.Fatal(err)
+	}
+	// Completed delivery can be replayed even without a live Continuation.
+	_, err = server.sessions.AppendEvent(created.ID, session.EventKindLifecycle, session.EventPayload{
+		"phase": "provider_permission_response_applied", "mode": "permission_response",
+		"permission_request_id": "perm-1", "request_id": "reply-1",
+		"permission_decision": "allow", "outcome": "applied",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, body, want string
+		status           int
+	}{
+		{"invalid JSON", "{", "invalid JSON body", http.StatusBadRequest},
+		{"empty decision", `{}`, "permission decision must be allow or deny", http.StatusBadRequest},
+		{"invalid decision", `{"decision":"maybe"}`, "permission decision must be allow or deny", http.StatusBadRequest},
+		{"replay", `{"request_id":"reply-1","decision":"approved"}`, `"outcome":"applied"`, http.StatusAccepted},
+		{"conflicting replay", `{"request_id":"reply-1","decision":"deny"}`, "different decision", http.StatusConflict},
+		{"no pending request", `{"request_id":"reply-2","decision":"allow"}`, "no longer pending", http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/api/sessions/"+created.ID+"/permissions/perm-1/respond", bytes.NewBufferString(tc.body)))
+			if response.Code != tc.status || !strings.Contains(response.Body.String(), tc.want) {
+				t.Fatalf("status=%d body=%s; want %d containing %q", response.Code, response.Body.String(), tc.status, tc.want)
+			}
+			if requests := provider.LastRequests(); len(requests) != 0 {
+				t.Fatalf("validation or replay dispatched Provider requests: %#v", requests)
+			}
+		})
+	}
+}

--- a/internal/daemon/session_runtime_handlers.go
+++ b/internal/daemon/session_runtime_handlers.go
@@ -1883,38 +1883,16 @@ func (server *Server) handleSessionProviderPermissionResponse(response http.Resp
 		writeError(response, http.StatusConflict, "Session Runtime provider session is unavailable")
 		return
 	}
-	permissionID := strings.TrimSpace(request.PathValue("permission_id"))
-	if permissionID == "" {
-		writeError(response, http.StatusBadRequest, "permission request id is required")
+	input, permissionID, valid := readPermissionResponse(response, request, func(value any) error { return decodeOptionalJSON(request, value) })
+	if !valid {
 		return
 	}
-	var input providerPermissionResponseRequest
-	if err := decodeOptionalJSON(request, &input); err != nil {
-		writeError(response, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-	input.Decision = normalizePermissionDecision(input.Decision)
-	if input.Decision == "" {
-		writeError(response, http.StatusBadRequest, "permission decision must be allow or deny")
-		return
-	}
-	derivePermissionResponseRequestID(request, &input)
 	events, err := server.sessions.Events(id)
 	if err != nil {
 		writeSessionError(response, err)
 		return
 	}
-	pending, priorOutcome, priorDecision := providerPermissionStatus(sessionEventsAsTimeline(events), permissionID, input.RequestID)
-	if priorDecision != "" && priorDecision != input.Decision {
-		writeError(response, http.StatusConflict, "permission request id already belongs to a different decision")
-		return
-	}
-	if priorOutcome != "" {
-		writePermissionResponseAccepted(response, input, permissionID, provider.SessionID(), priorOutcome)
-		return
-	}
-	if !pending {
-		writeError(response, http.StatusNotFound, "provider permission request is no longer pending")
+	if !permissionResponsePending(response, input, permissionID, provider.SessionID(), sessionEventsAsTimeline(events)) {
 		return
 	}
 	if !provider.Capabilities().PermissionResponse {

--- a/internal/daemon/task_handlers.go
+++ b/internal/daemon/task_handlers.go
@@ -3302,39 +3302,16 @@ func (server *Server) handleProviderPermissionResponse(response http.ResponseWri
 		writeError(response, http.StatusConflict, "provider session is unavailable")
 		return
 	}
-	permissionID := strings.TrimSpace(request.PathValue("permission_id"))
-	if permissionID == "" {
-		writeError(response, http.StatusBadRequest, "permission request id is required")
+	input, permissionID, valid := readPermissionResponse(response, request, json.NewDecoder(request.Body).Decode)
+	if !valid {
 		return
 	}
-	var input providerPermissionResponseRequest
-	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
-		writeError(response, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-	input.Decision = normalizePermissionDecision(input.Decision)
-	if input.Decision == "" {
-		writeError(response, http.StatusBadRequest, "permission decision must be allow or deny")
-		return
-	}
-	derivePermissionResponseRequestID(request, &input)
-
 	events, err := server.tasks.Events(found.ID)
 	if err != nil {
 		writeError(response, http.StatusInternalServerError, "list task events")
 		return
 	}
-	pending, priorOutcome, priorDecision := providerPermissionStatus(eventsToTimelineEvents(events), permissionID, input.RequestID)
-	if priorDecision != "" && priorDecision != input.Decision {
-		writeError(response, http.StatusConflict, "permission request id already belongs to a different decision")
-		return
-	}
-	if priorOutcome != "" {
-		writePermissionResponseAccepted(response, input, permissionID, session.SessionID(), priorOutcome)
-		return
-	}
-	if !pending {
-		writeError(response, http.StatusNotFound, "provider permission request is no longer pending")
+	if !permissionResponsePending(response, input, permissionID, session.SessionID(), eventsToTimelineEvents(events)) {
 		return
 	}
 	if found.Status != task.StatusRunning && found.Status != task.StatusPaused {

--- a/web/src/lib/runtimeOwner/adapter.ts
+++ b/web/src/lib/runtimeOwner/adapter.ts
@@ -60,8 +60,41 @@ function transcriptURL(base: string, mode: "initial" | "poll", cursor: number): 
   return mode === "initial" ? `${base}/transcript` : `${base}/transcript?after=${cursor}`;
 }
 
+function ownerHistory(timeline: TaskTimeline, transcript: TaskTranscript, current: OwnerHistory) {
+  return {
+    timeline: timeline.items ?? [],
+    transcript: transcript.entries ?? [],
+    timelineCursor: timeline.cursor ?? current.timelineCursor,
+    transcriptCursor: transcript.cursor ?? current.transcriptCursor,
+    timelineHasOlder: timeline.has_older === true,
+    transcriptHasOlder: transcript.has_older === true,
+    transcriptBefore: transcript.before,
+  };
+}
+
+type SharedOwnerOperations = Pick<RuntimeOwnerAdapter,
+  "loadOlderTranscript" | "loadOlderTimeline" | "stop" | "finish" | "resume" | "respondPermission" | "remove"
+>;
+
+function sharedOwnerOperations(base: string): SharedOwnerOperations {
+  return {
+    loadOlderTranscript: (before) => apiGet<TaskTranscript>(`${base}/transcript?before=${before}`),
+    loadOlderTimeline: (before) => apiGet<TaskTimeline>(`${base}/timeline?before=${before}`),
+    stop: () => apiPost(`${base}/stop`, {}),
+    finish: () => apiPost(`${base}/finish`, {}),
+    resume: (selection) => apiPost(`${base}/resume`, selection),
+    respondPermission: (permissionRequestID, decision) =>
+      apiPost(`${base}/permissions/${encodeURIComponent(permissionRequestID)}/respond`, {
+        request_id: newPermissionRequestID(),
+        decision,
+      }),
+    remove: () => apiDelete(base),
+  };
+}
+
 export function taskRuntimeOwnerAdapter(base: string): RuntimeOwnerAdapter {
   return {
+    ...sharedOwnerOperations(base),
     kind: "task",
     base,
     async loadWorkspace(signal, mode, current) {
@@ -76,17 +109,9 @@ export function taskRuntimeOwnerAdapter(base: string): RuntimeOwnerAdapter {
         finishReadiness: typeof finishReadiness.ready_to_finish === "boolean" && Array.isArray(finishReadiness.blockers)
           ? finishReadiness
           : undefined,
-        timeline: timeline.items ?? [],
-        transcript: transcript.entries ?? [],
-        timelineCursor: timeline.cursor ?? current.timelineCursor,
-        transcriptCursor: transcript.cursor ?? current.transcriptCursor,
-        timelineHasOlder: timeline.has_older === true,
-        transcriptHasOlder: transcript.has_older === true,
-        transcriptBefore: transcript.before,
+        ...ownerHistory(timeline, transcript, current),
       };
     },
-    loadOlderTranscript: (before) => apiGet<TaskTranscript>(`${base}/transcript?before=${before}`),
-    loadOlderTimeline: (before) => apiGet<TaskTimeline>(`${base}/timeline?before=${before}`),
     async sendMessage(text, selection) {
       return taskAsRuntimeOwner(await apiPost<Task>(`${base}/messages`, { message: text, ...selection }));
     },
@@ -98,26 +123,18 @@ export function taskRuntimeOwnerAdapter(base: string): RuntimeOwnerAdapter {
           : { directive: text, ...selection },
       ),
     queueSteer: (text, selection) => apiPost(`${base}/steer/queue`, { directive: text, ...selection }),
-    stop: () => apiPost(`${base}/stop`, {}),
-    finish: () => apiPost(`${base}/finish`, {}),
-    resume: (selection) => apiPost(`${base}/resume`, selection),
-    respondPermission: (permissionRequestID, decision) =>
-      apiPost(`${base}/permissions/${encodeURIComponent(permissionRequestID)}/respond`, {
-        request_id: newPermissionRequestID(),
-        decision,
-      }),
     async rename() {
       throw new Error("Tasks cannot be renamed");
     },
     async changeLifecycle() {
       throw new Error("Tasks cannot be archived");
     },
-    remove: () => apiDelete(base),
   };
 }
 
 export function sessionRuntimeOwnerAdapter(base: string): RuntimeOwnerAdapter {
   return {
+    ...sharedOwnerOperations(base),
     kind: "session",
     base,
     async loadWorkspace(signal, mode, current) {
@@ -130,35 +147,18 @@ export function sessionRuntimeOwnerAdapter(base: string): RuntimeOwnerAdapter {
         owner: sessionAsRuntimeOwner(session),
         // Session timelines and transcripts are built by the same daemon pipeline
         // as task ones, so the rendered shapes are identical.
-        timeline: timeline.items ?? [],
-        transcript: transcript.entries ?? [],
-        timelineCursor: timeline.cursor ?? current.timelineCursor,
-        transcriptCursor: transcript.cursor ?? current.transcriptCursor,
-        timelineHasOlder: timeline.has_older === true,
-        transcriptHasOlder: transcript.has_older === true,
-        transcriptBefore: transcript.before,
+        ...ownerHistory(timeline, transcript, current),
       };
     },
-    loadOlderTranscript: (before) => apiGet<TaskTranscript>(`${base}/transcript?before=${before}`),
-    loadOlderTimeline: (before) => apiGet<TaskTimeline>(`${base}/timeline?before=${before}`),
     sendMessage: (text, selection, attachments) => postSessionRuntimeMessage(`${base}/messages`, text, selection, attachments).then(sessionAsRuntimeOwner),
     steer: ({ text, selection, requestID, attachments, forceReplace }) => postSessionRuntimeMessage(
       `${base}/steer`, text, selection, attachments ?? [], forceReplace ? { force_replace: true } : {}, requestID,
     ),
     queueSteer: (text, selection, attachments) => postSessionRuntimeMessage(`${base}/steer/queue`, text, selection, attachments),
-    stop: () => apiPost(`${base}/stop`, {}),
-    finish: () => apiPost(`${base}/finish`, {}),
-    resume: (selection) => apiPost(`${base}/resume`, selection),
-    respondPermission: (permissionRequestID, decision) =>
-      apiPost(`${base}/permissions/${encodeURIComponent(permissionRequestID)}/respond`, {
-        request_id: newPermissionRequestID(),
-        decision,
-      }),
     async rename(title) {
       return sessionAsRuntimeOwner(await apiPatch<Session>(base, { title }));
     },
     changeLifecycle: async (action) => sessionAsRuntimeOwner(await apiPost<Session>(`${base}/${action}`, {})),
-    remove: () => apiDelete(base),
   };
 }
 


### PR DESCRIPTION
Task and Session permission handlers duplicated request validation and replay checks, while their frontend adapters repeated common owner operations. Share those paths so both owners use the same validation, idempotent response handling, history mapping, pagination, and common control requests.

Keep owner lookup, body decoding contracts, lifecycle gates, control locking, settlement waits, event persistence, and attachment formats in their existing adapters. Add Session permission-route coverage for invalid input, replay, conflicting decisions, and absence of a pending request, including no Provider dispatch on validation or replay.

Validation:
- 596 frontend tests passed with two workers; an earlier run alongside race compilation had four timeouts.
- 106 focused workspace/conversation tests passed.
- Related Task and Session provider-control tests passed, including race checks.
- Session permission-route tests, frontend lint, TypeScript checks, and diff whitespace checks passed.
