### PR TITLE
Add verify-finding and verify-solution Built-in Skills

### DIFF
--- a/docs/adr/0037-add-verification-skills.md
+++ b/docs/adr/0037-add-verification-skills.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-09-09
+---
+
+# Add verification Skills to the curated Built-in set
+
+ADR 0033 froze the daemon-seeded Built-in Skill set at ten bundles. This
+decision adds two product-protocol Skills. It does not restore pruned
+methodology Skills.
+
+## Decision
+
+- Add `verify-finding` and `verify-solution` to the curated Built-in Skill
+  set. `TestBuiltinBundlesIncludeRequestedProjects` remains the equality
+  gate, now twelve bundles.
+- These Skills state only Blackboard settlement rules the Runtime cannot
+  infer from model pretraining: required fields, derived severity, support
+  edges, immutable verified Solution fields, and the Working Graph write
+  ban.
+- They do not grant Scope, authorization, Host Runner activation, or a
+  platform submit. Working Graph publication of a Fact is not confirmation
+  or verification.
+
+## Why these two
+
+- Finding confirmation and Solution verification are separate product
+  outcomes. One Skill would hide the Pentest and `ctf_challenge` split.
+- Interactive Blackboard writes use `pentestctl blackboard change`. Working
+  Graph Mode does not authorize that write. The Skills have to say both, or
+  a Runtime will call the wrong interface.
+- Methodology for how to test a target stays out. ADR 0033 already rejected
+  that class of Built-in Skill.
+
+## Consequences
+
+- Daemon startup seeds the two new Built-in Skills. A user-imported Skill
+  with the same ID is not purged.
+- Historical Runtime Configuration Snapshots do not gain these IDs. New
+  launches can enable them through the existing Skill enablement path.
+- A later removal must add the IDs to `retiredPrunedBuiltinIDs` and update
+  the equality test in the same change.

--- a/internal/skill/builtin_test.go
+++ b/internal/skill/builtin_test.go
@@ -29,11 +29,14 @@ func TestBuiltinBundlesIncludeRequestedProjects(t *testing.T) {
 	}
 
 	// The curated builtin set: sandbox tooling discipline the model cannot know
-	// from pretraining, the product-integrated scoreboard flow, and the
-	// operator-authored benchmark orchestration skill.
+	// from pretraining, the product-integrated scoreboard flow, the
+	// operator-authored benchmark orchestration skill, and the two
+	// verification Skills that state Blackboard settlement rules.
 	want := []string{
 		"scoreboard-driven-web-challenge",
 		"ctf-orchestrator",
+		"verify-finding",
+		"verify-solution",
 		"tooling-ffuf",
 		"tooling-httpx",
 		"tooling-katana",
@@ -441,4 +444,42 @@ func assertBuiltinBundle(t *testing.T, bundles map[string]skill.ImportedBundle, 
 		t.Fatalf("builtin bundle %q has no display name", id)
 	}
 	return bundle
+}
+
+
+func TestVerificationSkillsStateProductProtocol(t *testing.T) {
+	bundles, err := skill.BuiltinBundles()
+	if err != nil {
+		t.Fatalf("load builtin bundles: %v", err)
+	}
+	byID := map[string]string{}
+	for _, bundle := range bundles {
+		byID[bundle.Metadata.ID] = bundle.Files["SKILL.md"]
+	}
+	finding := byID["verify-finding"]
+	for _, needle := range []string{
+		"pentestctl blackboard change",
+		"false_positive",
+		"supports",
+		"Do not set `severity`",
+		"cyberpenda-blackboard-working-graph",
+		"fact.append",
+	} {
+		if !strings.Contains(finding, needle) {
+			t.Fatalf("verify-finding missing %q", needle)
+		}
+	}
+	solution := byID["verify-solution"]
+	for _, needle := range []string{
+		"verification_summary",
+		"ctf_challenge",
+		"`status` `verified`",
+		"Do not set `solved`",
+		"cyberpenda-blackboard-working-graph",
+		"pentestctl blackboard change",
+	} {
+		if !strings.Contains(solution, needle) {
+			t.Fatalf("verify-solution missing %q", needle)
+		}
+	}
 }

--- a/internal/skill/builtins/assets/verify-finding/SKILL.md
+++ b/internal/skill/builtins/assets/verify-finding/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: verify-finding
+description: Confirm or reject a Finding through the Blackboard contract. Use when a Pentest Project Finding needs confirmed or false_positive status.
+blackboard_modes: [interactive, working_graph]
+---
+
+# Verify Finding
+
+Use this Skill only to settle an existing Finding. Do not invent a Finding, a target, or proof. Scope, authorization, and Runner choice stay in the product. This Skill does not grant them.
+
+## Working Graph
+
+If the projected Mode Skill is `cyberpenda-blackboard-working-graph`:
+
+- Do not call `pentestctl blackboard change`, `pentestctl blackboard evidence retain`, or `pentestctl blackboard continuation finish`.
+- Publish the check result with `pentestctl working-graph emit --input <file>`.
+- Use `fact.append` for what was observed. A Fact is not a confirmed Finding.
+- Do not write confirmed Finding status into the working graph.
+
+## Interactive Blackboard
+
+If the projected Mode Skill is `cyberpenda-blackboard-interactive`, write one atomic batch:
+
+`pentestctl blackboard change --input <file>`
+
+The file uses `schema` `semantic-change-batch/v2`, one `idempotency_key`, and ordered `changes`.
+
+Read the Finding first with `pentestctl blackboard read --key <key>`. Use that current version. Do not print, copy, or persist `PENTEST_INTERFACE_TOKEN`.
+
+### Confirm
+
+Confirm only when the same batch has both of these:
+
+1. A transition of the current Finding version to `confirmed`.
+2. An active `evidences` edge from Evidence, or a `supports` edge from a ProjectFact whose confidence is `confirmed`.
+
+A tentative Fact is not support. If either requirement is missing, leave the Finding `unconfirmed`.
+
+A confirmed Finding must already have, or the same batch must set:
+
+- `target`
+- `proof` (compact text; raw proof stays in Evidence)
+- `impact`
+- `recommendation`
+- `cvss_version` (`4.0` for a new vector)
+- `cvss_vector` (a complete vector for that version)
+
+Do not set `severity` or `cvss_pending`. The service derives them.
+
+Do not confirm from a hypothesis, a missing command, or an untested plan.
+
+### Reject
+
+Transition to `false_positive` only when the check disproves the Finding. `false_positive` is terminal. Do not reopen that Finding. A later question is a new Finding.
+
+## After the write
+
+Read the Finding again. Stop if the status is not `confirmed` or `false_positive`. Do not finish the Task from this Skill. Finding confirmation, Goal completion, and Task Finish are separate outcomes.

--- a/internal/skill/builtins/assets/verify-solution/SKILL.md
+++ b/internal/skill/builtins/assets/verify-solution/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: verify-solution
+description: Verify or reject a CTF Solution through the Blackboard contract. Use when a ctf_challenge Solution needs verified or rejected status.
+blackboard_modes: [interactive, working_graph]
+---
+
+# Verify Solution
+
+Use this Skill only to settle an existing Solution in a `ctf_challenge` Project. A Solution is invalid in a Pentest Project. Do not invent a flag, an answer, or a verification summary. This Skill does not submit a platform result and does not finish the Task.
+
+## Working Graph
+
+If the projected Mode Skill is `cyberpenda-blackboard-working-graph`:
+
+- Do not call `pentestctl blackboard change`.
+- Publish the check result with `pentestctl working-graph emit --input <file>` as a Fact.
+- A Fact is not a verified Solution. Derived solved state changes only when a current Solution has `kind` `flag` and `status` `verified`.
+
+## Interactive Blackboard
+
+Write with `pentestctl blackboard change --input <file>`.
+
+Read the Solution first. Use its current version. Do not print, copy, or persist `PENTEST_INTERFACE_TOKEN`.
+
+### Verify
+
+Only a `candidate` Solution can become `verified`.
+
+The transition uses:
+
+- `op`: `transition`
+- `status`: `verified`
+- `verification_summary`: required, concise, and specific to the check that accepted the value
+
+Do not set `solved`. Solved state is derived.
+
+Do not change `kind` or `value` in the verify transition. After `verified`, `kind`, `value`, and `verification_summary` are immutable. A correction is a new candidate Solution. The live Solution transition statuses are `verified` and `rejected`.
+
+A verified `flag` or `answer` requires a non-empty `value` with no surrounding whitespace.
+
+`verification_summary` names the accepting check. Do not copy the Solution `summary`. Do not put `verification_summary` on an Objective, Attempt, or Finding transition.
+
+Add an outgoing `satisfies` edge from the verified Solution to the Objective it settles, in the same batch when that edge is not already current. Do not create a Goal node. The Blackboard does not copy Task Goals.
+
+### Reject
+
+Transition to `rejected` only when a current Fact already contradicts the Solution and keeps that invalidation meaning. The rejected transition also requires `verification_summary`. A rejected Solution stays rejected. If every verified flag later becomes rejected, derived solved state becomes false. History stays.
+
+## After the write
+
+Read the Solution again. Do not treat a candidate, a Fact, or a missing Receipt as verified. Do not finish the Continuation from this Skill.


### PR DESCRIPTION
## Summary
- Add two curated Built-in Skills: `verify-finding` and `verify-solution`.
- They state Blackboard settlement rules only: required Finding fields, derived severity, support edges, immutable verified Solution fields, and the Working Graph write ban.
- ADR 0037 records the set growing from 10 to 12. The equality test and a protocol assertion cover both Skills.

## Test plan
- [ ] `go test ./internal/skill -run 'TestBuiltinBundlesIncludeRequestedProjects|TestVerificationSkillsStateProductProtocol'`
- [ ] Confirm Working Graph text does not call `pentestctl blackboard change` as the Graph write path
- [ ] Confirm neither Skill contains an attack procedure or a platform submit